### PR TITLE
schema(nice): licenses(.licenses)

### DIFF
--- a/data/licenses.json
+++ b/data/licenses.json
@@ -1,745 +1,750 @@
-[
-	{
-		"name": "Community Use Policy",
-		"entries": [
-			"Pf2etools uses trademarks and/or copyrights owned by Paizo Inc., used under {@link Paizo's Community Use Policy|https://paizo.com/communityuse}. We are expressly prohibited from charging you to use or access this content. Pf2etools is not published, endorsed, or specifically approved by Paizo. For more information about Paizo Inc. and Paizo products, visit {@link paizo.com|https://paizo.com}."
-		]
-	},
-	{
-		"name": "Open Game License",
-		"entries": [
-			"{@c OPEN GAME LICENSE Version 1.0a}",
-			"The following text is the property of Wizards of the Coast, Inc. and is Copyright 2000 Wizards of the Coast, Inc (\"Wizards\"). All Rights Reserved.",
-			"1. Definitions: (a)\"Contributors\" means the copyright and/or trademark owners who have contributed Open Game Content; (b)\"Derivative Material\"means copyrighted material including derivative works and translations (including into other computer languages), potation, modification, correction, addition, extension, upgrade, improvement, compilation, abridgment or other form in which an existing work may be recast, transformed or adapted; (c) \"Distribute\"means to reproduce, license, rent, lease, sell, broadcast, publicly display, transmit or otherwise distribute; (d)\"Open Game Content\"means the game mechanic and includes the methods, procedures, processes and routines to the extent such content does not embody the Product Identity and is an enhancement over the prior art and any additional content clearly identified as Open Game Content by the Contributor, and means any work covered by this License, including translations and derivative works under copyright law, but specifically excludes Product Identity. (e) \"Product Identity\"means product and product line names, logos and identifying marks including trade dress; artifacts; creatures characters; stories, storylines, plots, thematic elements, dialogue, incidents, language, artwork, symbols, designs, depictions, likenesses, formats, poses, concepts, themes and graphic, photographic and other visual or audio representations; names and descriptions of characters, spells, enchantments, personalities, teams, personas, likenesses and special abilities; places, locations, environments, creatures, equipment, magical or supernatural abilities or effects, logos, symbols, or graphic designs; and any other trademark or registered trademark clearly identified as Product identity by the owner of the Product Identity, and which specifically excludes the Open Game Content; (f) \"Trademark\"means the logos, names, mark, sign, motto, designs that are used by a Contributor to identify itself or its products or the associated products contributed to the Open Game License by the Contributor (g) \"Use\", \"Used\"or \"Using\"means to use, Distribute, copy, edit, format, modify, translate and otherwise create Derivative Material of Open Game Content. (h) \"You\"or \"Your\"means the licensee in terms of this agreement.",
-			"2. The License: This License applies to any Open Game Content that contains a notice indicating that the Open Game Content may only be Used under and in terms of this License. You must affix such a notice to any Open Game Content that you Use. No terms may be added to or subtracted from this License except as described by the License itself. No other terms or conditions may be applied to any Open Game Content distributed using this License.",
-			"3. Offer and Acceptance: By Using the Open Game Content You indicate Your acceptance of the terms of this License.",
-			"4. Grant and Consideration: In consideration for agreeing to use this License, the Contributors grant You a perpetual, worldwide, royalty-free, non-exclusive license with the exact terms of this License to Use, the Open Game Content.",
-			"5. Representation of Authority to Contribute: If You are contributing original material as Open Game Content, You represent that Your Contributions are Your original creation and/or You have sufficient rights to grant the rights conveyed by this License.",
-			"6. Notice of License Copyright: You must update the COPYRIGHT NOTICE portion of this License to include the exact text of the COPYRIGHT NOTICE of any Open Game Content You are copying, modifying or distributing, and You must add the title, the copyright date, and the copyright holder's name to the COPYRIGHT NOTICE of any original Open Game Content you Distribute.",
-			"7. Use of Product Identity: You agree not to Use any Product Identity, including as an indication as to compatibility, except as expressly licensed in another, independent Agreement with the owner of each element of that Product Identity. You agree not to indicate compatibility or co-adaptability with any Trademark or Registered Trademark in conjunction with a work containing Open Game Content except as expressly licensed in another, independent Agreement with the owner of such Trademark or Registered Trademark. The use of any Product Identity in Open Game Content does not constitute a challenge to the ownership of that Product Identity. The owner of any Product Identity used in Open Game Content shall retain all rights, title and interest in and to that Product Identity.",
-			"8. Identification: If you distribute Open Game Content You must clearly indicate which portions of the work that you are distributing are Open Game Content.",
-			"9. Updating the License: Wizards or its designated Agents may publish updated versions of this License. You may use any authorized version of this License to copy, modify and distribute any Open Game Content originally distributed under any version of this License.",
-			"10. Copy of this License: You MUST include a copy of this License with every copy of the Open Game Content You Distribute.",
-			"11. Use of Contributor Credits: You may not market or advertise the Open Game Content using the name of any Contributor unless You have written permission from the Contributor to do so.",
-			"12. Inability to Comply: If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Open Game Content due to statute, judicial order, or governmental regulation then You may not Use any Open Game Material so affected.",
-			"13. Termination: This License will terminate automatically if You fail to comply with all terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses shall survive the termination of this License.",
-			"14. Reformation: If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.",
-			"15. COPYRIGHT NOTICE",
-			"{@b {@b Open Game License} v 1.0} © 2000, Wizards of the Coast, Inc.",
-			"{@b {@b System Reference Document}} © 2000. Wizards of the Coast, Inc; Authors: Jonathan Tweet, Monte Cook, Skip Williams, based on material by E. Gary Gygax and Dave Arneson."
-		]
-	},
-	{
-		"name": "",
-		"entries": [
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Abomination Vaults Player's Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Abomination Vaults Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen, with James Jacobs."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Advanced Player's Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Advanced Player's Guide} © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro, Clark Valentine, and Andrew White."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Age of Ashes Player's Guide",
-				"entries": [
-					"{@b Age of Ashes Player's Guide} © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Agents of Edgewatch Player's Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Agents of Edgewatch Player's Guide} © 2020, Paizo Inc.; Author: Patrick Renie."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Ancestry Guide",
-				"entries": [
-					"{@b The Book of Fiends © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb. Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous © 2002, Aaron Loeb. Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens Ancestry Guide (Second Edition)} © 2021, Paizo Inc.; Authors: Calder CaDavid, James Case, Jessica Catalan, Eleanor Ferron, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Andrew Mullen, Samantha Phelan, Jessica Redekop, Mikhail Rekun, David N. Ross, Mark Seifter, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Azarketi Ancestry Web Supplement",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens Azarketi Ancestry Web Supplement} © 2021, Paizo Inc.; Author: Samantha Phelan."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Bestiary",
-				"entries": [
-					"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-					"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
-					"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-					"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Mite from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.",
-					"{@b Pathfinder Bestiary (Second Edition)} © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Bestiary 2",
-				"entries": [
-					"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Aurumvorax from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Blindheim from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.",
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-					"{@b Cave Fisher from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.",
-					"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
-					"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-					"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-					"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Korred from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Necrophidius from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.",
-					"{@b Nereid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Quickling from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Quickwood from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Scythe Tree from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.",
-					"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-					"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-					"{@b Troll, Two-Headed from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.",
-					"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-					"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Bestiary 2 (Second Edition)} © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Bestiary 3",
-				"entries": [
-					"{@b Flumph from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowell and Douglas Naismith.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Bestiary 3 (Second Edition)} © 2021, Paizo Inc.; Authors: Logan Bonner, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Adam Daigle, Katina Davis, Erik Scott de Bie, Jesse Decker, Brian Duckwitz, Hexe Fey, Keith Garrett, Matthew Goodall, Violet Gray, Alice Grizzle, Steven Hammond, Sasha Laranoa Harving, Joan Hong, James Jacobs, Michelle Jones, Virginia Jordan, TJ Kahn, Mikko Kallio, Jason Keeley, Joshua Kim, Avi Kool, Jeff Lee, Lyz Liddell, Luis Loza, Ron Lundeen, Philippe-Antoine Menard, Patchen Mortimer, Dennis Muldoon, Andrew Mullen, Quinn Murphy, Dave Nelson, Jason Nelson, Samantha Phelan, Stephen Radney-MacFarland, Danita Rambo, Shiv Ramdas, BJ Recio, Jessica Redekop, Mikhail Rekun, Patrick Renie, Alex Riggs, David N. Ross, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen.H.H.S, Abigail Slater, Rodney Sloan, Shay Snow, Pidj Sorensen, Kendra Leigh Speedling, Tan Shao Han, William Thompson, Jason Tondro, Clark Valentine, Ruvaid Virk, Skylar Wall, Andrew White, and Landon Winkler."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Character Guide",
-				"entries": [
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Lost Omens Character Guide (Second Edition)} © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer, Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Core Rulebook",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Extinction Curse Player's Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Extinction Curse Player's Guide} © 2020, Paizo Inc.; Author: Ron Lundeen."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Fists of the Ruby Phoenix Player's Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Fists of the Ruby Phoenix Player's Guide} © 2021, Paizo Inc.; Author: Patrick Renie, with Luis Loza."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Gamemastery Guide",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #152: Legacy of the Lost God} © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis Loza, Ron Lundeen, Andrew Mullen, and David N. Ross."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Gods & Magic",
-				"entries": [
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Lost Omens Gods & Magic (Second Edition)} © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris, Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre, David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason Tondro, and Diego Valdez."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Gods & Magic - Web Supplement",
-				"entries": [
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Lost Omens Gods & Magic Web Supplement} © 2020, Paizo Inc.; Authors: James Case, Adam Daigle, Leo Glass, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Luis Loza, Ron Lundeen, Matt Morris, Nathan Reinecke, Simone D. Sallé, Michael Sayre, Shahreena Shahrani, Isabelle Thorne, and Diego Valdez."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Grand Bazaar",
-				"entries": [
-					"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens Grand Bazaar} © 2021, Paizo Inc.; Authors: Tineke Bolleman, Logan Bonner, Jessica Catalan, Dominique Dickey, Dana Ebert, Steven Hammond, Sen H.H.S., Dustin Knight, Avi Kool, Aaron Lascano, Carlos Luna, Ron Lundeen, Sydney Meeker, Randal Meyer, Jacob Michaels, Matt Morris, Andrew Mullen, Ianara Natividad, Dave Nelson, Jessica Redekop, Nathan Reinecke, Erin Roberts, David N. Ross, Simone Sallé, Mark Seifter, Shay Snow, Ashton Sperry, Amber Stewart, Andrew Stoeckle, Isabelle Thorne, Jason Tondro, and Scott D. Young."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Guns & Gears",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Guns & Gears} © 2021, Paizo Inc.; Authors: Logan Bonner, Jessica Catalan, John Compton, Andrew D. Geels, Steven Hammond, Sen H.H.S., Brent Holtsberry, Jason Keeley, Dustin Knight, Luis Loza, Ron Lundeen, Chris Mastey, Liane Merciel, Jacob W. Michaels, Dave Nelson, Samantha Phelan, Mikhail Rekun, Stephen Radney-MacFarland, Sydney Meeker, Kendra Leigh Speedling, Michael Sayre., Mark Seifter, Andrew Stoeckle, Calliope Lee Taylor, Andrew White, and Scott D. Young."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Legends",
-				"entries": [
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens Legends} © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn, Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan, Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs, Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen, Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen K.C. Stephens, and Isabelle Thorne"
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Little Trouble in Big Absalom",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure: Little Trouble in Big Absalom} © 2020, Paizo Inc.; Author: Eleanor Ferron."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Malevolence",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure: Malevolence} © 2021, Paizo Inc.; Author: James Jacobs."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Night of the Gray Death",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure: Night of the Gray Death} © 2021, Paizo Inc.; Author: Ron Lundeen."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #145: Hellknight Hill",
-				"entries": [
-					"{@b Pathfinder Adventure Path #145: Hellknight Hill} © 2019, Paizo Inc.; Authors: Amanda Hamon, with Logan Bonner, James Jacobs, and Jason Tondro."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #146: Cult of Cinders",
-				"entries": [
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #146: Cult of Cinders} © 2019, Paizo Inc.; Authors: Eleanor Ferron, with Leo Glass, James Jacobs, Jason Keeley, and Owen KC Stephens."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #147: Tomorrow Must Burn",
-				"entries": [
-					"{@b Pathfinder Adventure Path #147: Tomorrow Must Burn} © 2019, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen, with Lyz Liddell and James Sutter."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #148: Fires of the Haunted City",
-				"entries": [
-					"{@b Pathfinder Adventure Path #148: Fires of the Haunted City} © 2019, Paizo Inc.; Authors: Linda Zayas-Palmer, with Owen K.C. Stephens, James L. Sutter, and Greg Vaughan."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #149: Against the Scarlet Triad",
-				"entries": [
-					"{@b Pech from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #149: Against the Scarlet Triad} © 2019, Paizo Inc.; Authors: John Compton, with Tim Nightengale and James L. Sutter."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #150: Broken Promises",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #150: Broken Promises} © 2019, Paizo Inc.; Authors: Luis Loza, with James Jacobs, Alex Riggs, and Owen K.C. Stephens."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #151: The Show Must Go On",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #151: The Show Must Go On} © 2020, Paizo Inc.; Authors: Jason Tondro, with Andrew Mullen, Patrick Renie, David N. Ross, and Michael Sayre."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #152: Legacy of the Lost God",
-				"entries": [
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Gamemastery Guide} © 2020, Paizo Inc.; Authors: Alexander Augunas, Jesse Benner, John Bennett, Logan Bonner, Clinton J. Boomer, Jason Bulmahn, James Case, Paris Crenshaw, Jesse Decker, Robert N. Emerson, Eleanor Ferron, Jaym Gates, Matthew Goetz, T.H. Gulliver, Kev Hamilton, Sasha Laranoa Harving, BJ Hensley, Vanessa Hoskins, Brian R. James, Jason LeMaitre, Lyz Liddell, Luis Loza, Colm Lundberg, Ron Lundeen, Stephen Radney-MacFarland, Jessica Redekop, Alistair Rigg, Mark Seifter, Owen K.C. Stephens, Amber Stewart, Christina Stiles, Landon Winkler, and Linda Zayas-Palmer."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #153: Life's Long Shadow",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #153: Life's Long Shadows} © 2020, Paizo Inc.; Authors: Greg A. Vaughan, with Anthony Bono, Jacob W. Michaels, Andrew Mullen, Patrick Renie, Alex Riggs, Timothy Snow, and Amber Stewart."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #154: Siege of the Dinosaurs",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #154: Siege of the Dinosaurs} © 2020, Paizo Inc.; Authors: Kate Baker, with Luis Loza, Andrew Mullen, Jason Nelson, Jennifer Povey, David Schwartz, and Amber Stewart."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #155: Lord of the Black Sands",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #155: Lord of the Black Sands} © 2020, Paizo Inc.; Authors: Mikko Kallio, with Andrew Mullen, Nathan Reinecke, David Schwartz, and Scott Young."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #156: The Apocalypse Prophet",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Demon Lord, Baphomet from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #156: The Apocalypse Prophet} © 2020, Paizo Inc.; Authors: Lyz Liddell, with Kevin Bryan, Steven Hammond, Andrew Mullen, Mikhail Rekun, Patrick Renie, and David N. Ross."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #157: Devil at the Dreaming Palace",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-					"{@b Pathfinder Adventure Path #157: Devil at the Dreaming Palace} © 2020, Paizo Inc.; Authors: James L. Sutter, with Luis Loza, Andrew Mullen, Samantha Phelan, and Patrick Renie."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #158: Sixty Feet Under",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-					"{@b Pathfinder Adventure Path #158: Sixty Feet Under} © 2020, Paizo Inc.; Authors: Michael Sayre, with Saif Ansari, Leo Glass, Ron Lundeen, Jacob W. Michaels, Patrick Renie, and David N. Ross."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #159: All or Nothing",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #159: All or Nothing} © 2020, Paizo Inc.; Authors: Jason Keeley, with Alexander Augunas, Jessica Catalan, Stephen Glicker, Mike Kimmel, Alex Riggs, and Mike Welham."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #160: Assault on Hunting Lodge Seven",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #160: Assault on Hunting Lodge Seven} © 2020, Paizo Inc.; Authors: Ron Lundeen, with Luis Loza and Hilary Moon Murphy."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #161: Belly of the Black Whale",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #161: Belly of the Black Whale} © 2020, Paizo Inc.; Authors: Cole Kronewitter, with Kim Frandsen, Patchen Mortimer, Kyle T. Raes, Andrew White, and Brian Yaksha."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #162: Ruins of the Radiant Siege",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #162: Ruins of the Radiant Siege} © 2020, Paizo Inc.; Authors: Amber Stewart, with Carlos Cabrera, Benjamin U. Fields, Kim Frandsen, Jim Groves, John S. Roberts, and Diego Valdez."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #163: Ruins of Gauntlight",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-					"{@b Pathfinder Adventure Path #163: Ruins of Gauntlight} © 2021, Paizo Inc.; Author: James Jacobs."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #164: Hands of the Devil",
-				"entries": [
-					"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #164: Hands of the Devil} © 2021, Paizo Inc.; Authors: Vanessa Hoskins, with Ron Lundeen, Quinn Murphy, and Amber Stewart."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #165: Eyes of Empty Death",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-					"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen Radney- MacFarland, with James Jacobs and Mikhail Rekun."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #166: Despair on Danger Island",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-					"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen RadneyMacFarland, with James Jacobs and Mikhail Rekun."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #167: Ready? Fight!",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #167: Ready? Fight!} © 2021, Paizo Inc.; Authors: David N. Ross, with Joan Hong, Joshua Kim, Danita Rambo, Sen H.H.S., Tan Shao Han, and Ruvaid Virk."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #168: King of the Mountain",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #168: King of the Mountain} © 2021, Paizo Inc.; Authors: James Case, with Joan Hong, Danita Rambo, David N. Ross, Amber Stewart, William Thompson, Ruvaid Virk, and Jabari Weathers."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #169: Kindled Magic",
-				"entries": [
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #169: Kindled Magic} © 2021, Paizo Inc.; Authors: Eleanor Ferron and Alexandria Bustion, with Shanyce Henley, Jenny Jarzabski, Jessica Redekop, and Mark Seifter."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #170: Spoken on the Song Wind",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #170: Spoken on the Song Wind} © 2021, Paizo Inc.; Authors: Quinn Murphy, with James Case, Jessica Catalan, Brian Cortijo, Isaac Kerry, Dave Nelson, Lu Pellazar, and Shan Wolf."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #171: Hurricane's Howl",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Adventure Path #171: Hurricane's Howl} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder #172: Secrets of the Temple City",
-				"entries": [
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure Path #172: Secrets of the Temple-City} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Guide",
-				"entries": [
-					"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-					"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-					"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-					"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-					"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-					"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens Pathfinder Society Guide} © 2020, Paizo Inc.; Authors: Kate Baker, James Case, John Compton, Vanessa Hoskins, Mike Kimmel, Ron Lundeen, Dennis Muldoon, kieran t. newton, Michael Sayre, Clark Valentine, Tonya Woldridge, and Linda Zayas-Palmer"
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Quest #2: Unforgiving Fire",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Quest #2: Unforgiving Fire} © 2019, Paizo Inc.; Author: Leo Glass."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day} © 2019, Paizo Inc.; Author: Luis Loza."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Quest #10: The Broken Scales",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Quest #10: The Broken Scales} © 2020, Paizo Inc.; Amber Stewart."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Scenario #1-03: Escaping the Grave",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Scenario #1\u201303: Escaping the Grave} © 2019, Paizo Inc.; Author: Adrian Ng."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Scenario #1-15: The Blooming Catastrophe",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Scenario #1\u201315: The Blooming Catastrophe} © 2020, Paizo Inc.; Author: Mikhail Rekun."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Scenario #1-17: The Perennial Crown Part 2, The Thorned Monarch",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Scenario #1\u201317: The Perennial Crown Part 2: The Thorned Monarch} © 2020, Paizo Inc.; Author: Alexander Augunas."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Scenario #1-19: Iolite Squad Alpha",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Scenario #1\u201319: Iolite Squad Alpha} © 2020, Paizo Inc.; Author: Mike Kimmel."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Pathfinder Society Scenario #1-24: Lightning Strikes, Stars Fall",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Society Scenario #1\u201324: Lightning Strikes, Stars Fall} © 2020, Paizo Inc.; Author: Vanessa Hoskins"
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Secrets of Magic",
-				"entries": [
-					"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-					"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Secrets of Magic} © 2021, Paizo Inc.; Authors: Amirali Attar Olyaee, Kate Baker, Minty Belmont, Logan Bonner, James Case, Jessica Catalan, John Compton, Katina Davis, Jesse Decker, Chris Eng, Eleanor Ferron, Leo Glass, Joan Hong, Vanessa Hoskins, Jason Keeley, Joshua Kim, Luis Loza, Ron Lundeen, Liane Merciel, David N. Ross, Ianara Natividad, Chesley Oxendine, Stephen Radney-MacFarland, Shiv Ramdas, Mikhail Rekun, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen H.H.S., Shay Snow, Kendra Leigh Speedling, Tan Shao Han, Calliope Lee Taylor, Mari Tokuda, Jason Tondro, Clark Valentine, Ruvaid Virk, Andrew White, Landon Winkler, Tonya Woldridge, and Isis Wozniakowska."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Strength of Thousands Player's Guide",
-				"entries": [
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Strength of Thousands Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "The Fall of Plaguestone",
-				"entries": [
-					"{@b Pathfinder Adventure: The Fall of Plaguestone} © 2019, Paizo Inc.; Author: Jason Bulmahn."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "The Mwangi Expanse",
-				"entries": [
-					"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Lost Omens The Mwangi Expanse} © 2021, Paizo Inc.; Authors: Laura-Shay Adams, Mariam Ahmad, Jahmal Brown, Misha Bushyager, Alexandria Bustion, Duan Byrd, John Compton, Sarah Davis, Naomi Fritts, Kent Hamilton, Sasha Laranoa Harving, Gabriel Hicks, TK Johnson, Michelle Jones, Joshua Kim, Travis Lionel, Ron Lundeen, Stephanie Lundeen, Hillary Moon Murphy, Lu Pellazar, Mikhail Rekun, Nate Wright, and Jabari Weathers."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "The Slithering",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure: The Slithering} © 2020, Paizo Inc.; Author: Ron Lundeen."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "Troubles in Otari",
-				"entries": [
-					"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-					"{@b Pathfinder Adventure: Troubles in Otari} © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen."
-				]
-			},
-			{
-				"type": "pf2-h3",
-				"collapsible": true,
-				"name": "World Guide",
-				"entries": [
-					"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-					"{@b Pathfinder Lost Omens World Guide (Second Edition)} © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter."
-				]
-			}
-		]
-	}
-]
+{
+	"licenses": [
+		{
+			"name": "Community Use Policy",
+			"type": "entries",
+			"entries": [
+				"Pf2etools uses trademarks and/or copyrights owned by Paizo Inc., used under {@link Paizo's Community Use Policy|https://paizo.com/communityuse}. We are expressly prohibited from charging you to use or access this content. Pf2etools is not published, endorsed, or specifically approved by Paizo. For more information about Paizo Inc. and Paizo products, visit {@link paizo.com|https://paizo.com}."
+			]
+		},
+		{
+			"name": "Open Game License",
+			"type": "entries",
+			"entries": [
+				"{@c OPEN GAME LICENSE Version 1.0a}",
+				"The following text is the property of Wizards of the Coast, Inc. and is Copyright 2000 Wizards of the Coast, Inc (\"Wizards\"). All Rights Reserved.",
+				"1. Definitions: (a)\"Contributors\" means the copyright and/or trademark owners who have contributed Open Game Content; (b)\"Derivative Material\"means copyrighted material including derivative works and translations (including into other computer languages), potation, modification, correction, addition, extension, upgrade, improvement, compilation, abridgment or other form in which an existing work may be recast, transformed or adapted; (c) \"Distribute\"means to reproduce, license, rent, lease, sell, broadcast, publicly display, transmit or otherwise distribute; (d)\"Open Game Content\"means the game mechanic and includes the methods, procedures, processes and routines to the extent such content does not embody the Product Identity and is an enhancement over the prior art and any additional content clearly identified as Open Game Content by the Contributor, and means any work covered by this License, including translations and derivative works under copyright law, but specifically excludes Product Identity. (e) \"Product Identity\"means product and product line names, logos and identifying marks including trade dress; artifacts; creatures characters; stories, storylines, plots, thematic elements, dialogue, incidents, language, artwork, symbols, designs, depictions, likenesses, formats, poses, concepts, themes and graphic, photographic and other visual or audio representations; names and descriptions of characters, spells, enchantments, personalities, teams, personas, likenesses and special abilities; places, locations, environments, creatures, equipment, magical or supernatural abilities or effects, logos, symbols, or graphic designs; and any other trademark or registered trademark clearly identified as Product identity by the owner of the Product Identity, and which specifically excludes the Open Game Content; (f) \"Trademark\"means the logos, names, mark, sign, motto, designs that are used by a Contributor to identify itself or its products or the associated products contributed to the Open Game License by the Contributor (g) \"Use\", \"Used\"or \"Using\"means to use, Distribute, copy, edit, format, modify, translate and otherwise create Derivative Material of Open Game Content. (h) \"You\"or \"Your\"means the licensee in terms of this agreement.",
+				"2. The License: This License applies to any Open Game Content that contains a notice indicating that the Open Game Content may only be Used under and in terms of this License. You must affix such a notice to any Open Game Content that you Use. No terms may be added to or subtracted from this License except as described by the License itself. No other terms or conditions may be applied to any Open Game Content distributed using this License.",
+				"3. Offer and Acceptance: By Using the Open Game Content You indicate Your acceptance of the terms of this License.",
+				"4. Grant and Consideration: In consideration for agreeing to use this License, the Contributors grant You a perpetual, worldwide, royalty-free, non-exclusive license with the exact terms of this License to Use, the Open Game Content.",
+				"5. Representation of Authority to Contribute: If You are contributing original material as Open Game Content, You represent that Your Contributions are Your original creation and/or You have sufficient rights to grant the rights conveyed by this License.",
+				"6. Notice of License Copyright: You must update the COPYRIGHT NOTICE portion of this License to include the exact text of the COPYRIGHT NOTICE of any Open Game Content You are copying, modifying or distributing, and You must add the title, the copyright date, and the copyright holder's name to the COPYRIGHT NOTICE of any original Open Game Content you Distribute.",
+				"7. Use of Product Identity: You agree not to Use any Product Identity, including as an indication as to compatibility, except as expressly licensed in another, independent Agreement with the owner of each element of that Product Identity. You agree not to indicate compatibility or co-adaptability with any Trademark or Registered Trademark in conjunction with a work containing Open Game Content except as expressly licensed in another, independent Agreement with the owner of such Trademark or Registered Trademark. The use of any Product Identity in Open Game Content does not constitute a challenge to the ownership of that Product Identity. The owner of any Product Identity used in Open Game Content shall retain all rights, title and interest in and to that Product Identity.",
+				"8. Identification: If you distribute Open Game Content You must clearly indicate which portions of the work that you are distributing are Open Game Content.",
+				"9. Updating the License: Wizards or its designated Agents may publish updated versions of this License. You may use any authorized version of this License to copy, modify and distribute any Open Game Content originally distributed under any version of this License.",
+				"10. Copy of this License: You MUST include a copy of this License with every copy of the Open Game Content You Distribute.",
+				"11. Use of Contributor Credits: You may not market or advertise the Open Game Content using the name of any Contributor unless You have written permission from the Contributor to do so.",
+				"12. Inability to Comply: If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Open Game Content due to statute, judicial order, or governmental regulation then You may not Use any Open Game Material so affected.",
+				"13. Termination: This License will terminate automatically if You fail to comply with all terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses shall survive the termination of this License.",
+				"14. Reformation: If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.",
+				"15. COPYRIGHT NOTICE",
+				"{@b {@b Open Game License} v 1.0} © 2000, Wizards of the Coast, Inc.",
+				"{@b {@b System Reference Document}} © 2000. Wizards of the Coast, Inc; Authors: Jonathan Tweet, Monte Cook, Skip Williams, based on material by E. Gary Gygax and Dave Arneson."
+			]
+		},
+		{
+			"name": "",
+			"type": "entries",
+			"entries": [
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Abomination Vaults Player's Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Abomination Vaults Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen, with James Jacobs."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Advanced Player's Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Advanced Player's Guide} © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro, Clark Valentine, and Andrew White."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Age of Ashes Player's Guide",
+					"entries": [
+						"{@b Age of Ashes Player's Guide} © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Agents of Edgewatch Player's Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Agents of Edgewatch Player's Guide} © 2020, Paizo Inc.; Author: Patrick Renie."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Ancestry Guide",
+					"entries": [
+						"{@b The Book of Fiends © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb. Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous © 2002, Aaron Loeb. Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens Ancestry Guide (Second Edition)} © 2021, Paizo Inc.; Authors: Calder CaDavid, James Case, Jessica Catalan, Eleanor Ferron, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Andrew Mullen, Samantha Phelan, Jessica Redekop, Mikhail Rekun, David N. Ross, Mark Seifter, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Azarketi Ancestry Web Supplement",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens Azarketi Ancestry Web Supplement} © 2021, Paizo Inc.; Author: Samantha Phelan."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Bestiary",
+					"entries": [
+						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+						"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
+						"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Mite from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.",
+						"{@b Pathfinder Bestiary (Second Edition)} © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Bestiary 2",
+					"entries": [
+						"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Aurumvorax from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Blindheim from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.",
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+						"{@b Cave Fisher from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.",
+						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
+						"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+						"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Korred from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Necrophidius from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.",
+						"{@b Nereid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Quickling from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Quickwood from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Scythe Tree from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.",
+						"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+						"{@b Troll, Two-Headed from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.",
+						"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+						"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Bestiary 2 (Second Edition)} © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Bestiary 3",
+					"entries": [
+						"{@b Flumph from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowell and Douglas Naismith.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Bestiary 3 (Second Edition)} © 2021, Paizo Inc.; Authors: Logan Bonner, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Adam Daigle, Katina Davis, Erik Scott de Bie, Jesse Decker, Brian Duckwitz, Hexe Fey, Keith Garrett, Matthew Goodall, Violet Gray, Alice Grizzle, Steven Hammond, Sasha Laranoa Harving, Joan Hong, James Jacobs, Michelle Jones, Virginia Jordan, TJ Kahn, Mikko Kallio, Jason Keeley, Joshua Kim, Avi Kool, Jeff Lee, Lyz Liddell, Luis Loza, Ron Lundeen, Philippe-Antoine Menard, Patchen Mortimer, Dennis Muldoon, Andrew Mullen, Quinn Murphy, Dave Nelson, Jason Nelson, Samantha Phelan, Stephen Radney-MacFarland, Danita Rambo, Shiv Ramdas, BJ Recio, Jessica Redekop, Mikhail Rekun, Patrick Renie, Alex Riggs, David N. Ross, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen.H.H.S, Abigail Slater, Rodney Sloan, Shay Snow, Pidj Sorensen, Kendra Leigh Speedling, Tan Shao Han, William Thompson, Jason Tondro, Clark Valentine, Ruvaid Virk, Skylar Wall, Andrew White, and Landon Winkler."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Character Guide",
+					"entries": [
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Lost Omens Character Guide (Second Edition)} © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer, Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Core Rulebook",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Extinction Curse Player's Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Extinction Curse Player's Guide} © 2020, Paizo Inc.; Author: Ron Lundeen."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Fists of the Ruby Phoenix Player's Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Fists of the Ruby Phoenix Player's Guide} © 2021, Paizo Inc.; Author: Patrick Renie, with Luis Loza."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Gamemastery Guide",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #152: Legacy of the Lost God} © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis Loza, Ron Lundeen, Andrew Mullen, and David N. Ross."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Gods & Magic",
+					"entries": [
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Lost Omens Gods & Magic (Second Edition)} © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris, Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre, David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason Tondro, and Diego Valdez."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Gods & Magic - Web Supplement",
+					"entries": [
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Lost Omens Gods & Magic Web Supplement} © 2020, Paizo Inc.; Authors: James Case, Adam Daigle, Leo Glass, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Luis Loza, Ron Lundeen, Matt Morris, Nathan Reinecke, Simone D. Sallé, Michael Sayre, Shahreena Shahrani, Isabelle Thorne, and Diego Valdez."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Grand Bazaar",
+					"entries": [
+						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens Grand Bazaar} © 2021, Paizo Inc.; Authors: Tineke Bolleman, Logan Bonner, Jessica Catalan, Dominique Dickey, Dana Ebert, Steven Hammond, Sen H.H.S., Dustin Knight, Avi Kool, Aaron Lascano, Carlos Luna, Ron Lundeen, Sydney Meeker, Randal Meyer, Jacob Michaels, Matt Morris, Andrew Mullen, Ianara Natividad, Dave Nelson, Jessica Redekop, Nathan Reinecke, Erin Roberts, David N. Ross, Simone Sallé, Mark Seifter, Shay Snow, Ashton Sperry, Amber Stewart, Andrew Stoeckle, Isabelle Thorne, Jason Tondro, and Scott D. Young."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Guns & Gears",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Guns & Gears} © 2021, Paizo Inc.; Authors: Logan Bonner, Jessica Catalan, John Compton, Andrew D. Geels, Steven Hammond, Sen H.H.S., Brent Holtsberry, Jason Keeley, Dustin Knight, Luis Loza, Ron Lundeen, Chris Mastey, Liane Merciel, Jacob W. Michaels, Dave Nelson, Samantha Phelan, Mikhail Rekun, Stephen Radney-MacFarland, Sydney Meeker, Kendra Leigh Speedling, Michael Sayre., Mark Seifter, Andrew Stoeckle, Calliope Lee Taylor, Andrew White, and Scott D. Young."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Legends",
+					"entries": [
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens Legends} © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn, Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan, Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs, Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen, Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen K.C. Stephens, and Isabelle Thorne"
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Little Trouble in Big Absalom",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure: Little Trouble in Big Absalom} © 2020, Paizo Inc.; Author: Eleanor Ferron."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Malevolence",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure: Malevolence} © 2021, Paizo Inc.; Author: James Jacobs."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Night of the Gray Death",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure: Night of the Gray Death} © 2021, Paizo Inc.; Author: Ron Lundeen."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #145: Hellknight Hill",
+					"entries": [
+						"{@b Pathfinder Adventure Path #145: Hellknight Hill} © 2019, Paizo Inc.; Authors: Amanda Hamon, with Logan Bonner, James Jacobs, and Jason Tondro."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #146: Cult of Cinders",
+					"entries": [
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #146: Cult of Cinders} © 2019, Paizo Inc.; Authors: Eleanor Ferron, with Leo Glass, James Jacobs, Jason Keeley, and Owen KC Stephens."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #147: Tomorrow Must Burn",
+					"entries": [
+						"{@b Pathfinder Adventure Path #147: Tomorrow Must Burn} © 2019, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen, with Lyz Liddell and James Sutter."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #148: Fires of the Haunted City",
+					"entries": [
+						"{@b Pathfinder Adventure Path #148: Fires of the Haunted City} © 2019, Paizo Inc.; Authors: Linda Zayas-Palmer, with Owen K.C. Stephens, James L. Sutter, and Greg Vaughan."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #149: Against the Scarlet Triad",
+					"entries": [
+						"{@b Pech from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #149: Against the Scarlet Triad} © 2019, Paizo Inc.; Authors: John Compton, with Tim Nightengale and James L. Sutter."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #150: Broken Promises",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #150: Broken Promises} © 2019, Paizo Inc.; Authors: Luis Loza, with James Jacobs, Alex Riggs, and Owen K.C. Stephens."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #151: The Show Must Go On",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #151: The Show Must Go On} © 2020, Paizo Inc.; Authors: Jason Tondro, with Andrew Mullen, Patrick Renie, David N. Ross, and Michael Sayre."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #152: Legacy of the Lost God",
+					"entries": [
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Gamemastery Guide} © 2020, Paizo Inc.; Authors: Alexander Augunas, Jesse Benner, John Bennett, Logan Bonner, Clinton J. Boomer, Jason Bulmahn, James Case, Paris Crenshaw, Jesse Decker, Robert N. Emerson, Eleanor Ferron, Jaym Gates, Matthew Goetz, T.H. Gulliver, Kev Hamilton, Sasha Laranoa Harving, BJ Hensley, Vanessa Hoskins, Brian R. James, Jason LeMaitre, Lyz Liddell, Luis Loza, Colm Lundberg, Ron Lundeen, Stephen Radney-MacFarland, Jessica Redekop, Alistair Rigg, Mark Seifter, Owen K.C. Stephens, Amber Stewart, Christina Stiles, Landon Winkler, and Linda Zayas-Palmer."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #153: Life's Long Shadow",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #153: Life's Long Shadows} © 2020, Paizo Inc.; Authors: Greg A. Vaughan, with Anthony Bono, Jacob W. Michaels, Andrew Mullen, Patrick Renie, Alex Riggs, Timothy Snow, and Amber Stewart."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #154: Siege of the Dinosaurs",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #154: Siege of the Dinosaurs} © 2020, Paizo Inc.; Authors: Kate Baker, with Luis Loza, Andrew Mullen, Jason Nelson, Jennifer Povey, David Schwartz, and Amber Stewart."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #155: Lord of the Black Sands",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #155: Lord of the Black Sands} © 2020, Paizo Inc.; Authors: Mikko Kallio, with Andrew Mullen, Nathan Reinecke, David Schwartz, and Scott Young."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #156: The Apocalypse Prophet",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Demon Lord, Baphomet from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #156: The Apocalypse Prophet} © 2020, Paizo Inc.; Authors: Lyz Liddell, with Kevin Bryan, Steven Hammond, Andrew Mullen, Mikhail Rekun, Patrick Renie, and David N. Ross."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #157: Devil at the Dreaming Palace",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+						"{@b Pathfinder Adventure Path #157: Devil at the Dreaming Palace} © 2020, Paizo Inc.; Authors: James L. Sutter, with Luis Loza, Andrew Mullen, Samantha Phelan, and Patrick Renie."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #158: Sixty Feet Under",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+						"{@b Pathfinder Adventure Path #158: Sixty Feet Under} © 2020, Paizo Inc.; Authors: Michael Sayre, with Saif Ansari, Leo Glass, Ron Lundeen, Jacob W. Michaels, Patrick Renie, and David N. Ross."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #159: All or Nothing",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #159: All or Nothing} © 2020, Paizo Inc.; Authors: Jason Keeley, with Alexander Augunas, Jessica Catalan, Stephen Glicker, Mike Kimmel, Alex Riggs, and Mike Welham."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #160: Assault on Hunting Lodge Seven",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #160: Assault on Hunting Lodge Seven} © 2020, Paizo Inc.; Authors: Ron Lundeen, with Luis Loza and Hilary Moon Murphy."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #161: Belly of the Black Whale",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #161: Belly of the Black Whale} © 2020, Paizo Inc.; Authors: Cole Kronewitter, with Kim Frandsen, Patchen Mortimer, Kyle T. Raes, Andrew White, and Brian Yaksha."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #162: Ruins of the Radiant Siege",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #162: Ruins of the Radiant Siege} © 2020, Paizo Inc.; Authors: Amber Stewart, with Carlos Cabrera, Benjamin U. Fields, Kim Frandsen, Jim Groves, John S. Roberts, and Diego Valdez."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #163: Ruins of Gauntlight",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+						"{@b Pathfinder Adventure Path #163: Ruins of Gauntlight} © 2021, Paizo Inc.; Author: James Jacobs."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #164: Hands of the Devil",
+					"entries": [
+						"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #164: Hands of the Devil} © 2021, Paizo Inc.; Authors: Vanessa Hoskins, with Ron Lundeen, Quinn Murphy, and Amber Stewart."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #165: Eyes of Empty Death",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen Radney- MacFarland, with James Jacobs and Mikhail Rekun."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #166: Despair on Danger Island",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen RadneyMacFarland, with James Jacobs and Mikhail Rekun."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #167: Ready? Fight!",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #167: Ready? Fight!} © 2021, Paizo Inc.; Authors: David N. Ross, with Joan Hong, Joshua Kim, Danita Rambo, Sen H.H.S., Tan Shao Han, and Ruvaid Virk."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #168: King of the Mountain",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #168: King of the Mountain} © 2021, Paizo Inc.; Authors: James Case, with Joan Hong, Danita Rambo, David N. Ross, Amber Stewart, William Thompson, Ruvaid Virk, and Jabari Weathers."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #169: Kindled Magic",
+					"entries": [
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #169: Kindled Magic} © 2021, Paizo Inc.; Authors: Eleanor Ferron and Alexandria Bustion, with Shanyce Henley, Jenny Jarzabski, Jessica Redekop, and Mark Seifter."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #170: Spoken on the Song Wind",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #170: Spoken on the Song Wind} © 2021, Paizo Inc.; Authors: Quinn Murphy, with James Case, Jessica Catalan, Brian Cortijo, Isaac Kerry, Dave Nelson, Lu Pellazar, and Shan Wolf."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #171: Hurricane's Howl",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Adventure Path #171: Hurricane's Howl} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder #172: Secrets of the Temple City",
+					"entries": [
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure Path #172: Secrets of the Temple-City} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Guide",
+					"entries": [
+						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens Pathfinder Society Guide} © 2020, Paizo Inc.; Authors: Kate Baker, James Case, John Compton, Vanessa Hoskins, Mike Kimmel, Ron Lundeen, Dennis Muldoon, kieran t. newton, Michael Sayre, Clark Valentine, Tonya Woldridge, and Linda Zayas-Palmer"
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Quest #2: Unforgiving Fire",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Quest #2: Unforgiving Fire} © 2019, Paizo Inc.; Author: Leo Glass."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day} © 2019, Paizo Inc.; Author: Luis Loza."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Quest #10: The Broken Scales",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Quest #10: The Broken Scales} © 2020, Paizo Inc.; Amber Stewart."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Scenario #1-03: Escaping the Grave",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Scenario #1\u201303: Escaping the Grave} © 2019, Paizo Inc.; Author: Adrian Ng."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Scenario #1-15: The Blooming Catastrophe",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Scenario #1\u201315: The Blooming Catastrophe} © 2020, Paizo Inc.; Author: Mikhail Rekun."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Scenario #1-17: The Perennial Crown Part 2, The Thorned Monarch",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Scenario #1\u201317: The Perennial Crown Part 2: The Thorned Monarch} © 2020, Paizo Inc.; Author: Alexander Augunas."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Scenario #1-19: Iolite Squad Alpha",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Scenario #1\u201319: Iolite Squad Alpha} © 2020, Paizo Inc.; Author: Mike Kimmel."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Pathfinder Society Scenario #1-24: Lightning Strikes, Stars Fall",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Society Scenario #1\u201324: Lightning Strikes, Stars Fall} © 2020, Paizo Inc.; Author: Vanessa Hoskins"
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Secrets of Magic",
+					"entries": [
+						"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Secrets of Magic} © 2021, Paizo Inc.; Authors: Amirali Attar Olyaee, Kate Baker, Minty Belmont, Logan Bonner, James Case, Jessica Catalan, John Compton, Katina Davis, Jesse Decker, Chris Eng, Eleanor Ferron, Leo Glass, Joan Hong, Vanessa Hoskins, Jason Keeley, Joshua Kim, Luis Loza, Ron Lundeen, Liane Merciel, David N. Ross, Ianara Natividad, Chesley Oxendine, Stephen Radney-MacFarland, Shiv Ramdas, Mikhail Rekun, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen H.H.S., Shay Snow, Kendra Leigh Speedling, Tan Shao Han, Calliope Lee Taylor, Mari Tokuda, Jason Tondro, Clark Valentine, Ruvaid Virk, Andrew White, Landon Winkler, Tonya Woldridge, and Isis Wozniakowska."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Strength of Thousands Player's Guide",
+					"entries": [
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Strength of Thousands Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "The Fall of Plaguestone",
+					"entries": [
+						"{@b Pathfinder Adventure: The Fall of Plaguestone} © 2019, Paizo Inc.; Author: Jason Bulmahn."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "The Mwangi Expanse",
+					"entries": [
+						"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Lost Omens The Mwangi Expanse} © 2021, Paizo Inc.; Authors: Laura-Shay Adams, Mariam Ahmad, Jahmal Brown, Misha Bushyager, Alexandria Bustion, Duan Byrd, John Compton, Sarah Davis, Naomi Fritts, Kent Hamilton, Sasha Laranoa Harving, Gabriel Hicks, TK Johnson, Michelle Jones, Joshua Kim, Travis Lionel, Ron Lundeen, Stephanie Lundeen, Hillary Moon Murphy, Lu Pellazar, Mikhail Rekun, Nate Wright, and Jabari Weathers."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "The Slithering",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure: The Slithering} © 2020, Paizo Inc.; Author: Ron Lundeen."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "Troubles in Otari",
+					"entries": [
+						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+						"{@b Pathfinder Adventure: Troubles in Otari} © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen."
+					]
+				},
+				{
+					"type": "pf2-h3",
+					"collapsible": true,
+					"name": "World Guide",
+					"entries": [
+						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+						"{@b Pathfinder Lost Omens World Guide (Second Edition)} © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter."
+					]
+				}
+			]
+		}
+	]
+}

--- a/licenses.html
+++ b/licenses.html
@@ -95,7 +95,7 @@
 <script>
 	ExcludeUtil.pInitialise(); // don't await, as this is only used for search
 	DataUtil.loadJSON(`${Renderer.get().baseUrl || "."}/data/licenses.json`).then(licenses => {
-		UtilsLicenses.renderLicenses(licenses);
+		UtilsLicenses.renderLicenses(licenses.licenses);
 	});
 </script>
 </body>

--- a/test/schema-template/changelog.json
+++ b/test/schema-template/changelog.json
@@ -35,5 +35,8 @@
 			},
 			"minItems": 1
 		}
-	}
+	},
+	"required": [
+		"changelog"
+	]
 }

--- a/test/schema-template/licenses.json
+++ b/test/schema-template/licenses.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"version": "0.0.1",
+	"$id": "licenses.json",
+	"title": "License Schema",
+	"description": "Schema for Pf2eTools licenses file.",
+	"type": "object",
+	"properties": {
+		"licenses": {
+			"type": "array",
+			"items": {
+				"$ref": "entry.json"
+			},
+			"minItems": 1
+		}
+	},
+	"required": [
+		"licenses"
+	]
+}

--- a/test/schema-template/schema.json
+++ b/test/schema-template/schema.json
@@ -20,6 +20,9 @@
 		"changelog": {
 			"$ref": "changelog.json#/properties/changelog"
 		},
+		"licenses": {
+			"$ref": "licenses.json#/properties/licenses"
+		},
 		"variantrule": {
 			"$ref": "variantrules.json#/properties/variantrule"
 		},


### PR DESCRIPTION
Moved licenses down a level (`licenses.licenses`)
Added `"type": "entries"` a few times.
Schema validation of the licenses.