### PR TITLE
Fix to Manticore bestiary entry

### DIFF
--- a/data/bestiary/creatures-bst.json
+++ b/data/bestiary/creatures-bst.json
@@ -48866,12 +48866,6 @@
 					],
 					"name": "Spike Volley"
 				},
-				{
-					"entries": [
-						"These monstrously oversized insects are silent predators with lightning-quick forelegs and a bone-breaking bite."
-					],
-					"name": "Mantis, Giant"
-				}
 			],
 			"inflicts": {
 				"damage": [


### PR DESCRIPTION
Removed the entry for the Giant Mantis (appears on the following page) from the Manticore's Bestiary entry.