### PR TITLE
Fix BUG-125: Encounter Builder Doesn't Work

### DIFF
--- a/js/bestiary-encounterbuilder.js
+++ b/js/bestiary-encounterbuilder.js
@@ -553,8 +553,20 @@ class EncounterBuilder extends ProxyBase {
 
 	handleClick (evt, ix, add, customHashId) {
 		const data = customHashId ? {customHashId} : undefined;
-		if (add) ListUtil.pDoSublistAdd(ix, true, evt.shiftKey ? 5 : 1, data);
-		else ListUtil.pDoSublistSubtract(ix, evt.shiftKey ? 5 : 1, data);
+		if (add) {
+			ListUtil.pDoSublistAdd({
+				index: ix,
+				doFinalize: true,
+				addCount: evt.shiftKey ? 5 : 1,
+				customHashId: data,
+			});
+		} else {
+			ListUtil.pDoSublistSubtract({
+				index: ix,
+				subtractCount: evt.shiftKey ? 5 : 1,
+				customHashId: data,
+			});
+		}
 	}
 
 	async pHandleShuffleClick (ix) {

--- a/js/list2.js
+++ b/js/list2.js
@@ -293,7 +293,7 @@ class List {
 
 	removeItemByIndex (ix, ixItem) {
 		ixItem = ixItem ?? this._items.findIndex(it => it.ix === ix);
-		if (!ixItem) throw new Error(`Tried to remove item that doesn't exist (${ix}, ${ixItem})`);
+		if (!~ixItem) throw new Error(`Tried to remove item that doesn't exist (${ix}, ${ixItem})`);
 
 		this._isDirty = true;
 		const removed = this._items.splice(ixItem, 1);


### PR DESCRIPTION
Looks like v0.5.15 updated the signature of `pDoSublistAdd` and `pDoSublistSubtract`, but did not update the usage in bestiary encounter builder.