### PR TITLE
Critical Hit/Fumble Decks

### DIFF
--- a/data/licenses.json
+++ b/data/licenses.json
@@ -33,904 +33,919 @@
 			]
 		},
 		{
-			"name": "",
-			"type": "entries",
+			"type": "hr"
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Abomination Vaults Hardcover",
 			"entries": [
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Abomination Vaults Hardcover",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-						"{@b Abomination Vaults Adventure Path} © 2022, Paizo Inc.; Authors: Vanessa Hoskins, James Jacobs, and Stephen Radney-MacFarland, with Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Abomination Vaults Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Abomination Vaults Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen, with James Jacobs."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Absalom, City of Lost Omens",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Absalom, City of Lost Omens} © 2021, Paizo Inc.; Authors: Allie Bustion, John Compton, Jeremy Corff, Katina Davis, Vanessa Hoskins, James Jacobs, Virginia Jordan, Erik Mona, Matt Morris, Liane Merciel, Dave Nelson, Samantha Phelan, Jessica Redekop, Mikhail Rekun, Brian Richmond, David N. Ross, Simone D. Sallé, Shahreena Shahrani, Abigail Slater, Chris Spivey, Diego Valdez, and Skylar- James Wall."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Advanced Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Advanced Player's Guide} © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro, Clark Valentine, and Andrew White."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Age of Ashes Player's Guide",
-					"entries": [
-						"{@b Age of Ashes Player's Guide} © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Agents of Edgewatch Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Agents of Edgewatch Player's Guide} © 2020, Paizo Inc.; Author: Patrick Renie."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Ancestry Guide",
-					"entries": [
-						"{@b The Book of Fiends © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb. Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous © 2002, Aaron Loeb. Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Ancestry Guide (Second Edition)} © 2021, Paizo Inc.; Authors: Calder CaDavid, James Case, Jessica Catalan, Eleanor Ferron, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Andrew Mullen, Samantha Phelan, Jessica Redekop, Mikhail Rekun, David N. Ross, Mark Seifter, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Azarketi Ancestry Web Supplement",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Azarketi Ancestry Web Supplement} © 2021, Paizo Inc.; Author: Samantha Phelan."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Bestiary",
-					"entries": [
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
-						"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Mite from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.",
-						"{@b Pathfinder Bestiary (Second Edition)} © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Bestiary 2",
-					"entries": [
-						"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Aurumvorax from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Blindheim from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.",
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Cave Fisher from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.",
-						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
-						"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-						"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Korred from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Necrophidius from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.",
-						"{@b Nereid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Quickling from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Quickwood from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Scythe Tree from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.",
-						"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-						"{@b Troll, Two-Headed from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.",
-						"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Bestiary 2 (Second Edition)} © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Bestiary 3",
-					"entries": [
-						"{@b Flumph from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowell and Douglas Naismith.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Bestiary 3 (Second Edition)} © 2021, Paizo Inc.; Authors: Logan Bonner, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Adam Daigle, Katina Davis, Erik Scott de Bie, Jesse Decker, Brian Duckwitz, Hexe Fey, Keith Garrett, Matthew Goodall, Violet Gray, Alice Grizzle, Steven Hammond, Sasha Laranoa Harving, Joan Hong, James Jacobs, Michelle Jones, Virginia Jordan, TJ Kahn, Mikko Kallio, Jason Keeley, Joshua Kim, Avi Kool, Jeff Lee, Lyz Liddell, Luis Loza, Ron Lundeen, Philippe-Antoine Menard, Patchen Mortimer, Dennis Muldoon, Andrew Mullen, Quinn Murphy, Dave Nelson, Jason Nelson, Samantha Phelan, Stephen Radney-MacFarland, Danita Rambo, Shiv Ramdas, BJ Recio, Jessica Redekop, Mikhail Rekun, Patrick Renie, Alex Riggs, David N. Ross, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen.H.H.S, Abigail Slater, Rodney Sloan, Shay Snow, Pidj Sorensen, Kendra Leigh Speedling, Tan Shao Han, William Thompson, Jason Tondro, Clark Valentine, Ruvaid Virk, Skylar Wall, Andrew White, and Landon Winkler."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Blood Lords Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Blood Lords Player's Guide} © 2022, Paizo Inc.; Author: Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Book of the Dead",
-					"entries": [
-						"{@b Demon Lord, Orcus from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene and Clark Peterson, based on material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter. Pathfinder Book of the Dead © 2022, Paizo Inc.; Authors: Brian Bauman, Tineke Bolleman. Logan Bonner, Jason Bulmahn, Jessica Catalan, John Compton, Chris Eng, Logan Harper, Michelle Jones, Jason Keeley, Luis Loza, Ron Lundeen, Liane Merciel, Patchen Mortimer, Quinn Murphy, Jessica Redekop, Mikhail Rekun, Solomon St. John, Michael Sayre, Mark Seifter, Sen.H.H.S., Kendra Leigh Speedling, Jason Tondro, Andrew White."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Character Guide",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Lost Omens Character Guide (Second Edition)} © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer, Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Core Rulebook",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Extinction Curse Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Extinction Curse Player's Guide} © 2020, Paizo Inc.; Author: Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Fists of the Ruby Phoenix Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Fists of the Ruby Phoenix Player's Guide} © 2021, Paizo Inc.; Author: Patrick Renie, with Luis Loza."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Gamemastery Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #152: Legacy of the Lost God} © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis Loza, Ron Lundeen, Andrew Mullen, and David N. Ross."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Gods & Magic",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Lost Omens Gods & Magic (Second Edition)} © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris, Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre, David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason Tondro, and Diego Valdez."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Gods & Magic - Web Supplement",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Lost Omens Gods & Magic Web Supplement} © 2020, Paizo Inc.; Authors: James Case, Adam Daigle, Leo Glass, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Luis Loza, Ron Lundeen, Matt Morris, Nathan Reinecke, Simone D. Sallé, Michael Sayre, Shahreena Shahrani, Isabelle Thorne, and Diego Valdez."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Grand Bazaar",
-					"entries": [
-						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Grand Bazaar} © 2021, Paizo Inc.; Authors: Tineke Bolleman, Logan Bonner, Jessica Catalan, Dominique Dickey, Dana Ebert, Steven Hammond, Sen H.H.S., Dustin Knight, Avi Kool, Aaron Lascano, Carlos Luna, Ron Lundeen, Sydney Meeker, Randal Meyer, Jacob Michaels, Matt Morris, Andrew Mullen, Ianara Natividad, Dave Nelson, Jessica Redekop, Nathan Reinecke, Erin Roberts, David N. Ross, Simone Sallé, Mark Seifter, Shay Snow, Ashton Sperry, Amber Stewart, Andrew Stoeckle, Isabelle Thorne, Jason Tondro, and Scott D. Young."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Guns & Gears",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Guns & Gears} © 2021, Paizo Inc.; Authors: Logan Bonner, Jessica Catalan, John Compton, Andrew D. Geels, Steven Hammond, Sen H.H.S., Brent Holtsberry, Jason Keeley, Dustin Knight, Luis Loza, Ron Lundeen, Chris Mastey, Liane Merciel, Jacob W. Michaels, Dave Nelson, Samantha Phelan, Mikhail Rekun, Stephen Radney-MacFarland, Sydney Meeker, Kendra Leigh Speedling, Michael Sayre., Mark Seifter, Andrew Stoeckle, Calliope Lee Taylor, Andrew White, and Scott D. Young."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Knights of Lastwall",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-						"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Knights of Lastwall} © 2022, Paizo Inc.; Authors: Banana Chan, Jessica Catalan, Ryan Costello, Katina Davis, Alastor Guzman, Ron Lundeen, Ianara Natividad, Erin Roberts, Ashton Sperry, and Isabelle Thorne"
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Legends",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Legends} © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn, Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan, Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs, Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen, Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen K.C. Stephens, and Isabelle Thorne"
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Little Trouble in Big Absalom",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Little Trouble in Big Absalom} © 2020, Paizo Inc.; Author: Eleanor Ferron."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Malevolence",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Malevolence} © 2021, Paizo Inc.; Author: James Jacobs."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Monsters of Myth",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Monsters of Myth} © 2021, Paizo Inc.; Authors: James Case, John Compton, Dana Ebert, Joshua Kim, Aaron Lascano, Luis Loza, Ron Lundeen, Stephanie Lundeen, Liane Merciel, Andrew Mullen, Michael Sayre, Sen H.H.S., Shay Snow, and Jason Tondro."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Night of the Gray Death",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Night of the Gray Death} © 2021, Paizo Inc.; Author: Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Outlaws of Alkenstar Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Outlaws of Alkenstar Player's Guide} © 2022, Paizo Inc.; Author: Patrick Renie."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #145: Hellknight Hill",
-					"entries": [
-						"{@b Pathfinder Adventure Path #145: Hellknight Hill} © 2019, Paizo Inc.; Authors: Amanda Hamon, with Logan Bonner, James Jacobs, and Jason Tondro."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #146: Cult of Cinders",
-					"entries": [
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #146: Cult of Cinders} © 2019, Paizo Inc.; Authors: Eleanor Ferron, with Leo Glass, James Jacobs, Jason Keeley, and Owen KC Stephens."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #147: Tomorrow Must Burn",
-					"entries": [
-						"{@b Pathfinder Adventure Path #147: Tomorrow Must Burn} © 2019, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen, with Lyz Liddell and James Sutter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #148: Fires of the Haunted City",
-					"entries": [
-						"{@b Pathfinder Adventure Path #148: Fires of the Haunted City} © 2019, Paizo Inc.; Authors: Linda Zayas-Palmer, with Owen K.C. Stephens, James L. Sutter, and Greg Vaughan."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #149: Against the Scarlet Triad",
-					"entries": [
-						"{@b Pech from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #149: Against the Scarlet Triad} © 2019, Paizo Inc.; Authors: John Compton, with Tim Nightengale and James L. Sutter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #150: Broken Promises",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #150: Broken Promises} © 2019, Paizo Inc.; Authors: Luis Loza, with James Jacobs, Alex Riggs, and Owen K.C. Stephens."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #151: The Show Must Go On",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #151: The Show Must Go On} © 2020, Paizo Inc.; Authors: Jason Tondro, with Andrew Mullen, Patrick Renie, David N. Ross, and Michael Sayre."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #152: Legacy of the Lost God",
-					"entries": [
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Gamemastery Guide} © 2020, Paizo Inc.; Authors: Alexander Augunas, Jesse Benner, John Bennett, Logan Bonner, Clinton J. Boomer, Jason Bulmahn, James Case, Paris Crenshaw, Jesse Decker, Robert N. Emerson, Eleanor Ferron, Jaym Gates, Matthew Goetz, T.H. Gulliver, Kev Hamilton, Sasha Laranoa Harving, BJ Hensley, Vanessa Hoskins, Brian R. James, Jason LeMaitre, Lyz Liddell, Luis Loza, Colm Lundberg, Ron Lundeen, Stephen Radney-MacFarland, Jessica Redekop, Alistair Rigg, Mark Seifter, Owen K.C. Stephens, Amber Stewart, Christina Stiles, Landon Winkler, and Linda Zayas-Palmer."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #153: Life's Long Shadow",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #153: Life's Long Shadows} © 2020, Paizo Inc.; Authors: Greg A. Vaughan, with Anthony Bono, Jacob W. Michaels, Andrew Mullen, Patrick Renie, Alex Riggs, Timothy Snow, and Amber Stewart."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #154: Siege of the Dinosaurs",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #154: Siege of the Dinosaurs} © 2020, Paizo Inc.; Authors: Kate Baker, with Luis Loza, Andrew Mullen, Jason Nelson, Jennifer Povey, David Schwartz, and Amber Stewart."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #155: Lord of the Black Sands",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #155: Lord of the Black Sands} © 2020, Paizo Inc.; Authors: Mikko Kallio, with Andrew Mullen, Nathan Reinecke, David Schwartz, and Scott Young."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #156: The Apocalypse Prophet",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Demon Lord, Baphomet from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #156: The Apocalypse Prophet} © 2020, Paizo Inc.; Authors: Lyz Liddell, with Kevin Bryan, Steven Hammond, Andrew Mullen, Mikhail Rekun, Patrick Renie, and David N. Ross."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #157: Devil at the Dreaming Palace",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Pathfinder Adventure Path #157: Devil at the Dreaming Palace} © 2020, Paizo Inc.; Authors: James L. Sutter, with Luis Loza, Andrew Mullen, Samantha Phelan, and Patrick Renie."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #158: Sixty Feet Under",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Pathfinder Adventure Path #158: Sixty Feet Under} © 2020, Paizo Inc.; Authors: Michael Sayre, with Saif Ansari, Leo Glass, Ron Lundeen, Jacob W. Michaels, Patrick Renie, and David N. Ross."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #159: All or Nothing",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #159: All or Nothing} © 2020, Paizo Inc.; Authors: Jason Keeley, with Alexander Augunas, Jessica Catalan, Stephen Glicker, Mike Kimmel, Alex Riggs, and Mike Welham."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #160: Assault on Hunting Lodge Seven",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #160: Assault on Hunting Lodge Seven} © 2020, Paizo Inc.; Authors: Ron Lundeen, with Luis Loza and Hilary Moon Murphy."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #161: Belly of the Black Whale",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #161: Belly of the Black Whale} © 2020, Paizo Inc.; Authors: Cole Kronewitter, with Kim Frandsen, Patchen Mortimer, Kyle T. Raes, Andrew White, and Brian Yaksha."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #162: Ruins of the Radiant Siege",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #162: Ruins of the Radiant Siege} © 2020, Paizo Inc.; Authors: Amber Stewart, with Carlos Cabrera, Benjamin U. Fields, Kim Frandsen, Jim Groves, John S. Roberts, and Diego Valdez."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #163: Ruins of Gauntlight",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
-						"{@b Pathfinder Adventure Path #163: Ruins of Gauntlight} © 2021, Paizo Inc.; Author: James Jacobs."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #164: Hands of the Devil",
-					"entries": [
-						"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #164: Hands of the Devil} © 2021, Paizo Inc.; Authors: Vanessa Hoskins, with Ron Lundeen, Quinn Murphy, and Amber Stewart."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #165: Eyes of Empty Death",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen Radney- MacFarland, with James Jacobs and Mikhail Rekun."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #166: Despair on Danger Island",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen RadneyMacFarland, with James Jacobs and Mikhail Rekun."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #167: Ready? Fight!",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #167: Ready? Fight!} © 2021, Paizo Inc.; Authors: David N. Ross, with Joan Hong, Joshua Kim, Danita Rambo, Sen H.H.S., Tan Shao Han, and Ruvaid Virk."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #168: King of the Mountain",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #168: King of the Mountain} © 2021, Paizo Inc.; Authors: James Case, with Joan Hong, Danita Rambo, David N. Ross, Amber Stewart, William Thompson, Ruvaid Virk, and Jabari Weathers."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #169: Kindled Magic",
-					"entries": [
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #169: Kindled Magic} © 2021, Paizo Inc.; Authors: Eleanor Ferron and Alexandria Bustion, with Shanyce Henley, Jenny Jarzabski, Jessica Redekop, and Mark Seifter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #170: Spoken on the Song Wind",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #170: Spoken on the Song Wind} © 2021, Paizo Inc.; Authors: Quinn Murphy, with James Case, Jessica Catalan, Brian Cortijo, Isaac Kerry, Dave Nelson, Lu Pellazar, and Shan Wolf."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #171: Hurricane's Howl",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #171: Hurricane's Howl} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #172: Secrets of the Temple City",
-					"entries": [
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #172: Secrets of the Temple-City} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #173: Doorway to the Red Star",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #173: Doorway to the Red Star} © 2021, Paizo Inc.; Author: Michael Sayre."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #174: Shadows of the Ancients",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #174: Shadows of the Ancients} © 2021, Paizo Inc.; Authors: Saif Ansari, with Matt Hardin, Jacob W. Michaels, Matt Morris, Brendan Perry, Jessica Redekop, Nathan Reinecke, and Darren Spurrier."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #175: Broken Tusk Moon",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #175: Broken Tusk Moon} © 2022, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #176: Lost Mammoth Valley",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Battlezoo Bestiary} © 2021, Skyscraper Studios Inc.; Authors: Stephen Glicker, Patrick Renie, AND Mark Seifter",
-						"{@b Demon, Nabasu from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Shadow from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-						"{@b Grippli from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Adventure Path #176: Lost Mammoth Valley} © 2022, Paizo Inc.; Author: Jessica Catalan."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #177: Burning Tundra",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-						"{@b Pathfinder Adventure Path #177: Burning Tundra} © 2022, Paizo Inc.; Author: Jason Tondro."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #178: Punks in a Powderkeg",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #178: Punks in a Powder Keg} © 2022, Paizo Inc.; Authors: Vanessa Hoskins, with Stephanie Lundeen and Matt Morris."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #179: Cradle of Quartz",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #179: Cradle of Quartz} © 2022, Paizo Inc.; Authors: Scott D. Young and Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder #180: The Smoking Gun",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure Path #180: The Smoking Gun} © 2022, Paizo Inc.; Author: Cole Kronewitter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Special: Fumbus",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Guide",
-					"entries": [
-						"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
-						"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
-						"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
-						"{@b Book of the Righteous} © 2002, Aaron Loeb.",
-						"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
-						"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens Pathfinder Society Guide} © 2020, Paizo Inc.; Authors: Kate Baker, James Case, John Compton, Vanessa Hoskins, Mike Kimmel, Ron Lundeen, Dennis Muldoon, kieran t. newton, Michael Sayre, Clark Valentine, Tonya Woldridge, and Linda Zayas-Palmer"
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Quest #2: Unforgiving Fire",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Quest #2: Unforgiving Fire} © 2019, Paizo Inc.; Author: Leo Glass."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day} © 2019, Paizo Inc.; Author: Luis Loza."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Quest #10: The Broken Scales",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Quest #10: The Broken Scales} © 2020, Paizo Inc.; Amber Stewart."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Scenario #1-03: Escaping the Grave",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Scenario #1\u201303: Escaping the Grave} © 2019, Paizo Inc.; Author: Adrian Ng."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Scenario #1-15: The Blooming Catastrophe",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Scenario #1\u201315: The Blooming Catastrophe} © 2020, Paizo Inc.; Author: Mikhail Rekun."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Scenario #1-17: The Perennial Crown Part 2, The Thorned Monarch",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Scenario #1\u201317: The Perennial Crown Part 2: The Thorned Monarch} © 2020, Paizo Inc.; Author: Alexander Augunas."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Scenario #1-19: Iolite Squad Alpha",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Scenario #1\u201319: Iolite Squad Alpha} © 2020, Paizo Inc.; Author: Mike Kimmel."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Pathfinder Society Scenario #1-24: Lightning Strikes, Stars Fall",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Society Scenario #1\u201324: Lightning {@action Strike||Strikes}, Stars Fall} © 2020, Paizo Inc.; Author: Vanessa Hoskins"
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Quest for the Frozen Flame Player's Guide",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Quest for the Frozen Flame Player's Guide} © 2022, Paizo Inc.; Author: Patrick Renie."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Secrets of Magic",
-					"entries": [
-						"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
-						"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Secrets of Magic} © 2021, Paizo Inc.; Authors: Amirali Attar Olyaee, Kate Baker, Minty Belmont, Logan Bonner, James Case, Jessica Catalan, John Compton, Katina Davis, Jesse Decker, Chris Eng, Eleanor Ferron, Leo Glass, Joan Hong, Vanessa Hoskins, Jason Keeley, Joshua Kim, Luis Loza, Ron Lundeen, Liane Merciel, David N. Ross, Ianara Natividad, Chesley Oxendine, Stephen Radney-MacFarland, Shiv Ramdas, Mikhail Rekun, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen H.H.S., Shay Snow, Kendra Leigh Speedling, Tan Shao Han, Calliope Lee Taylor, Mari Tokuda, Jason Tondro, Clark Valentine, Ruvaid Virk, Andrew White, Landon Winkler, Tonya Woldridge, and Isis Wozniakowska."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Shadows at Sundown",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Shadows at Sundown} © 2022, Paizo Inc.; Author: Landon Winkler."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Strength of Thousands Player's Guide",
-					"entries": [
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Strength of Thousands Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "The Fall of Plaguestone",
-					"entries": [
-						"{@b Pathfinder Adventure: The Fall of Plaguestone} © 2019, Paizo Inc.; Author: Jason Bulmahn."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "The Mwangi Expanse",
-					"entries": [
-						"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Lost Omens The Mwangi Expanse} © 2021, Paizo Inc.; Authors: Laura-Shay Adams, Mariam Ahmad, Jahmal Brown, Misha Bushyager, Alexandria Bustion, Duan Byrd, John Compton, Sarah Davis, Naomi Fritts, Kent Hamilton, Sasha Laranoa Harving, Gabriel Hicks, TK Johnson, Michelle Jones, Joshua Kim, Travis Lionel, Ron Lundeen, Stephanie Lundeen, Hillary Moon Murphy, Lu Pellazar, Mikhail Rekun, Nate Wright, and Jabari Weathers."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "The Slithering",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: The Slithering} © 2020, Paizo Inc.; Author: Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Threshold of Knowledge",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Threshold of Knowledge} © 2021, Paizo Inc.; Authors: Ron Lundeen, Jabari Weathers."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "Troubles in Otari",
-					"entries": [
-						"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
-						"{@b Pathfinder Adventure: Troubles in Otari} © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen."
-					]
-				},
-				{
-					"type": "pf2-h3",
-					"collapsible": true,
-					"name": "World Guide",
-					"entries": [
-						"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
-						"{@b Pathfinder Lost Omens World Guide (Second Edition)} © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter."
-					]
-				}
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+				"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+				"{@b Abomination Vaults Adventure Path} © 2022, Paizo Inc.; Authors: Vanessa Hoskins, James Jacobs, and Stephen Radney-MacFarland, with Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Abomination Vaults Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Abomination Vaults Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen, with James Jacobs."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Absalom, City of Lost Omens",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Absalom, City of Lost Omens} © 2021, Paizo Inc.; Authors: Allie Bustion, John Compton, Jeremy Corff, Katina Davis, Vanessa Hoskins, James Jacobs, Virginia Jordan, Erik Mona, Matt Morris, Liane Merciel, Dave Nelson, Samantha Phelan, Jessica Redekop, Mikhail Rekun, Brian Richmond, David N. Ross, Simone D. Sallé, Shahreena Shahrani, Abigail Slater, Chris Spivey, Diego Valdez, and Skylar- James Wall."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Advanced Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Advanced Player's Guide} © 2020, Paizo Inc.; Authors: Amirali Attar Olyaee, Alexander Augunas, Kate Baker, Brian Bauman, Logan Bonner, Carlos Cabrera, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Jesse Decker, Fabby Garza Marroquín, Steven Hammond, Sasha Laranoa Harving, Joan Hong, Nicolas Hornyak, Vanessa Hoskins, James Jacobs, Erik Keith, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Dennis Muldoon, Stephen Radney-MacFarland, Jessica Redekop, Mikhail Rekun, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Kendra Leigh Speedling, Jason Tondro, Clark Valentine, and Andrew White."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Age of Ashes Player's Guide",
+			"entries": [
+				"{@b Age of Ashes Player's Guide} © 2019, Paizo Inc.; Authors: James Jacobs, with Amanda Hamon."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Agents of Edgewatch Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Agents of Edgewatch Player's Guide} © 2020, Paizo Inc.; Author: Patrick Renie."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Ancestry Guide",
+			"entries": [
+				"{@b The Book of Fiends © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb. Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous © 2002, Aaron Loeb. Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Ancestry Guide (Second Edition)} © 2021, Paizo Inc.; Authors: Calder CaDavid, James Case, Jessica Catalan, Eleanor Ferron, Lyz Liddell, Luis Loza, Ron Lundeen, Patchen Mortimer, Andrew Mullen, Samantha Phelan, Jessica Redekop, Mikhail Rekun, David N. Ross, Mark Seifter, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Azarketi Ancestry Web Supplement",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Azarketi Ancestry Web Supplement} © 2021, Paizo Inc.; Author: Samantha Phelan."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Bestiary",
+			"entries": [
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
+				"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+				"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Mite from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian Livingstone and Mark Barnes.",
+				"{@b Pathfinder Bestiary (Second Edition)} © 2019, Paizo Inc.; Authors: Alexander Augunas, Logan Bonner, Jason Bulmahn, John Compton, Paris Crenshaw, Adam Daigle, Eleanor Ferron, Leo Glass, Thurston Hillman, James Jacobs, Jason Keeley, Lyz Liddell, Ron Lundeen, Robert G. McCreary, Tim Nightengale, Stephen Radney-MacFarland, Alex Riggs, David N. Ross, Michael Sayre, Mark Seifter, Chris S. Sims, Jeffrey Swank, Jason Tondro, Tonya Woldridge, and Linda Zayas-Palmer."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Bestiary 2",
+			"entries": [
+				"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Aurumvorax from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Blindheim from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Roger Musson.",
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Cave Fisher from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Lawrence Schick.",
+				"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Dark Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Rik Shepard.",
+				"{@b Dark Stalker from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+				"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+				"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Korred from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Necrophidius from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Tillbrook.",
+				"{@b Nereid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Quickling from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Quickwood from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Scythe Tree from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene.",
+				"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+				"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+				"{@b Troll, Two-Headed from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Oliver Charles MacDonald.",
+				"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Bestiary 2 (Second Edition)} © 2020, Paizo Inc.; Authors: Alexander Augunas, Dennis Baker, Jesse Benner, Joseph Blomquist, Logan Bonner, Paris Crenshaw, Adam Daigle, Jesse Decker, Darrin Drader, Brian Duckwitz, Robert N. Emerson, Scott Fernandez, Keith Garrett, Scott Gladstein, Matthew Goodall, T.H. Gulliver, BJ Hensley, Tim Hitchcock, Vanessa Hoskins, James Jacobs, Brian R. James, Jason Keeley, John Laffan, Lyz Liddell, Colm Lundberg, Ron Lundeen, Jason Nelson, Randy Price, Jessica Redekop, Patrick Renie, Alistair Rigg, Alex Riggs, David N. Ross, David Schwartz, Mark Seifter, Amber Stewart, Jeffrey Swank, Russ Taylor, and Jason Tondro."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Bestiary 3",
+			"entries": [
+				"{@b Flumph from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowell and Douglas Naismith.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Bestiary 3 (Second Edition)} © 2021, Paizo Inc.; Authors: Logan Bonner, James Case, Jessica Catalan, John Compton, Paris Crenshaw, Adam Daigle, Katina Davis, Erik Scott de Bie, Jesse Decker, Brian Duckwitz, Hexe Fey, Keith Garrett, Matthew Goodall, Violet Gray, Alice Grizzle, Steven Hammond, Sasha Laranoa Harving, Joan Hong, James Jacobs, Michelle Jones, Virginia Jordan, TJ Kahn, Mikko Kallio, Jason Keeley, Joshua Kim, Avi Kool, Jeff Lee, Lyz Liddell, Luis Loza, Ron Lundeen, Philippe-Antoine Menard, Patchen Mortimer, Dennis Muldoon, Andrew Mullen, Quinn Murphy, Dave Nelson, Jason Nelson, Samantha Phelan, Stephen Radney-MacFarland, Danita Rambo, Shiv Ramdas, BJ Recio, Jessica Redekop, Mikhail Rekun, Patrick Renie, Alex Riggs, David N. Ross, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen.H.H.S, Abigail Slater, Rodney Sloan, Shay Snow, Pidj Sorensen, Kendra Leigh Speedling, Tan Shao Han, William Thompson, Jason Tondro, Clark Valentine, Ruvaid Virk, Skylar Wall, Andrew White, and Landon Winkler."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Blood Lords Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Blood Lords Player's Guide} © 2022, Paizo Inc.; Author: Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Book of the Dead",
+			"entries": [
+				"{@b Demon Lord, Orcus from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene and Clark Peterson, based on material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter. Pathfinder Book of the Dead © 2022, Paizo Inc.; Authors: Brian Bauman, Tineke Bolleman. Logan Bonner, Jason Bulmahn, Jessica Catalan, John Compton, Chris Eng, Logan Harper, Michelle Jones, Jason Keeley, Luis Loza, Ron Lundeen, Liane Merciel, Patchen Mortimer, Quinn Murphy, Jessica Redekop, Mikhail Rekun, Solomon St. John, Michael Sayre, Mark Seifter, Sen.H.H.S., Kendra Leigh Speedling, Jason Tondro, Andrew White."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Character Guide",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Lost Omens Character Guide (Second Edition)} © 2019, Paizo Inc.; Authors: John Compton, Sasha Lindley Hall, Amanda Hamon, Mike Kimmel, Luis Loza, Ron Lundeen, Matt Morris, Patchen Mortimer, Andrew Mullen, Mikhail Rekun, Micheal Sayre, Owen K.C. Stephens, Isabelle Thorne, and Linda Zayas-Palmer."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Core Rulebook",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Designers: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Critical Fumble Deck",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Critical Hit Deck (Second Edition)} © 2019, Paizo Inc.; Author: Stephen Radney-MacFarland."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Critical Hit Deck",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Critical Fumble Deck (Second Edition)} © 2019, Paizo Inc.; Author: Stephen Radney-MacFarland."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Extinction Curse Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Extinction Curse Player's Guide} © 2020, Paizo Inc.; Author: Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Fists of the Ruby Phoenix Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Fists of the Ruby Phoenix Player's Guide} © 2021, Paizo Inc.; Author: Patrick Renie, with Luis Loza."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Gamemastery Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #152: Legacy of the Lost God} © 2020, Paizo Inc.; Authors: Jenny Jarzabski, with Stephen Glicker, Luis Loza, Ron Lundeen, Andrew Mullen, and David N. Ross."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Gods & Magic",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Lost Omens Gods & Magic (Second Edition)} © 2020, Paizo Inc.; Authors: Robert Adducci, Amirali Attar Olyaee, Calder CaDavid, James Case, Adam Daigle, Katina Davis, Leo Glass, Joshua Grinlinton, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Ron Lundeen, Stephanie Lundeen, Jacob W. Michaels, Matt Morris, Dave Nelson, Samantha Phelan, Jennifer Povey, Jessica Redekop, Nathan Reinecke, Patrick Renie, David N. Ross, Simone D. Sallé, Michael Sayre, David Schwartz, Shahreena Shahrani, Isabelle Thorne, Marc Thuot, Jason Tondro, and Diego Valdez."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Gods & Magic Web Supplement",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Lost Omens Gods & Magic Web Supplement} © 2020, Paizo Inc.; Authors: James Case, Adam Daigle, Leo Glass, James Jacobs, Virginia Jordan, Jason Keeley, Jacky Leung, Lyz Liddell, Luis Loza, Ron Lundeen, Matt Morris, Nathan Reinecke, Simone D. Sallé, Michael Sayre, Shahreena Shahrani, Isabelle Thorne, and Diego Valdez."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Grand Bazaar",
+			"entries": [
+				"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Grand Bazaar} © 2021, Paizo Inc.; Authors: Tineke Bolleman, Logan Bonner, Jessica Catalan, Dominique Dickey, Dana Ebert, Steven Hammond, Sen H.H.S., Dustin Knight, Avi Kool, Aaron Lascano, Carlos Luna, Ron Lundeen, Sydney Meeker, Randal Meyer, Jacob Michaels, Matt Morris, Andrew Mullen, Ianara Natividad, Dave Nelson, Jessica Redekop, Nathan Reinecke, Erin Roberts, David N. Ross, Simone Sallé, Mark Seifter, Shay Snow, Ashton Sperry, Amber Stewart, Andrew Stoeckle, Isabelle Thorne, Jason Tondro, and Scott D. Young."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Guns & Gears",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Guns & Gears} © 2021, Paizo Inc.; Authors: Logan Bonner, Jessica Catalan, John Compton, Andrew D. Geels, Steven Hammond, Sen H.H.S., Brent Holtsberry, Jason Keeley, Dustin Knight, Luis Loza, Ron Lundeen, Chris Mastey, Liane Merciel, Jacob W. Michaels, Dave Nelson, Samantha Phelan, Mikhail Rekun, Stephen Radney-MacFarland, Sydney Meeker, Kendra Leigh Speedling, Michael Sayre., Mark Seifter, Andrew Stoeckle, Calliope Lee Taylor, Andrew White, and Scott D. Young."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Knights of Lastwall",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+				"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Yellow Musk Zombie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Knights of Lastwall} © 2022, Paizo Inc.; Authors: Banana Chan, Jessica Catalan, Ryan Costello, Katina Davis, Alastor Guzman, Ron Lundeen, Ianara Natividad, Erin Roberts, Ashton Sperry, and Isabelle Thorne"
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Legends",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Legends} © 2020, Paizo Inc.; Authors: Alexander Augunas, Kate Baker, Jason Bulmahn, Alexandria Bustion, Carlos Cabrera, Calder CaDavid, Jessica Catalan, Natalie Collazo, Ryan Costello, Greg Diaz, Fabby Garza Marroquín, Jaym Gates, Alice Grizzle, Steven Hammond, Nicolas Hornyak, James Jacobs, Michelle Jones, Kristina Sisto Kindel, Aaron Lascano, Ron Lundeen, Stephanie Lundeen, Sydney Meeker, Liane Merciel, Matt Morris, Patchen Mortimer, Hilary Moon Murphy, Dennis Muldoon, Andrew Mullen, Amirali Attar Olyaee, Mikhail Rekun, Michael Sayre, Mark Seifter, Ashton Sperry, Owen K.C. Stephens, and Isabelle Thorne"
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Little Trouble in Big Absalom",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Little Trouble in Big Absalom} © 2020, Paizo Inc.; Author: Eleanor Ferron."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Malevolence",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Malevolence} © 2021, Paizo Inc.; Author: James Jacobs."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Monsters of Myth",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Monsters of Myth} © 2021, Paizo Inc.; Authors: James Case, John Compton, Dana Ebert, Joshua Kim, Aaron Lascano, Luis Loza, Ron Lundeen, Stephanie Lundeen, Liane Merciel, Andrew Mullen, Michael Sayre, Sen H.H.S., Shay Snow, and Jason Tondro."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Night of the Gray Death",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Night of the Gray Death} © 2021, Paizo Inc.; Author: Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Outlaws of Alkenstar Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Outlaws of Alkenstar Player's Guide} © 2022, Paizo Inc.; Author: Patrick Renie."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #145: Hellknight Hill",
+			"entries": [
+				"{@b Pathfinder Adventure Path #145: Hellknight Hill} © 2019, Paizo Inc.; Authors: Amanda Hamon, with Logan Bonner, James Jacobs, and Jason Tondro."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #146: Cult of Cinders",
+			"entries": [
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #146: Cult of Cinders} © 2019, Paizo Inc.; Authors: Eleanor Ferron, with Leo Glass, James Jacobs, Jason Keeley, and Owen KC Stephens."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #147: Tomorrow Must Burn",
+			"entries": [
+				"{@b Pathfinder Adventure Path #147: Tomorrow Must Burn} © 2019, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen, with Lyz Liddell and James Sutter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #148: Fires of the Haunted City",
+			"entries": [
+				"{@b Pathfinder Adventure Path #148: Fires of the Haunted City} © 2019, Paizo Inc.; Authors: Linda Zayas-Palmer, with Owen K.C. Stephens, James L. Sutter, and Greg Vaughan."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #149: Against the Scarlet Triad",
+			"entries": [
+				"{@b Pech from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #149: Against the Scarlet Triad} © 2019, Paizo Inc.; Authors: John Compton, with Tim Nightengale and James L. Sutter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #150: Broken Promises",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #150: Broken Promises} © 2019, Paizo Inc.; Authors: Luis Loza, with James Jacobs, Alex Riggs, and Owen K.C. Stephens."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #151: The Show Must Go On",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #151: The Show Must Go On} © 2020, Paizo Inc.; Authors: Jason Tondro, with Andrew Mullen, Patrick Renie, David N. Ross, and Michael Sayre."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #152: Legacy of the Lost God",
+			"entries": [
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Gamemastery Guide} © 2020, Paizo Inc.; Authors: Alexander Augunas, Jesse Benner, John Bennett, Logan Bonner, Clinton J. Boomer, Jason Bulmahn, James Case, Paris Crenshaw, Jesse Decker, Robert N. Emerson, Eleanor Ferron, Jaym Gates, Matthew Goetz, T.H. Gulliver, Kev Hamilton, Sasha Laranoa Harving, BJ Hensley, Vanessa Hoskins, Brian R. James, Jason LeMaitre, Lyz Liddell, Luis Loza, Colm Lundberg, Ron Lundeen, Stephen Radney-MacFarland, Jessica Redekop, Alistair Rigg, Mark Seifter, Owen K.C. Stephens, Amber Stewart, Christina Stiles, Landon Winkler, and Linda Zayas-Palmer."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #153: Life's Long Shadow",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #153: Life's Long Shadows} © 2020, Paizo Inc.; Authors: Greg A. Vaughan, with Anthony Bono, Jacob W. Michaels, Andrew Mullen, Patrick Renie, Alex Riggs, Timothy Snow, and Amber Stewart."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #154: Siege of the Dinosaurs",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #154: Siege of the Dinosaurs} © 2020, Paizo Inc.; Authors: Kate Baker, with Luis Loza, Andrew Mullen, Jason Nelson, Jennifer Povey, David Schwartz, and Amber Stewart."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #155: Lord of the Black Sands",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #155: Lord of the Black Sands} © 2020, Paizo Inc.; Authors: Mikko Kallio, with Andrew Mullen, Nathan Reinecke, David Schwartz, and Scott Young."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #156: The Apocalypse Prophet",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Demon Lord, Baphomet from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Demon Lord, Pazuzu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #156: The Apocalypse Prophet} © 2020, Paizo Inc.; Authors: Lyz Liddell, with Kevin Bryan, Steven Hammond, Andrew Mullen, Mikhail Rekun, Patrick Renie, and David N. Ross."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #157: Devil at the Dreaming Palace",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Carbuncle from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Pathfinder Adventure Path #157: Devil at the Dreaming Palace} © 2020, Paizo Inc.; Authors: James L. Sutter, with Luis Loza, Andrew Mullen, Samantha Phelan, and Patrick Renie."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #158: Sixty Feet Under",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Pathfinder Adventure Path #158: Sixty Feet Under} © 2020, Paizo Inc.; Authors: Michael Sayre, with Saif Ansari, Leo Glass, Ron Lundeen, Jacob W. Michaels, Patrick Renie, and David N. Ross."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #159: All or Nothing",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #159: All or Nothing} © 2020, Paizo Inc.; Authors: Jason Keeley, with Alexander Augunas, Jessica Catalan, Stephen Glicker, Mike Kimmel, Alex Riggs, and Mike Welham."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #160: Assault on Hunting Lodge Seven",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #160: Assault on Hunting Lodge Seven} © 2020, Paizo Inc.; Authors: Ron Lundeen, with Luis Loza and Hilary Moon Murphy."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #161: Belly of the Black Whale",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #161: Belly of the Black Whale} © 2020, Paizo Inc.; Authors: Cole Kronewitter, with Kim Frandsen, Patchen Mortimer, Kyle T. Raes, Andrew White, and Brian Yaksha."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #162: Ruins of the Radiant Siege",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #162: Ruins of the Radiant Siege} © 2020, Paizo Inc.; Authors: Amber Stewart, with Carlos Cabrera, Benjamin U. Fields, Kim Frandsen, Jim Groves, John S. Roberts, and Diego Valdez."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #163: Ruins of Gauntlight",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Soul Eater from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by David Cook.",
+				"{@b Pathfinder Adventure Path #163: Ruins of Gauntlight} © 2021, Paizo Inc.; Author: James Jacobs."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #164: Hands of the Devil",
+			"entries": [
+				"{@b Skulk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Simon Muth.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #164: Hands of the Devil} © 2021, Paizo Inc.; Authors: Vanessa Hoskins, with Ron Lundeen, Quinn Murphy, and Amber Stewart."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #165: Eyes of Empty Death",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen Radney- MacFarland, with James Jacobs and Mikhail Rekun."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #166: Despair on Danger Island",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Daemon, Derghodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #165: Eyes of Empty Death} © 2021, Paizo Inc.; Authors: Stephen RadneyMacFarland, with James Jacobs and Mikhail Rekun."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #167: Ready? Fight!",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #167: Ready? Fight!} © 2021, Paizo Inc.; Authors: David N. Ross, with Joan Hong, Joshua Kim, Danita Rambo, Sen H.H.S., Tan Shao Han, and Ruvaid Virk."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #168: King of the Mountain",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #168: King of the Mountain} © 2021, Paizo Inc.; Authors: James Case, with Joan Hong, Danita Rambo, David N. Ross, Amber Stewart, William Thompson, Ruvaid Virk, and Jabari Weathers."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #169: Kindled Magic",
+			"entries": [
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #169: Kindled Magic} © 2021, Paizo Inc.; Authors: Eleanor Ferron and Alexandria Bustion, with Shanyce Henley, Jenny Jarzabski, Jessica Redekop, and Mark Seifter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #170: Spoken on the Song Wind",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Demon Lord, Jubilex from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #170: Spoken on the Song Wind} © 2021, Paizo Inc.; Authors: Quinn Murphy, with James Case, Jessica Catalan, Brian Cortijo, Isaac Kerry, Dave Nelson, Lu Pellazar, and Shan Wolf."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #171: Hurricane's Howl",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #171: Hurricane's Howl} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #172: Secrets of the Temple City",
+			"entries": [
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #172: Secrets of the Temple-City} © 2021, Paizo Inc.; Authors: Luis Loza, with Eleanor Ferron, John Godek III, and Shanyce Henley."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #173: Doorway to the Red Star",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #173: Doorway to the Red Star} © 2021, Paizo Inc.; Author: Michael Sayre."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #174: Shadows of the Ancients",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #174: Shadows of the Ancients} © 2021, Paizo Inc.; Authors: Saif Ansari, with Matt Hardin, Jacob W. Michaels, Matt Morris, Brendan Perry, Jessica Redekop, Nathan Reinecke, and Darren Spurrier."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #175: Broken Tusk Moon",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #175: Broken Tusk Moon} © 2022, Paizo Inc.; Authors: Ron Lundeen and Stephanie Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #176: Lost Mammoth Valley",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Battlezoo Bestiary} © 2021, Skyscraper Studios Inc.; Authors: Stephen Glicker, Patrick Renie, AND Mark Seifter",
+				"{@b Demon, Nabasu from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Shadow from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+				"{@b Grippli from Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Adventure Path #176: Lost Mammoth Valley} © 2022, Paizo Inc.; Author: Jessica Catalan."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #177: Burning Tundra",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Dracolisk from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+				"{@b Pathfinder Adventure Path #177: Burning Tundra} © 2022, Paizo Inc.; Author: Jason Tondro."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #178: Punks in a Powderkeg",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #178: Punks in a Powder Keg} © 2022, Paizo Inc.; Authors: Vanessa Hoskins, with Stephanie Lundeen and Matt Morris."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #179: Cradle of Quartz",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #179: Cradle of Quartz} © 2022, Paizo Inc.; Authors: Scott D. Young and Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder #180: The Smoking Gun",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure Path #180: The Smoking Gun} © 2022, Paizo Inc.; Author: Cole Kronewitter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Special: Fumbus",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Guide",
+			"entries": [
+				"{@b The Book of Fiends} © 2003, Green Ronin Publishing; Authors: Aaron Loeb, Erik Mona, Chris Pramas, and Robert J. Schwalb.",
+				"{@b Armies of the Abyss} © 2002, Green Ronin Publishing; Authors: Erik Mona and Chris Pramas.",
+				"{@b The Avatar's Handbook} © 2003, Green Ronin Publishing; Authors: Jesse Decker and Chris Thomasson.",
+				"{@b Book of the Righteous} © 2002, Aaron Loeb.",
+				"{@b Legions of Hell} © 2001, Green Ronin Publishing; Author: Chris Pramas.",
+				"{@b The Unholy Warrior's Handbook} © 2003, Green Ronin Publishing; Author: Robert J. Schwalb.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Dragon, Faerie from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Brian Jaeger and Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens Pathfinder Society Guide} © 2020, Paizo Inc.; Authors: Kate Baker, James Case, John Compton, Vanessa Hoskins, Mike Kimmel, Ron Lundeen, Dennis Muldoon, kieran t. newton, Michael Sayre, Clark Valentine, Tonya Woldridge, and Linda Zayas-Palmer"
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Quest #2: Unforgiving Fire",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Quest #2: Unforgiving Fire} © 2019, Paizo Inc.; Author: Leo Glass."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Quest #5: The Dragon Who Stole Evoking Day} © 2019, Paizo Inc.; Author: Luis Loza."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Quest #10: The Broken Scales",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Quest #10: The Broken Scales} © 2020, Paizo Inc.; Amber Stewart."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Scenario #1-03: Escaping the Grave",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Scenario #1\u201303: Escaping the Grave} © 2019, Paizo Inc.; Author: Adrian Ng."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Scenario #1-15: The Blooming Catastrophe",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Scenario #1\u201315: The Blooming Catastrophe} © 2020, Paizo Inc.; Author: Mikhail Rekun."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Scenario #1-17: The Perennial Crown Part 2, The Thorned Monarch",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Scenario #1\u201317: The Perennial Crown Part 2: The Thorned Monarch} © 2020, Paizo Inc.; Author: Alexander Augunas."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Scenario #1-19: Iolite Squad Alpha",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Scenario #1\u201319: Iolite Squad Alpha} © 2020, Paizo Inc.; Author: Mike Kimmel."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Pathfinder Society Scenario #1-24: Lightning Strikes, Stars Fall",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Society Scenario #1\u201324: Lightning {@action Strike||Strikes}, Stars Fall} © 2020, Paizo Inc.; Author: Vanessa Hoskins"
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Quest for the Frozen Flame Player's Guide",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Quest for the Frozen Flame Player's Guide} © 2022, Paizo Inc.; Author: Patrick Renie."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Secrets of Magic",
+			"entries": [
+				"{@b Angel, Monadic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Angel, Movanic Deva from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Daemon, Guardian from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Ian McDowall.",
+				"{@b Daemon, Piscodaemon from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Shadow from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Neville White.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Secrets of Magic} © 2021, Paizo Inc.; Authors: Amirali Attar Olyaee, Kate Baker, Minty Belmont, Logan Bonner, James Case, Jessica Catalan, John Compton, Katina Davis, Jesse Decker, Chris Eng, Eleanor Ferron, Leo Glass, Joan Hong, Vanessa Hoskins, Jason Keeley, Joshua Kim, Luis Loza, Ron Lundeen, Liane Merciel, David N. Ross, Ianara Natividad, Chesley Oxendine, Stephen Radney-MacFarland, Shiv Ramdas, Mikhail Rekun, Simone D. Sallé, Michael Sayre, Mark Seifter, Sen H.H.S., Shay Snow, Kendra Leigh Speedling, Tan Shao Han, Calliope Lee Taylor, Mari Tokuda, Jason Tondro, Clark Valentine, Ruvaid Virk, Andrew White, Landon Winkler, Tonya Woldridge, and Isis Wozniakowska."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Shadows at Sundown",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Shadows at Sundown} © 2022, Paizo Inc.; Author: Landon Winkler."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Strength of Thousands Player's Guide",
+			"entries": [
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Strength of Thousands Player's Guide} © 2021, Paizo Inc.; Author: Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "The Fall of Plaguestone",
+			"entries": [
+				"{@b Pathfinder Adventure: The Fall of Plaguestone} © 2019, Paizo Inc.; Author: Jason Bulmahn."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "The Mwangi Expanse",
+			"entries": [
+				"{@b Basidirond from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Demon, Nabasu from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Froghemoth from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Grippli from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Yellow Musk Creeper from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Albie Fiore.",
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Lost Omens The Mwangi Expanse} © 2021, Paizo Inc.; Authors: Laura-Shay Adams, Mariam Ahmad, Jahmal Brown, Misha Bushyager, Alexandria Bustion, Duan Byrd, John Compton, Sarah Davis, Naomi Fritts, Kent Hamilton, Sasha Laranoa Harving, Gabriel Hicks, TK Johnson, Michelle Jones, Joshua Kim, Travis Lionel, Ron Lundeen, Stephanie Lundeen, Hillary Moon Murphy, Lu Pellazar, Mikhail Rekun, Nate Wright, and Jabari Weathers."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "The Slithering",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: The Slithering} © 2020, Paizo Inc.; Author: Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Threshold of Knowledge",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Threshold of Knowledge} © 2021, Paizo Inc.; Authors: Ron Lundeen, Jabari Weathers."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "Troubles in Otari",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Adventure: Troubles in Otari} © 2020, Paizo Inc.; Authors: Jason Keeley, Lyz Liddell, and Ron Lundeen."
+			]
+		},
+		{
+			"type": "pf2-h3",
+			"collapsible": true,
+			"name": "World Guide",
+			"entries": [
+				"{@b Genie, Marid from the Tome of Horrors Complete} © 2011, Necromancer Games, Inc., published and distributed by Frog God Games; Author: Scott Greene, based on original material by Gary Gygax.",
+				"{@b Pathfinder Lost Omens World Guide (Second Edition)} © 2019, Paizo Inc.; Authors: Tanya DePass, James Jacobs, Lyz Liddell, Ron Lundeen, Liane Merciel, Erik Mona, Mark Seifter, James L. Sutter."
 			]
 		}
 	]

--- a/data/quickrules.json
+++ b/data/quickrules.json
@@ -150,9 +150,9 @@
 								"Backgrounds allow you to customize your character based on their life before adventuring. This is the next step in their life story after their ancestry, which reflects the circumstances of their birth. Your character's background can help you learn or portray more about their personality while also suggesting what sorts of things they're likely to know. Consider what events set your character on their path to the life of an adventurer and how those circumstances relate to their background."
 							]
 						},
-						"At 1st level when you create your character, you gain a background of your choice. This decision is permanent; you can't change it at later levels. Each background listed here grants two ability boosts, a skill feat, and the trained proficiency rank in two skills, one of which is a Lore skill. If you gain the trained proficiency rank in a skill from your background and would then gain the trained proficiency rank in the same skill from your class at 1st level, you instead become trained in another skill of your choice.",
-						"Lore skills represent deep knowledge of a specific subject and are described on page 247. If a Lore skill involves a choice (for instance, a choice of terrain), explain your preference to the GM, who has final say on whether it's acceptable or not. If you'd like some suggestions, the Common Lore Subcategories sidebar on page 248 lists a number of Lore skills that are suitable for most campaigns.",
-						"Skill feats expand the functions of your skills and appear in Chapter 5: Feats."
+						"At 1st level when you create your character, you gain a background of your choice. This decision is permanent; you can't change it at later levels. Each background listed here grants two ability boosts, a skill feat, and the trained proficiency rank in two skills, one of which is a {@skill Lore} skill. If you gain the trained proficiency rank in a skill from your background and would then gain the trained proficiency rank in the same skill from your class at 1st level, you instead become trained in another skill of your choice.",
+						"{@skill Lore} skills represent deep knowledge of a specific subject. If a {@skill Lore} skill involves a choice (for instance, a choice of terrain), explain your preference to the GM, who has final say on whether it's acceptable or not. If you'd like some suggestions, the {@book Common Lore Subcategories|CRB|4|Lore (Int)} sidebar lists a number of Lore skills that are suitable for most campaigns.",
+						"Skill feats expand the functions of your skills and appear in {@book Chapter 5: Feats|CRB|5}."
 					]
 				}
 			]
@@ -261,8 +261,8 @@
 								"All kinds of experiences and training can shape your character beyond what you learn by advancing in your class. Abilities that require a degree of training but can be learned by anyone\u2014not only members of certain ancestries or classes\u2014are called general feats."
 							]
 						},
-						"For most classes, you gain a general feat when you reach 3rd level and every 4 levels thereafter. Each time you gain a general feat, you can select any feat with the general trait whose prerequisites you satisfy.",
-						"General feats also include a subcategory of skill feats, which expand on what you can accomplish via skills. These feats also have the skill trait. Most characters gain skill feats at 2nd level and every 2 levels thereafter. When you gain a skill feat, you must select a general feat with the skill trait; you can't select a general feat that lacks the skill trait. The level of a skill feat is typically the minimum level at which a character could meet its proficiency prerequisite."
+						"For most classes, you gain a general feat when you reach 3rd level and every 4 levels thereafter. Each time you gain a general feat, you can select any feat with the {@trait general} trait whose prerequisites you satisfy.",
+						"General feats also include a subcategory of skill feats, which expand on what you can accomplish via skills. These feats also have the {@trait skill} trait. Most characters gain skill feats at 2nd level and every 2 levels thereafter. When you gain a skill feat, you must select a {@filter general feat with the skill trait|feats||general=general;skill=sand}; you can't select a general feat that lacks the {@trait skill} trait. The level of a skill feat is typically the minimum level at which a character could meet its proficiency prerequisite."
 					]
 				}
 			]
@@ -1690,6 +1690,92 @@
 						},
 						"Vehicles can play many roles in a game. They might simply be the means by which the party travels from one location to another, determining only the Price to be paid for passage. But a caravan wagon that gets attacked becomes part of an encounter. In a pirate campaign, the ship is both the party's home and its primary weapon.",
 						"The majority of the rules in this section are for using vehicles in encounters, but vehicles are also useful during exploration and even downtime play."
+					]
+				}
+			]
+		},
+		"criticalHitDeck": {
+			"source": "CHD",
+			"page": 0,
+			"entries": [
+				{
+					"type": "pf2-h1",
+					"name": "The Rules",
+					"blue": true,
+					"entries": [
+						"A group can use a {@i Critical Hit Deck} in their game to make combat more surprising and dangerous. Whenever a PC scores a critical hit due to a natural 20 on the die roll, that player can draw one card from this deck and apply the effect appropriate to that attack's type (bludgeoning, piercing, or slashing in the case of a weapon or unarmed attack, or bomb or spell for either a bomb or spell attack roll). Since these effects can be deadly against player characters, the GM draws for a monster, NPC, or hazard only if the creature or hazard's level is equal to or greater than the target's level.",
+						{
+							"type": "pf2-h2",
+							"name": "Deadly Variant",
+							"entries": [
+								"For a deadlier and more chaotic game, the GM can allow a player to draw on any critical hit, not just one due to a natural 20, and draw for any critical hits scored by an enemy regardless of that enemy's level."
+							]
+						},
+						{
+							"type": "pf2-h2",
+							"name": "Special Rules",
+							"entries": [
+								{
+									"type": "list",
+									"items": [
+										"A critical hit still deals double damage to the target unless the card's entry says it deals normal damage or triple damage, or if the entry's effect doesn't apply to the attack used.",
+										"Any effect listed as a Crit Effect replaces your attack's critical specialization effect, if it had one. You can disregard the card effect and use your attack's existing {@quickref critical specialization|CRB|1|Critical Specialization Effects} if you prefer.",
+										"Any card effect using a {@quickref critical specialization effect|CRB|1|Critical Specialization Effects} follows the rules for that effect unless stated otherwise.",
+										"Effects that scale by level use the attacker's level. The save DC for an effect inflicted by a PC is their class DC. For other creatures and hazards, use a hard DC for the creature or hazard's level",
+										"An effect that lasts until healed ends once the target has Hit Points restored with {@action Treat Wounds} or is restored to full Hit Points and rests for 10 minutes."
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		"criticalFumbleDeck": {
+			"source": "CFD",
+			"page": 0,
+			"entries": [
+				{
+					"type": "pf2-h1",
+					"name": "The Rules",
+					"blue": true,
+					"entries": [
+						"A group can use a {@i Critical Fumble Deck} in their game to make combat more surprising and perilous. Whenever a PC or foe gets a critical failure on an attack roll due to a natural 1 on the die roll, that player can draw one card from this deck and apply the effect appropriate to the attack's type (melee weapon, ranged attack, unarmed attack, or spell).",
+						{
+							"type": "pf2-h2",
+							"name": "Special Rules",
+							"entries": [
+								{
+									"type": "list",
+									"items": [
+										"Effects that scale based on level use the attacker's level.",
+										"The save DC for an effect applied to a PC is a hard DC for the target creature or hazard's level. Effects applied to a foe use the PC's class DC.",
+										"An effect that lasts until healed ends once the recipient regains Hit Points from {@action Treat Wounds}, or is restored to full Hit Points and rests for 10 minutes."
+									]
+								}
+							]
+						},
+						{
+							"type": "pf2-h2",
+							"name": "Deadly Variant",
+							"entries": [
+								"For a deadlier and more chaotic game, the GM can allow a  draw on any critical failure, not just one due to a natural 1."
+							]
+						},
+						{
+							"type": "pf2-h2",
+							"name": "Proficiency Variant",
+							"entries": [
+								"If the PC, NPC, or other creature has a master proficiency rank in the attack that they fumbled, they can draw two fumble cards and apply one of the two listed effects. If the creature is legendary with that attack, they can draw three fumble cards and choose one effect to apply from the three listed effects."
+							]
+						},
+						{
+							"type": "pf2-h2",
+							"name": "Critical Hit Deck Variant",
+							"entries": [
+								"If you are using the {@i Pathfinder Critical Hit Deck}, anytime a PC scores a critical hit, the player can draw a card and, instead of playing it, deal normal damage and keep the card. That player can later exchange the critical hit card to negate a critical failure rolled by their PC or any other PC in the group."
+							]
+						}
 					]
 				}
 			]

--- a/data/sources.json
+++ b/data/sources.json
@@ -1126,6 +1126,24 @@
 			],
 			"adventure": true,
 			"store": "https://paizo.com/products/btq027qf"
+		},
+		{
+			"source": "CHD",
+			"date": "2019-10-16",
+			"name": "Critical Hit Deck",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Critical Hit Deck (Second Edition)} © 2019, Paizo Inc.; Author: Stephen Radney-MacFarland."
+			]
+		},
+		{
+			"source": "CFD",
+			"date": "2019-10-16",
+			"name": "Critical Fumble Deck",
+			"entries": [
+				"{@b Pathfinder Core Rulebook (Second Edition)} © 2019, Paizo Inc.; Authors: Logan Bonner, Jason Bulmahn, Stephen Radney-MacFarland, and Mark Seifter.",
+				"{@b Pathfinder Critical Fumble Deck (Second Edition)} © 2019, Paizo Inc.; Author: Stephen Radney-MacFarland."
+			]
 		}
 	]
 }

--- a/data/tables.json
+++ b/data/tables.json
@@ -1,6 +1,1918 @@
 {
 	"table": [
 		{
+			"name": "Critical Hit Deck: Bomb or Spell",
+			"source": "CHD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Allergic Reaction} The target takes {@damage 1d8} poison damage."
+				],
+				[
+					"2",
+					"{@b Mind Cloud} The target is {@condition stupefied} 2 until healed."
+				],
+				[
+					"3",
+					"{@b Olfactory Overload} The target loses its sense of smell and any scent ability or other olfactory sense until healed."
+				],
+				[
+					"4",
+					"{@b Stunned} Normal damage. The target is {@condition stunned} 2."
+				],
+				[
+					"5",
+					"{@b Cut Off From Magic} Normal damage. The target can't cast spells or activate magic items for {@dice 1d4} rounds."
+				],
+				[
+					"6",
+					"{@b Now You See Me...} You become {@condition invisible} until the end of your next turn or until you use a hostile action."
+				],
+				[
+					"7",
+					"{@b Petrified} The target is {@condition petrified} for 10 minutes."
+				],
+				[
+					"8",
+					"{@b Protective Charm} You gain a +2 status bonus to AC and all saving throws until the end of your next turn."
+				],
+				[
+					"9",
+					"{@b Pretty Colors} The target is {@condition dazzled} until the end of your next turn."
+				],
+				[
+					"10",
+					"{@b Conduit} The target takes a -2 status penalty to AC and saves against your bombs or spells until the end of your next turn."
+				],
+				[
+					"11",
+					"{@b Nerve Damage} Normal damage. The target is {@condition slowed} 1 until healed."
+				],
+				[
+					"12",
+					"{@b Strange Goo} Normal damage and the target is {@condition restrained}, using your class DC as the DC to {@action Escape}."
+				],
+				[
+					"13",
+					"{@b Life Leech} If this is a spell, the target becomes {@condition doomed} 1 and you regain {@damage 1d8} Hit Points."
+				],
+				[
+					"14",
+					"{@b Vampiric Feedback} Normal damage. You regain Hit Points equal half the damage you dealt."
+				],
+				[
+					"15",
+					"{@b Knockback} Push the target up to 10 feet."
+				],
+				[
+					"16",
+					"{@b Electrocuted} If this is a {@trait electricity} spell or bomb, the target takes double damage, and at the start of its next turn, it takes normal damage. Any other bomb or spell deals double damage."
+				],
+				[
+					"17",
+					"{@b Frozen} If this is a {@trait cold} bomb or spell, the target takes triple damage and is {@condition slowed} 2 for 1 round. Any other bomb or spell deals double damage."
+				],
+				[
+					"18",
+					"{@b Power Surge} Triple damage."
+				],
+				[
+					"19",
+					"{@b Devastating Strike} Triple damage. The target is {@condition stunned} 1."
+				],
+				[
+					"20",
+					"{@b Eyeburn} The target is {@condition blinded} until the end of its next turn."
+				],
+				[
+					"21",
+					"{@b Transposition} If this is a spell attack, you and the target switch places. This is a {@trait teleportation} effect."
+				],
+				[
+					"22",
+					"{@b Hypnotic Link} If this is a spell, the target takes normal damage and is {@condition controlled} by you until the end of its next turn."
+				],
+				[
+					"23",
+					"{@b Distraction} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"24",
+					"{@b Funny Bone} The target laughs uncontrollably until the end of its next turn. While laughing, it is {@condition slowed} 1 and can't use reactions."
+				],
+				[
+					"25",
+					"{@b Shrink Aftereffect} Normal damage. The target is reduced in size as if subject to a {@spell shrink} spell until the end of its next turn."
+				],
+				[
+					"26",
+					"{@b Psychic Overflow} The target takes {@damage 1d8} mental damage."
+				],
+				[
+					"27",
+					"{@b Vulnerability} The target gains weakness 5 to any damage types dealt by the bomb or spell for 1 minute."
+				],
+				[
+					"28",
+					"{@b Lingering Damage} The target takes {@damage 1d6} {@condition persistent damage||persistent damage} of the same type as the bomb or spell's damage."
+				],
+				[
+					"29",
+					"{@b Unnatural Selection} Triple damage to {@trait aberration||aberrations}, {@trait celestial||celestials}, {@trait fiend||fiends}, and {@trait monitor||monitors}. Double damage to all other creatures."
+				],
+				[
+					"30",
+					"{@b Hoarder's Wrath} Triple damage to {@trait dragon||dragons}. Double damage to all other creatures."
+				],
+				[
+					"31",
+					"{@b Slowed Down} The target is {@condition slowed} 2 for 1 round."
+				],
+				[
+					"32",
+					"{@b Doomed!} The target is {@condition slowed} 1 for 1 round, and is also {@condition doomed} 1."
+				],
+				[
+					"33",
+					"{@b Forceful Blast} The bomb or spell deals and additional {@damage 1d8} force damage."
+				],
+				[
+					"34",
+					"{@b Terrifying Display} The target is {@condition frightened} 3."
+				],
+				[
+					"35",
+					"{@b Returning Spell} If a spell attack, the spell or spell slot is not expended."
+				],
+				[
+					"36",
+					"{@b Call of the Wild} Triple damage to {@trait animal||animals}, {@trait beast||beasts}, and {@trait fey||fey}. Double damage to all other creatures."
+				],
+				[
+					"37",
+					"{@b Corrosive} If this is an {@trait acid} bomb or spell, the target takes triple damage and {@damage 1d6} {@condition persistent damage||persistent acid damage}. Any other bomb or spell deals double damage."
+				],
+				[
+					"38",
+					"{@b Magical Glow} The target glows for 1 minute with the effect of a {@spell faerie fire} spell."
+				],
+				[
+					"39",
+					"{@b Draining Strike} The target loses one random prepared spell or spell slot, as determined by the GM."
+				],
+				[
+					"40",
+					"{@b Combustion} If this is a {@trait fire} bomb or spell, the target takes triple damage and {@damage 1d6} {@condition persistent damage||persistent fire damage}. Any other bomb or spell deals double damage."
+				],
+				[
+					"41",
+					"{@b Maximum Effect} Don't roll for damage. You deal the maximum possible critical hit damage with this attack."
+				],
+				[
+					"42",
+					"{@b Intense Strike} The attack ignores all resistances."
+				],
+				[
+					"43",
+					"{@b Excruciating} The target is {@condition sickened} 3."
+				],
+				[
+					"44",
+					"{@b Intense Splash} The target takes normal damage, and all creatures adjacent to the target take half damage of the same type."
+				],
+				[
+					"45",
+					"{@b Planar Rift} If this is a spell, the target takes normal damage and must succeed at a Will save or be sent to a random plane (determined by the GM)."
+				],
+				[
+					"46",
+					"{@b Light Blast} The target is {@condition blinded} until the end of its next turn."
+				],
+				[
+					"47",
+					"{@b Mystical Thwart} The target can't activate magic items, cast spells, or use {@action Quick Alchemy} until the end of its next turn."
+				],
+				[
+					"48",
+					"{@b Light Blast} The target is {@condition blinded} until the end of its next turn."
+				],
+				[
+					"49",
+					"{@b Phased} The target becomes {@trait incorporeal} until the end of your next turn."
+				],
+				[
+					"50",
+					"{@b Time Vortex} If this is a spell, normal damage and the target vanished and reappears {@dice 1d4} rounds later. The target can use no actions, and any effects it has with durations do not pass while it's gone."
+				],
+				[
+					"51",
+					"{@b Energy Might} If the bomb or spell deals acid, cold, electricity, fire or sonic damage, it deals triple damage. Any other bomb or spells deals double damage."
+				],
+				[
+					"52",
+					"{@b Roaring Blast} The target is {@condition deafened} until healed."
+				],
+				[
+					"53",
+					"{@b Concussive Blast} The target is pushed up to 10 feet and knocked {@condition prone}."
+				],
+				[
+					"54",
+					"{@b Planar Rift} If this is a spell, the target takes normal damage and must succeed at a Will save or be sent to a random plane (determined by the GM)."
+				]
+			]
+		},
+		{
+			"name": "Critical Hit Deck: Slashing",
+			"source": "CHD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
+				],
+				[
+					"2",
+					"{@b Missing Ear} Normal damage. The target takes a -2 circumstance penalty to {@skill Perception} check and Charisma-based check except {@skill Intimidation} until healed."
+				],
+				[
+					"3",
+					"{@b Brow to Chin} The target takes a -2 status penalty to {@skill Perception} and ranged attack rolls until healer."
+				],
+				[
+					"4",
+					"{@b Gory} The target is {@condition sickened} 1."
+				],
+				[
+					"5",
+					"{@b Hamstring} Normal damage. The target is knocked {@condition prone}. The target is also {@condition clumsy} 2 until healed."
+				],
+				[
+					"6",
+					"{@b Ugly Wound} The target takes a -2 circumstance penalty to checks with all Charisma-based skills except {@skill Intimidation}."
+				],
+				[
+					"7",
+					"{@b Momentum} You gain a +2 circumstance bonus to all attack rolls until the end of your next turn."
+				],
+				[
+					"8",
+					"{@b Shattered Jaw} Until healed, the target is {@condition wounded} 1 and can't speak, eat, drink, or make attacks with its jaws."
+				],
+				[
+					"9",
+					"{@b Tangled} You can attempt to {@action Grapple} the target as a free action. This uses the same multiple attack penalty as your attack and doesn't count towards your multiple attack penalty."
+				],
+				[
+					"10",
+					"{@b Disembowel} Triple damage."
+				],
+				[
+					"11",
+					"{@b Weapon Strike} Deal normal damage to one of the target's weapons (applying Hardness normally)."
+				],
+				[
+					"12",
+					"{@b Missing Digits} Normal damage. The target loses {@dice 1d4} fingers on one hand and becomes {@condition clumsy} 1 until subject to {@spell regeneration} spell or similar effect."
+				],
+				[
+					"13",
+					"{@b Throat Slash} Normal damage. The target takes {@damage 1d8} {@condition persistent damage||persistent bleed damage}. The target can't talk, cast spells with a verbal component, or breathe while subject to this {@condition persistent damage||bleed damage}."
+				],
+				[
+					"14",
+					"{@b Stand Aside} Push the target 5 feet."
+				],
+				[
+					"15",
+					"{@b Overhand Chop} {@damage 1d8} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"16",
+					"{@b Cut Straps} The target's armor check penalty doubles until the armor is {@action repair||Repaired} (DC 15)."
+				],
+				[
+					"17",
+					"{@b Knockback} Push the target up to 10 feet."
+				],
+				[
+					"18",
+					"{@b Severed Tendon} Until healed, the target is {@condition clumsy} 1 and takes a -5-foot status penalty to its land Speed."
+				],
+				[
+					"19",
+					"{@b That'll Leave a Mark!} Normal damage. The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"20",
+					"{@b Fingertipped} Normal damage. Until healed, the target is {@condition clumsy} 1 and can't use one of its hands (chosen randomly by the GM)."
+				],
+				[
+					"21",
+					"{@b Rupture Abdominal Cavity} Triple damage. The target is {@condition fatigued}."
+				],
+				[
+					"22",
+					"{@b Pain and Simple} Triple damage."
+				],
+				[
+					"23",
+					"{@b Care Your Initials} Normal damage. The target is so humiliated it can do nothing but attack you. At the end of each of its turns, it can attempt a Will save to end this effect."
+				],
+				[
+					"24",
+					"{@b Lean into the Blow} Triple damage. You drop your weapon."
+				],
+				[
+					"25",
+					"{@b Hack and Slash} Triple damage. The target is {@condition flat-flooted} until the end of its next turn."
+				],
+				[
+					"26",
+					"{@b Severed Spine} The target must succeed at a Fortitude save or be {@condition paralyzed} until healed."
+				],
+				[
+					"27",
+					"{@b Long Gash} Normal damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. The DC of the flat check to remove this bleed damage is 5 higher than normal."
+				],
+				[
+					"28",
+					"{@b Broad Swipe} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"29",
+					"{@b Paper Cut} The target takes a -2 status penalty to attack rolls until the end of its next turn."
+				],
+				[
+					"30",
+					"{@b Wide Open} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"31",
+					"{@b Across the Eyes} Normal damage. The target is {@condition blinded} until healed."
+				],
+				[
+					"32",
+					"{@b From Chops to Groin} Triple damage. The target must succeed at a Fortitude save or die."
+				],
+				[
+					"33",
+					"{@b Never Slice} The target is {@condition slowed} 2 for 1 round."
+				],
+				[
+					"34",
+					"{@b Leg Swipe} The target is knocked {@condition prone}."
+				],
+				[
+					"35",
+					"{@b Decapitation} Triple damage. The target must succeed at a Fortitude save or die."
+				],
+				[
+					"36",
+					"{@b Lip Cut} The target must succeed at a DC 5 flat check to cast spells with a verbal component until healed."
+				],
+				[
+					"37",
+					"{@b Flay} Normal damage. The target is {@condition enfeebled} 3 until healed."
+				],
+				[
+					"38",
+					"{@b Flat-Blade Thwack} Triple damage. You can deal bludgeoning damage instead of slashing damage."
+				],
+				[
+					"39",
+					"{@b Armor Damage} The target's armor also takes the damage (applying the armor's Hardness normally)."
+				],
+				[
+					"40",
+					"{@b Sliced Hand} Normal damage. Until healed, the target is {@condition enfeebled} 1, {@condition clumsy} 1, and can't used one of its hands (determined randomly by the GM)."
+				],
+				[
+					"41",
+					"{@b Swing Through} Make an additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
+				],
+				[
+					"42",
+					"{@b Muscle Wound} The target is {@condition enfeebled} 2 until healed."
+				],
+				[
+					"43",
+					"{@b Terrible Cut} Triple damage."
+				],
+				[
+					"44",
+					"{@b Gut Slash} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage} and any creature it {@ability swallow whole|b1|Swallows Whole} is immediately released."
+				],
+				[
+					"45",
+					"{@b Bad Parry} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
+				],
+				[
+					"46",
+					"{@b Sapping Slash} The target is {@condition fatigued}."
+				],
+				[
+					"47",
+					"{@b Brow Cut} Normal damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. Until the bleed ends, all creatures are {@condition concealed} to the target."
+				],
+				[
+					"48",
+					"{@b Sapping Slash} The target is {@condition fatigued}."
+				],
+				[
+					"49",
+					"{@b Parrying Strike} Gain a +2 circumstance bonus to AC until the end of your next turn."
+				],
+				[
+					"50",
+					"{@b Spun Around} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"51",
+					"{@b Wing Tear} The target loses any fly Speed until healed."
+				],
+				[
+					"52",
+					"{@b Bewildering Display} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"53",
+					"{@b Delayed Wound} Normal damage. The target takes the same amount of damage at the end of its next two turns."
+				],
+				[
+					"54",
+					"{@b Bad Parry} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
+				]
+			]
+		},
+		{
+			"name": "Critical Hit Deck: Piercing",
+			"source": "CHD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Forearm Piercing} The target drops one weapon it's holding (chosen randomly by the GM)."
+				],
+				[
+					"2",
+					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
+				],
+				[
+					"3",
+					"{@b Tongue Piercing} The target must succeed at a DC 5 flat check to cast spells with the verbal component until healed."
+				],
+				[
+					"4",
+					"{@b Momentum} You gain a +2 circumstance bonus to all attack rolls until the end of your next turn."
+				],
+				[
+					"5",
+					"{@b Shoulder Wound} Until healed, the target is {@condition clumsy} 1 and {@condition enfeebled} 2."
+				],
+				[
+					"6",
+					"{@b Calf Jab} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to land Speed."
+				],
+				[
+					"7",
+					"{@b Skewered} Triple damage. The target is {@condition slowed} 1 for 1 round."
+				],
+				[
+					"8",
+					"{@b Send 'em Reeling} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"9",
+					"{@b Blowback} The target is knocked {@condition prone}."
+				],
+				[
+					"10",
+					"{@b Pinhole} The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target is healed."
+				],
+				[
+					"11",
+					"{@b Two in a Row} Deal normal damage to an additional target adjacent to the original target."
+				],
+				[
+					"12",
+					"{@b Stinger} Normal damage. The target is {@condition sickened} 3."
+				],
+				[
+					"13",
+					"{@b Pierced} The target is {@condition slowed} 1 until the end of its next turn."
+				],
+				[
+					"14",
+					"{@b Right in the Ear} Normal damage. The target is {@condition deafened} until healed."
+				],
+				[
+					"15",
+					"{@b Sucking Chest Wound} The target is {@condition fatigued}."
+				],
+				[
+					"16",
+					"{@b Pinned Arm} As the {@group bow||bow critical specialization effect}, and the target can't use one of its arms until freed. If using a melee weapon, you must drop it to gain this effect."
+				],
+				[
+					"17",
+					"{@b Ventilated} Triple damage."
+				],
+				[
+					"18",
+					"{@b Guarded Strike} Gain +2 circumstance bonus to AC until the end of your next turn."
+				],
+				[
+					"19",
+					"{@b Painful Poke} The target is {@condition stunned} 1."
+				],
+				[
+					"20",
+					"{@b Kidney Piercing} The target is {@condition sickened} 2."
+				],
+				[
+					"21",
+					"{@b Never Cluster} Normal damage. The target is {@condition stunned} 2."
+				],
+				[
+					"22",
+					"{@b Punctured Lung} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing."
+				],
+				[
+					"23",
+					"{@b Nicked an Artery} Normal damage. {@b Crit Effect:} The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"24",
+					"{@b Muscle Severed} Normal damage. Until healed, the target is {@condition clumsy} 3 and {@condition enfeebled} 3."
+				],
+				[
+					"25",
+					"{@b Chipped Bone} The target is {@condition clumsy} 1 until healed."
+				],
+				[
+					"26",
+					"{@b Lodged in the Bone} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"27",
+					"{@b Pierced Elbow} The target drops one item it is holding (determined randomly by the GM)."
+				],
+				[
+					"28",
+					"{@b hand Wound} Until healed, the target is {@condition clumsy} 2 and can't use one of its hands (determined randomly by the GM)."
+				],
+				[
+					"29",
+					"{@b Overreaction} Normal damage. The target triggers reactions as if it just used a {@trait move} action. It is also {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"30",
+					"{@b Clean Through} Triple damage."
+				],
+				[
+					"31",
+					"{@b Cheek Pierced} The target must succeed at a DC 5 flat check to cast spells with a verbal component until healed."
+				],
+				[
+					"32",
+					"{@b Head Shot} Triple damage. The target must succeed at a Fortitude save or die."
+				],
+				[
+					"33",
+					"{@b Spinal Tap} Normal damage. The target is {@condition sickened} 3."
+				],
+				[
+					"34",
+					"{@b Heart Shot} Triple damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"35",
+					"{@b Nailed in Place} As the {@group bow||bow critical specialization} effect. If this is a melee weapon, you must drop the weapon to gain this effect. If this attack already has that effect, the {@skill Athletics} check to pull free is DC 20 instead of DC 10."
+				],
+				[
+					"36",
+					"{@b Javelin Catcher} Triple damage if the attack was ranged or {@trait thrown} attack. Double damage for all other attacks."
+				],
+				[
+					"37",
+					"{@b Infection} The target must succeed at a Fortitude save or contract {@disease filth fever|B1}."
+				],
+				[
+					"38",
+					"{@b Eye patch for you} Triple damage. The target is {@condition dazzled} until healed."
+				],
+				[
+					"39",
+					"{@b Knockback} The target is pushed 10 feet."
+				],
+				[
+					"40",
+					"{@b Spun Around} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"41",
+					"{@b Grazing Hit} Normal damage. The target is {@condition stunned} 3."
+				],
+				[
+					"42",
+					"{@b Penetrating Wound} The attack ignores all resistances."
+				],
+				[
+					"43",
+					"{@b Gusher} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"44",
+					"{@b Deep Hurting} The target is {@condition fatigued}."
+				],
+				[
+					"45",
+					"{@b Hobbled} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
+				],
+				[
+					"46",
+					"{@b Perfect strike} Triple damage."
+				],
+				[
+					"47",
+					"{@b Deep Wound} The target is {@condition sickened} 3."
+				],
+				[
+					"48",
+					"{@b Perfect strike} Triple damage."
+				],
+				[
+					"49",
+					"{@b Tenacious Wound} Normal damage. The target can't heal this damage until it has rested at least 8 hours."
+				],
+				[
+					"50",
+					"{@b Leg Wound} The target takes a -5-foot status penalty to its land Speed until healed."
+				],
+				[
+					"51",
+					"{@b Organ Scramble} Triple damage. The target is {@condition fatigued}."
+				],
+				[
+					"52",
+					"{@b Bicep Wound} The target is {@condition enfeebled} 1 until healed."
+				],
+				[
+					"53",
+					"{@b Ragged Wound} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"54",
+					"{@b Hobbled} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
+				]
+			]
+		},
+		{
+			"name": "Critical Hit Deck: Bludgeoning",
+			"source": "CHD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Crunch} The target is {@condition sickened} 3."
+				],
+				[
+					"2",
+					"{@b Where Am I?} Normal damage. The target is {@condition stunned} 2."
+				],
+				[
+					"3",
+					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an {@trait attack} action against the target."
+				],
+				[
+					"4",
+					"{@b Cracked Rib} The target is {@condition fatigued}."
+				],
+				[
+					"5",
+					"{@b Feeble Parry} The target drops one weapon it's wielding determined by the GM."
+				],
+				[
+					"6",
+					"{@b Cracked Knee} Until healed, the target is {@condition clumsy} 2 and takes a -5-foot status penalty to land Speed."
+				],
+				[
+					"7",
+					"{@b Bell Ringer} The target is {@condition sickened} 2, and it is {@condition stupefied} 2 until it is no longer {@condition sickened}."
+				],
+				[
+					"8",
+					"{@b Split Open} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"9",
+					"{@b Momentum} You gain a +2 circumstance bonus to all attack rolls until the end of your next turn."
+				],
+				[
+					"10",
+					"{@b I See Stars} Normal damage. The target is {@condition dazzled} until healed."
+				],
+				[
+					"11",
+					"{@b Broken Nose} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"12",
+					"{@b Crushed Toe} Normal damage. The target is {@condition clumsy} 2 and takes a -10-foot status penalty to land Speed. Both effects last until healed."
+				],
+				[
+					"13",
+					"{@b Crumpling Blow} The target is knocked {@condition prone}."
+				],
+				[
+					"14",
+					"{@b Shattered Hand} Normal damage. Until healed, the target is {@condition clumsy} 2 and {@condition enfeebled} 2, and it can't use one of its hands (chosen randomly by the GM)."
+				],
+				[
+					"15",
+					"{@b Numbing Blow} Normal damage. The target is {@condition clumsy} 1 for 1 minute and must succeed at a Reflex save or drop one item it holds at random."
+				],
+				[
+					"16",
+					"{@b Two for One} Deal normal damage to one target adjacent to the original target."
+				],
+				[
+					"17",
+					"{@b And Stay Down} Normal damage. The target is knocked {@condition prone} and {@condition stunned} 2."
+				],
+				[
+					"18",
+					"{@b Rattled} Normal damage. The target is {@condition confused} for 1 round."
+				],
+				[
+					"19",
+					"{@b Nighty Night} Normal damage. The target falls {@condition unconscious} and can't wake up until the of its next turn."
+				],
+				[
+					"20",
+					"{@b Brained} The target is {@condition stunned} 1."
+				],
+				[
+					"21",
+					"{@b Collapsed Lung} Normal damage. Until healed, t he target is {@condition enfeebled} 2 and {@condition fatigued}."
+				],
+				[
+					"22",
+					"{@b Bony Masher} Normal damage. Either the target is {@condition clumsy} 2 and takes a -10-foot status penalty to land Speed or is {@condition clumsy} 2 and can't use one of its arms (your choice). Either effect last until healed."
+				],
+				[
+					"23",
+					"{@b Overwhelming Smash} Triple damage."
+				],
+				[
+					"24",
+					"{@b Ruptured Spleen} Normal damage. The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target has been subject to {@trait magical} healing."
+				],
+				[
+					"25",
+					"{@b Off Balance} Normal damage. The target triggers reactions as if it just used a {@trait move} action. It is also {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"26",
+					"{@b Crushed Intestines} Normal damage. The target is {@condition wounded} 2 and {@condition enfeebled} 2 until it is no longer wounded."
+				],
+				[
+					"27",
+					"{@b Crushed Trachea} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing. It can't speak while it is {@quickref suffocating|CRB|3|Drowning and Suffocating}."
+				],
+				[
+					"28",
+					"{@b Skull Crush} The target is {@condition stupefied} 3 until healed."
+				],
+				[
+					"29",
+					"{@b Caved Skull} Triple damage. The target must succeed at a Fortitude save or die."
+				],
+				[
+					"30",
+					"{@b To Your Thinky Bits} The target is {@condition stupefied} 2 until healed."
+				],
+				[
+					"31",
+					"{@b Dazing Thud} The target is {@condition stunned} 1."
+				],
+				[
+					"32",
+					"{@b Clocked!} Triple damage. The target is knocked {@condition prone}."
+				],
+				[
+					"33",
+					"{@b Broken Ribs} Normal damage. The target is {@condition slowed} 1 until healed."
+				],
+				[
+					"34",
+					"{@b Staggering Blow} The target is {@condition stunned} 2."
+				],
+				[
+					"35",
+					"{@b Thunder Strike} The target is {@condition deafened} until healed."
+				],
+				[
+					"36",
+					"{@b Box the Ears} The target is {@condition deafened} until healed."
+				],
+				[
+					"37",
+					"{@b Concussion} Normal damage. The target is {@condition confused} for 1 minute and {@condition stupefied} 2 until healed."
+				],
+				[
+					"38",
+					"{@b Armor Dent} Normal damage. Deal the same amount of damage to the target's armor, ignoring that armor's Hardness."
+				],
+				[
+					"39",
+					"{@b Soul-Crushing Blow} The target is {@condition doomed} 1 and is {@condition stupefied} 1 for as long as it is {@condition doomed}."
+				],
+				[
+					"40",
+					"{@b Breathless} The target is {@condition fatigued}."
+				],
+				[
+					"41",
+					"{@b Broken Leg} The target takes a -15-foot status penalty to its land Speed until healed."
+				],
+				[
+					"42",
+					"{@b Shield Smack} The target must succeed at a Reflex save or drop a shield it's holding."
+				],
+				[
+					"43",
+					"{@b My Teef!} The target must succeed at a DC 5 flat check to cast spells with the verbal component until healed."
+				],
+				[
+					"44",
+					"{@b Knockback} The target is pushed {@dice 1d4x5} feet away."
+				],
+				[
+					"45",
+					"{@b Low Blow} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
+				],
+				[
+					"46",
+					"{@b Busted Shin} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
+				],
+				[
+					"47",
+					"{@b Back Breaker} Until healed, the target is {@condition clumsy} 2 and {@condition enfeebled} 2."
+				],
+				[
+					"48",
+					"{@b Busted Shin} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
+				],
+				[
+					"49",
+					"{@b Solid Blow} Triple damage."
+				],
+				[
+					"50",
+					"{@b Tiring Blow} The target is {@condition fatigued}."
+				],
+				[
+					"51",
+					"{@b Foot Smash} The target is {@condition flat-footed} until the end of its next turn."
+				],
+				[
+					"52",
+					"{@b Lights Out} The target is {@condition blinded} until the end of its next turn."
+				],
+				[
+					"53",
+					"{@b Roundhouse} Make one additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
+				],
+				[
+					"54",
+					"{@b Low Blow} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
+				]
+			]
+		},
+		{
+			"name": "Critical Fumble Deck: Spell",
+			"source": "CFD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b How Did That Happen?} You call forth a mist with the effects of {@spell stinking cloud} centered on a corner of your space (determined by the GM)."
+				],
+				[
+					"2",
+					"{@b Power Down} Until healed, you are {@condition stupefied} 2."
+				],
+				[
+					"3",
+					"{@b Exploding Skull} You must attempt a Fortitude save. If you succeed, you take {@damage 3d6} mental damage. If you fail, your head explodes and you die."
+				],
+				[
+					"4",
+					"{@b Mental Slip} You are {@condition controlled} by the target until the end of your next turn."
+				],
+				[
+					"5",
+					"{@b Blastoff} You must succeed at a Will saving throw or be thrown {@dice 1d6x5} feet into the air (or in a random direction determined by the GM if you are flying)."
+				],
+				[
+					"6",
+					"{@b Strange Transference} Lost one prepared spell or spell slot, determined randomly by the GM. Your target can {@action cast a spell||Cast this Spell} on its next turn even if they can't cast spells, using your level, spell attack modifier, and spell DC."
+				],
+				[
+					"7",
+					"{@b Mental Backlash} Until healed, you are {@condition stupefied} 3."
+				],
+				[
+					"8",
+					"{@b Fragmented Magic} Your target gains the effect of a {@spell mirror image} spell."
+				],
+				[
+					"9",
+					"{@b Power Transfer} The highest-level spell effect currently affecting you is transferred to your target."
+				],
+				[
+					"10",
+					"{@b Power Drain} You lose one prepared spell or spell slot (determined randomly by the GM)."
+				],
+				[
+					"11",
+					"{@b Nosebleed} You take 1 {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"12",
+					"{@b Magic Vacuum} The effects of all beneficial spells affecting you end immediately."
+				],
+				[
+					"13",
+					"{@b Magic Fatigue} You can't cast any spells until the end of your next turn."
+				],
+				[
+					"14",
+					"{@b Electrical Feedback} You take {@damage 2d6} electricity damage."
+				],
+				[
+					"15",
+					"{@b Beastly Rift} Your spell becomes a {@spell summon animal} spell of the same level. The animal attacks you."
+				],
+				[
+					"16",
+					"{@b Reflection} The spell hits you instead of the target."
+				],
+				[
+					"17",
+					"{@b Spontaneous Combustion} You take {@damage 2d6} fire damage."
+				],
+				[
+					"18",
+					"{@b Critical Backlash} You critically hit yourself instead of the target."
+				],
+				[
+					"19",
+					"{@b Acidic Backlash} You take {@damage 2d6} acid damage."
+				],
+				[
+					"20",
+					"{@b Bleeding Eyes} You take {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"21",
+					"{@b Tangled in Your Gear} You are {@condition encumbered} until you spend 2 {@action Interact} actions to free your self."
+				],
+				[
+					"22",
+					"{@b Distance Rift} You are teleported to the nearest space adjacent to your spell's target."
+				],
+				[
+					"23",
+					"{@b Mind Drain} Until healed, you are {@condition stupefied} 1."
+				],
+				[
+					"24",
+					"{@b Vertigo} You are {@condition sickened} 2."
+				],
+				[
+					"25",
+					"{@b Apprentice Move} Reroll the attack roll, targeting the creature closest to the target (excluding yourself)."
+				],
+				[
+					"26",
+					"{@b Not Me, You Fool!} You hit the ally nearest to the target."
+				],
+				[
+					"27",
+					"{@b Tiring Spell} You are {@condition fatigued}."
+				],
+				[
+					"28",
+					"{@b Unexpected Blast} Your spell affects all targets within 30 feet of you. You are immune to this effect."
+				],
+				[
+					"29",
+					"{@b You made 'em Stronger} The target gains a +2 status bonus to attack rolls until the end of its next turn."
+				],
+				[
+					"30",
+					"{@b Drawing a Blank} Until healed, you are {@condition stupefied} 1."
+				],
+				[
+					"31",
+					"{@b Spell Shield} The target gains a +2 status bonus to saving throws against spells for 1 minute."
+				],
+				[
+					"32",
+					"{@b Left Reeling} You are {@condition stunned} 1."
+				],
+				[
+					"33",
+					"{@b Caster's Block} You can't cast this spell again at any level until you rest and make your daily preparations."
+				],
+				[
+					"34",
+					"{@b You Made 'em Bigger} The target increases in size, with the effects of a 2nd level {@spell enlarge} spell."
+				],
+				[
+					"35",
+					"{@b Side Effect} You are {@condition sickened} 1. You are also {@condition stupefied} 2 until healed."
+				],
+				[
+					"36",
+					"{@b Weakened} You take -2 circumstance penalty to spell attack rolls and spell DC's until the end of your next turn."
+				],
+				[
+					"37",
+					"{@b Spell Rush} You are {@condition stupefied} 1 until healed."
+				],
+				[
+					"38",
+					"{@b The Magic is Gone} You take a -1 circumstance penalty to attack rolls until you score a critical hit."
+				],
+				[
+					"39",
+					"{@b Can You Hear Me Now?} Until healed, you are {@condition deafened}."
+				],
+				[
+					"40",
+					"{@b Error!} You deal the spell's normal damage to yourself instead of the target."
+				],
+				[
+					"41",
+					"{@b Why Me?} You provoke reactions as if you used a {@trait move} action."
+				],
+				[
+					"42",
+					"{@b Poor Trade} You hit, but you lose a prepared spell or spell slot of the highest level available (you choose the spell)."
+				],
+				[
+					"43",
+					"{@b You Made 'em Tougher} The target gains resistance 5 to all damage until the start of its next turn."
+				],
+				[
+					"44",
+					"{@b You Made 'em Faster} The target is {@condition quickened} for 2 rounds."
+				],
+				[
+					"45",
+					"{@b Jumbled Components} You are {@condition slowed} 2 until the end of your next turn."
+				],
+				[
+					"46",
+					"{@b Clatto Verata Necktie} You critically hit your nearest ally."
+				],
+				[
+					"47",
+					"{@b Cursed} You are {@condition doomed} 1."
+				],
+				[
+					"48",
+					"{@b Magical Smackdown} You automatically fail (but do not critically fail) your next saving throw."
+				],
+				[
+					"49",
+					"{@b Wild Magic} Roll twice on the {@item rod of wonder} table. You are the target of those effects."
+				],
+				[
+					"50",
+					"{@b Draining Magic} You are {@condition drained} 1."
+				],
+				[
+					"51",
+					"{@b Everything to Fear} You are {@condition frightened} 3."
+				],
+				[
+					"52",
+					"{@b Now I See You...} Your target becomes {@condition invisible} until the end of its next turn or uses a hostile action."
+				],
+				[
+					"53",
+					"{@b It's So Sparkly!} You are {@condition blinded} until the end of your next turn."
+				],
+				[
+					"54",
+					"{@b Wild Magic} Roll twice on the {@item rod of wonder} table. You are the target of those effects."
+				]
+			]
+		},
+		{
+			"name": "Critical Fumble Deck: Unarmed",
+			"source": "CFD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Not the Weak Point} You take {@damage 1d6} {@condition persistent damage||persistent bleed damage} and can't use this attack until the end of your next turn."
+				],
+				[
+					"2",
+					"{@b Overthink It} Your target gains a +2 circumstance bonus to AC against attacks you make against it until the end of your next turn."
+				],
+				[
+					"3",
+					"{@b Bad Jam} You are {@condition clumsy} 1 and {@condition enfeebled} 2."
+				],
+				[
+					"4",
+					"{@b Pinched Nerve} Until healed, you take a -10-foot circumstance penalty to land Speed and are {@condition clumsy} 1."
+				],
+				[
+					"5",
+					"{@b Eye Strain} You are {@condition dazzled} until the end of your next turn."
+				],
+				[
+					"6",
+					"{@b That Tastes Awful!} If this was a jaws attack (or similar), you are {@condition sickened} 3."
+				],
+				[
+					"7",
+					"{@b Punctured Foot} You take {@damage 1d4} {@condition persistent damage||persistent bleed damage}. Until this effect ends, you take a -10-foot circumstance penalty to your land Speed."
+				],
+				[
+					"8",
+					"{@b Broken Tooth} Until healed, you take a -2 circumstance penalty to attack rolls."
+				],
+				[
+					"9",
+					"{@b Brutal Collision} Attempt a Fortitude saving throw. If you succeed, you're {@condition stunned} 1. If you fail, you're {@condition stunned} 2."
+				],
+				[
+					"10",
+					"{@b Something's Broken} You take {@damage 1d4} bludgeoning damage, and you can't use this attack until healed."
+				],
+				[
+					"11",
+					"{@b Bruised Ego} You can't attack another creature until the target is knocked out or the end of your next turn."
+				],
+				[
+					"12",
+					"{@b Hangnail} If you attacked with a claw or fist, you can't use that attack until the end of your next turn."
+				],
+				[
+					"13",
+					"{@b Torn Muscle} Until healed, you are {@condition enfeebled} 1."
+				],
+				[
+					"14",
+					"{@b Hit the Wall} You are {@condition fatigued}."
+				],
+				[
+					"15",
+					"{@b Frustration} You take a -2 circumstance penalty to attack rolls until the end of your next turn."
+				],
+				[
+					"16",
+					"{@b Overextended} You trigger reactions as if you had used a {@trait move} action."
+				],
+				[
+					"17",
+					"{@b Bit Your Tongue!} You take 1 {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"18",
+					"{@b Upset Stomach} You are {@condition sickened} 2."
+				],
+				[
+					"19",
+					"{@b Tiring Attack} You are {@condition fatigued}."
+				],
+				[
+					"20",
+					"{@b Awkward Attack} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"21",
+					"{@b Tripped} You fall {@condition prone}."
+				],
+				[
+					"22",
+					"{@b Fist Meet Face} You critically hit yourself with the attack."
+				],
+				[
+					"23",
+					"{@b Out of Position} You can't use this attack until the end of your next turn."
+				],
+				[
+					"24",
+					"{@b Bleeding Fist} You take {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"25",
+					"{@b Twisted Up} You are {@condition encumbered} until you spend 2 {@action Interact} actions to free yourself."
+				],
+				[
+					"26",
+					"{@b Stop Hitting Yourself} You hit yourself instead of the target."
+				],
+				[
+					"27",
+					"{@b Just a Taste} You hit an ally adjacent to you or the target."
+				],
+				[
+					"28",
+					"{@b Battered} Until healed, you take a -2 circumstance penalty to checks and saving throws."
+				],
+				[
+					"29",
+					"{@b Got Too Close} This attack grants and triggers a {@action Grapple} or {@action Grab} as a reaction by your enemy."
+				],
+				[
+					"30",
+					"{@b Can't Find an Opening} You can't use this attack until the end of your next turn."
+				],
+				[
+					"31",
+					"{@b Off Balance} You are {@condition slowed} 2 until the end of your next turn."
+				],
+				[
+					"32",
+					"{@b Caught Your Attack} This attack grants and triggers a {@action Trip} or {@action Shove} as a reaction by your enemy."
+				],
+				[
+					"33",
+					"{@b Bad Headbutt} You are {@condition stunned} 1."
+				],
+				[
+					"34",
+					"{@b Bone Bruise} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
+				],
+				[
+					"35",
+					"{@b Overexertion} You are {@condition fatigued}."
+				],
+				[
+					"36",
+					"{@b Sprain} Until healed, you are {@condition clumsy} 2."
+				],
+				[
+					"37",
+					"{@b Sneeze} You are {@condition slowed} 1 until the end of your next turn."
+				],
+				[
+					"38",
+					"{@b Ferocious Fumble} You critically hit an ally within your reach (determined randomly by the GM)."
+				],
+				[
+					"39",
+					"{@b Head, Meet Wall} You are {@condition stunned} 1."
+				],
+				[
+					"40",
+					"{@b Great Roar} Until healed, you are {@condition deafened}."
+				],
+				[
+					"41",
+					"{@b Pins and Needles} You are {@condition sickened} 3."
+				],
+				[
+					"42",
+					"{@b It Bit Your Fist} The target deals jaws damage to you."
+				],
+				[
+					"43",
+					"{@b Hard-Edged Adversary} You take {@damage 2d6} piercing or slashing damage (determined by the GM)."
+				],
+				[
+					"44",
+					"{@b Smash the Floor} You kick up a cloud of dust, becoming {@condition blinded} until the end of your next turn."
+				],
+				[
+					"45",
+					"{@b Whirlwind of Shame} You hit every creature adjacent to you except for the target."
+				],
+				[
+					"46",
+					"{@b Ingrown Nail} You take a -1 circumstance penalty to attack rolls until your score a critical hit."
+				],
+				[
+					"47",
+					"{@b Stinging Failure} Until healed, you take a -2 circumstance penalty to attack rolls made with this attack."
+				],
+				[
+					"48",
+					"{@b Don't Pick at It} You become {@condition wounded 1} or your {@condition wounded} value increases by 1."
+				],
+				[
+					"49",
+					"{@b Head First!} You fall {@condition unconscious} until you wake up or the end of your next turn."
+				],
+				[
+					"50",
+					"{@b Whiff} You hit yourself instead of the target."
+				],
+				[
+					"51",
+					"{@b Jam a Finger} You the the target for the minimum amount of damage you can deal with the attack. You take the attack's normal damage."
+				],
+				[
+					"52",
+					"{@b Winds of Change} You can't attack the same target again until the end of your next turn."
+				],
+				[
+					"53",
+					"{@b Unintentional Move} You are moved 10 feet in a random direction (determined by the GM). This movement triggers reactions."
+				],
+				[
+					"54",
+					"{@b Head First!} You fall {@condition unconscious} until you wake up or the end of your next turn."
+				]
+			]
+		},
+		{
+			"name": "Critical Fumble Deck: Ranged",
+			"source": "CFD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Misjudged the Distance} Until the end of your next turn, all your range increment penalties are doubled."
+				],
+				[
+					"2",
+					"{@b Phantom Wind} You take a -2 circumstance penalty to ranged attacks until the end of your next turn."
+				],
+				[
+					"3",
+					"{@b Spraining Shot} Until healed, you take a -10-foot circumstance penalty to your land Speed and are {@condition clumsy} 1."
+				],
+				[
+					"4",
+					"{@b Don't Hit Me!} Until the end of your next turn, each time you miss with a ranged attack targeting enemy adjacent to any of your allies, you hit one of those adjacent allies instead (determined randomly by the GM)."
+				],
+				[
+					"5",
+					"{@b Huh?} You are {@condition confused}."
+				],
+				[
+					"6",
+					"{@b Overcompensate} Cover provides a +4 circumstance bonus to AC against your ranged attacks for 1 minute."
+				],
+				[
+					"7",
+					"{@b Recoil} You are pushed 5 feet backwards and fall {@condition prone}."
+				],
+				[
+					"8",
+					"{@b Seeing Double} You are {@condition dazzled} until the end of your next turn."
+				],
+				[
+					"9",
+					"{@b Aim Carefully Next Time} Until the end of your next turn, your attacks require and extra action to use."
+				],
+				[
+					"10",
+					"{@b Friendly Fire} You the ally nearest to the target."
+				],
+				[
+					"11",
+					"{@b Backfire} You hit yourself instead of the target."
+				],
+				[
+					"12",
+					"{@b Mix it Up} You can't make ranged attacks until the end of your next turn."
+				],
+				[
+					"13",
+					"{@b Snapped String} If the attack used a weapon in the {@group bow} group, the string snaps, requiring 3 {@action Interact} actions to fix."
+				],
+				[
+					"14",
+					"{@b Notched Fingers} You take {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"15",
+					"{@b My Spleeny Bits!} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
+				],
+				[
+					"16",
+					"{@b Head Rush} You are {@condition sickened} 2."
+				],
+				[
+					"17",
+					"{@b Awkward Attack} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"18",
+					"{@b Aching Back} You are {@condition fatigued}."
+				],
+				[
+					"19",
+					"{@b Shot Your Eye Out} You critically hit yourself instead of the target."
+				],
+				[
+					"20",
+					"{@b Errant Aim} Reroll the attack roll, targeting the creature closest to the target (excluding yourself)."
+				],
+				[
+					"21",
+					"{@b Wide Open} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"22",
+					"{@b Cracked} The ranged weapon (not the ammunition) you are using takes {@damage 1d6} damage, ignoring Hardness."
+				],
+				[
+					"23",
+					"{@b Whoops!} You fall {@condition prone}."
+				],
+				[
+					"24",
+					"{@b Sprain} Until healed, you are {@condition clumsy} 2."
+				],
+				[
+					"25",
+					"{@b Nicked} You take 1 {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"26",
+					"{@b Klutz} You drop the weapon you used."
+				],
+				[
+					"27",
+					"{@b Spilled Ammo} The ammunition from the weapon you're using falls from its container onto the ground. You can spend 1 {@action Interact} action to pick up one piece of ammunition spilled this way."
+				],
+				[
+					"28",
+					"{@b Lost Grip} You are {@condition slowed} 2 until the end of your next turn."
+				],
+				[
+					"29",
+					"{@b Wrong Weapon} If you made a {@trait thrown} attack, you instead throw an object from your gear (determined randomly by the GM)."
+				],
+				[
+					"30",
+					"{@b Kickback Like a Mule} You fall {@condition prone}."
+				],
+				[
+					"31",
+					"{@b Archer's Elbow} Until healed, you take a -2 circumstance penalty to ranged attacks."
+				],
+				[
+					"32",
+					"{@b Double Miss} If this attack uses ammunition, you use twice the amount of ammunition on this attack."
+				],
+				[
+					"33",
+					"{@b Not My Pony!} You hit the nearest animal companion, mount, or familiar."
+				],
+				[
+					"34",
+					"{@b Amazing Miss} You are {@condition stunned} 1."
+				],
+				[
+					"35",
+					"{@b Shot Your Foot} Until healed, you are {@condition clumsy} 2 and take a -5-foot circumstance penalty to your land speed."
+				],
+				[
+					"36",
+					"{@b Lost the Target} You take a -2 circumstance penalty to attack rolls until the end of your next turn."
+				],
+				[
+					"37",
+					"{@b Weapon Problem} If the attack used a projectile weapon, something on the weapon malfunctions, requiring you to spend 2 {@action Interact} actions to fix."
+				],
+				[
+					"38",
+					"{@b Lowered Guard} You provoke reactions as if you used a {@trait move} action."
+				],
+				[
+					"39",
+					"{@b In the Line of Fire} You critically hit your nearest ally."
+				],
+				[
+					"40",
+					"{@b Insecure} You take a -1 circumstance penalty to attacks rolls until you score a critical hit."
+				],
+				[
+					"41",
+					"{@b Close to the Ear} You are {@condition deafened} until the end of your next turn."
+				],
+				[
+					"42",
+					"{@b Bad Alignment} You take a -2 circumstance penalty to attacks using this weapon until the end of your next turn."
+				],
+				[
+					"43",
+					"{@b Everything You Got} You are {@condition fatigued}."
+				],
+				[
+					"44",
+					"{@b Broken} Your weapon's current Hit Points are reduced to its Broken Threshold. If already {@condition broken}, the weapon takes {@damage 3d6} damage, ignoring Hardness."
+				],
+				[
+					"45",
+					"{@b What Are the Odds?} If this is a {@trait thrown} weapon attack and the target can hold the weapon, the target snatches the weapon out of the air and wields it."
+				],
+				[
+					"46",
+					"{@b Oopsie!} You hit yourself instead of the target."
+				],
+				[
+					"47",
+					"{@b Torn Tendon} Until healed, you are {@condition clumsy} 2."
+				],
+				[
+					"48",
+					"{@b Overthrow} If the attack used a {@trait thrown} weapon, the weapon travels three times its range increment in a random direction (determined by the GM)."
+				],
+				[
+					"49",
+					"{@b Tunnel Vision} For 3 rounds, you gain a +1 circumstance bonus to attack rolls, but you are {@condition flat-footed}."
+				],
+				[
+					"50",
+					"{@b All Thumbs} Until healed, you are {@condition clumsy} 1."
+				],
+				[
+					"51",
+					"{@b Bull's Eye} Your attack ricochets and hits you near the eye. You are {@condition blinded} until the end of your next turn."
+				],
+				[
+					"52",
+					"{@b Pinch a Finger} You take {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"53",
+					"{@b So Much Blood} You are {@condition sickened} 3."
+				],
+				[
+					"54",
+					"{@b Tunnel Vision} For 3 rounds, you gain a +1 circumstance bonus to attack rolls, but you are {@condition flat-footed}."
+				]
+			]
+		},
+		{
+			"name": "Critical Fumble Deck: Melee",
+			"source": "CFD",
+			"page": 0,
+			"rollable": true,
+			"labelRowIdx": [
+				0
+			],
+			"colSizes": [
+				1,
+				9
+			],
+			"colStyles": [
+				"text-center",
+				"text-left"
+			],
+			"rows": [
+				[
+					"{@dice d54}",
+					"Effect"
+				],
+				[
+					"1",
+					"{@b Meant To Do That} You are moved 10 feet in a random direction (determined by the GM). This movement triggers reactions."
+				],
+				[
+					"2",
+					"{@b Wrong End} If you are using a slashing weapon, you take {@damage 1d6} slashing damage and 1 {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"3",
+					"{@b Bad Fall} You fall {@condition prone} and are {@condition slowed} 1 until the end of your next turn."
+				],
+				[
+					"4",
+					"{@b Wait, What?} You are {@condition confused}."
+				],
+				[
+					"5",
+					"{@b Bad Grip} You take a -2 circumstance penalty to attack rolls with this weapon until the end of your next turn."
+				],
+				[
+					"6",
+					"{@b Eat Dirt} You fall {@condition prone} and are {@condition blinded} until the end of your next turn."
+				],
+				[
+					"7",
+					"{@b Vibration} If you're using a bludgeoning weapon, you drop that weapon and become {@condition enfeebled} 2 until healed."
+				],
+				[
+					"8",
+					"{@b Who Was That?} You are {@condition slowed} 1 until the end of your next turn."
+				],
+				[
+					"9",
+					"{@b Attack the Darkness} Your enemies are {@condition concealed} from you until the end of your next turn."
+				],
+				[
+					"10",
+					"{@b Off Balance} You take a -2 circumstance penalty to attack rolls until the end of your next turn."
+				],
+				[
+					"11",
+					"{@b Slipped} You fall {@condition prone}."
+				],
+				[
+					"12",
+					"{@b Second Thoughts} You are {@condition sickened} 3."
+				],
+				[
+					"13",
+					"{@b Butterfingers} You drop the weapon you made the attack with."
+				],
+				[
+					"14",
+					"{@b Notched} Your weapon takes {@damage 1d6} damage, ignoring Hardness."
+				],
+				[
+					"15",
+					"{@b Broken Weapon} Your weapon's current Hit Point are reduced to its Broken Threshold. If already {@condition broken}, the weapon takes {@damage 3d6} damage, ignoring Hardness."
+				],
+				[
+					"16",
+					"{@b Fling} You drop the weapon you used for the attack. It lands {@dice 1d6x5} feet away from your in a random direction."
+				],
+				[
+					"17",
+					"{@b Pulled Muscle} Until healed, you are {@condition enfeebled} 2."
+				],
+				[
+					"18",
+					"{@b Overextended} You trigger reactions as if you had used a {@trait move} action."
+				],
+				[
+					"19",
+					"{@b Awkward Attack} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"20",
+					"{@b This Sword Is Heavy} You are {@condition fatigued}."
+				],
+				[
+					"21",
+					"{@b Backswing} You deal the attack's normal damage to yourself instead of the target."
+				],
+				[
+					"22",
+					"{@b Wide Open} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"23",
+					"{@b Strained} Until healed, you are {@condition clumsy} 2."
+				],
+				[
+					"24",
+					"{@b Too Much Stuff!} You get tangled in your gear and are {@condition encumbered} until you spend 2 {@action Interact} actions to free yourself."
+				],
+				[
+					"25",
+					"{@b Spinning Swing} You are {@condition sickened} 2."
+				],
+				[
+					"26",
+					"{@b I Told You It's Sharp!} You take {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"27",
+					"{@b Pin Prick} You take 1 {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"28",
+					"{@b Armor Smash} You deal the attack's normal damage to your armor, applying Hardness."
+				],
+				[
+					"29",
+					"{@b Catch Your Breath} You are {@condition slowed} 2 until the end of your next turn."
+				],
+				[
+					"30",
+					"{@b Grave Miscalculation} You critically hit yourself with the attack."
+				],
+				[
+					"31",
+					"{@b Stuck} Your weapon is lodged into a nearby surface or item. To free it, you must succeed at a DC 20 {@skill Athletics} check made as an {@action Interact} action."
+				],
+				[
+					"32",
+					"{@b Bent} Your weapon's current Hit Point are reduced to its Broken Threshold. if already {@condition broken}, the weapon takes {@damage 3d6} damage, ignoring Hardness."
+				],
+				[
+					"33",
+					"{@b Funny Bone} You drop one item you are holding (determined randomly by the GM)."
+				],
+				[
+					"34",
+					"{@b Weapon Tangle} You can't use this weapon to attack until the end of your next turn."
+				],
+				[
+					"35",
+					"{@b Bonk!} You are {@condition stunned} 2."
+				],
+				[
+					"36",
+					"{@b Sorry!} You hit and ally adjacent to your or an ally adjacent to the target."
+				],
+				[
+					"37",
+					"{@b Better to Give} You hit yourself instead of the target."
+				],
+				[
+					"38",
+					"{@b Rang Your Own Bell} Until healed, you are {@condition deafened}."
+				],
+				[
+					"39",
+					"{@b On the receiving End} You deal damage to yourself instead of the target."
+				],
+				[
+					"40",
+					"{@b Creeping Hesitation} You are {@condition flat-footed} until the end of your next turn."
+				],
+				[
+					"41",
+					"{@b All or Nothing} You take a -1 circumstance penalty to attack rolls until you score a critical hit."
+				],
+				[
+					"42",
+					"{@b Winded} You are {@condition fatigued}."
+				],
+				[
+					"43",
+					"{@b Shield Crash} You deal the attack's normal damage to your shield, applying Hardness."
+				],
+				[
+					"44",
+					"{@b Hand It Over} Unless you succeed at a Reflex saving throw, your target gains possessions of your weapon."
+				],
+				[
+					"45",
+					"{@b This Is Bad} You take {@damage 1d10} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"46",
+					"{@b Clipped Your Hand} You take {@damage 1d8} {@condition persistent damage||persistent bleed damage}."
+				],
+				[
+					"47",
+					"{@b Decision Paralysis} You are {@condition slowed} 1 until the end of your next turn."
+				],
+				[
+					"48",
+					"{@b Catastrophic Failure} You fall {@condition unconscious} until you awake up or the end of your next turn."
+				],
+				[
+					"49",
+					"{@b Pointy End Goes There} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
+				],
+				[
+					"50",
+					"{@b Broken Haft} Your weapon's current Hit Points are reduced to its Broken Threshold. If already {@condition broken}, the weapon takes {@damage 3d6} damage, ignoring Hardness. If your weapon is a {@trait reach} weapon, it loses {@trait reach}."
+				],
+				[
+					"51",
+					"{@b Fog of War} You are {@condition dazzled} until the end of your next turn."
+				],
+				[
+					"52",
+					"{@b Go for the Eyes} You are {@condition dazzled} until the end of your next turn."
+				],
+				[
+					"53",
+					"{@b Punt} Your weapon files {@dice 1d4x5} feet in a random direction (determined by the GM)."
+				],
+				[
+					"54",
+					"{@b Pointy End goes There} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
+				]
+			]
+		},
+		{
 			"name": "Experimental Metal Compositions",
 			"source": "OoA3",
 			"page": 17,
@@ -448,7 +2360,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "OoA0",
 			"page": 9,
 			"name": "Suggested Character Options",
@@ -749,7 +2660,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "DA",
 			"page": 103,
 			"name": "Ability Quirks",
@@ -814,7 +2724,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 103,
 			"name": "Animal Caretaking Gear Prices",
@@ -882,7 +2791,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 103,
 			"name": "Animal Prices",
@@ -1046,7 +2954,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 65,
 			"name": "Common Crimes and Punishments",
@@ -1197,7 +3104,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 17,
 			"name": "Housing Costs",
@@ -1351,7 +3257,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "DA",
 			"page": 103,
 			"name": "Ability Quirks",
@@ -1388,7 +3293,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 103,
 			"name": "Animal Caretaking Gear Prices",
@@ -1456,7 +3360,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 103,
 			"name": "Animal Prices",
@@ -1620,7 +3523,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 65,
 			"name": "Common Crimes and Punishments",
@@ -1771,7 +3673,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "LOTG",
 			"page": 17,
 			"name": "Housing Costs",
@@ -1925,7 +3826,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "SoM",
 			"page": 166,
 			"name": "Personal Staves",
@@ -2091,7 +3991,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "GMG",
 			"page": 25,
 			"name": "EARN INCOME TASKS",
@@ -2324,7 +4223,6 @@
 			]
 		},
 		{
-			"type": "table",
 			"source": "GMG",
 			"page": 25,
 			"name": "DOWNTIME EVENTS",

--- a/data/tables.json
+++ b/data/tables.json
@@ -262,7 +262,7 @@
 				],
 				[
 					"1",
-					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
+					"{@b Surprise Opening} {@i Crit Effect:} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
 				],
 				[
 					"2",
@@ -270,7 +270,7 @@
 				],
 				[
 					"3",
-					"{@b Brow to Chin} The target takes a -2 status penalty to {@skill Perception} and ranged attack rolls until healer."
+					"{@b Brow to Chin} {@i Crit Effect:} The target takes a -2 status penalty to {@skill Perception} and ranged attack rolls until healer."
 				],
 				[
 					"4",
@@ -278,7 +278,7 @@
 				],
 				[
 					"5",
-					"{@b Hamstring} Normal damage. The target is knocked {@condition prone}. The target is also {@condition clumsy} 2 until healed."
+					"{@b Hamstring} Normal damage. {@i Crit Effect:} The target is knocked {@condition prone}. The target is also {@condition clumsy} 2 until healed."
 				],
 				[
 					"6",
@@ -290,11 +290,11 @@
 				],
 				[
 					"8",
-					"{@b Shattered Jaw} Until healed, the target is {@condition wounded} 1 and can't speak, eat, drink, or make attacks with its jaws."
+					"{@b Shattered Jaw} {@i Crit Effect:} Until healed, the target is {@condition wounded} 1 and can't speak, eat, drink, or make attacks with its jaws."
 				],
 				[
 					"9",
-					"{@b Tangled} You can attempt to {@action Grapple} the target as a free action. This uses the same multiple attack penalty as your attack and doesn't count towards your multiple attack penalty."
+					"{@b Tangled} {@i Crit Effect:} You can attempt to {@action Grapple} the target as a free action. This uses the same multiple attack penalty as your attack and doesn't count towards your multiple attack penalty."
 				],
 				[
 					"10",
@@ -302,27 +302,28 @@
 				],
 				[
 					"11",
-					"{@b Weapon Strike} Deal normal damage to one of the target's weapons (applying Hardness normally)."
+					"{@b Weapon Strike} {@i Crit Effect:} Deal normal damage to one of the target's weapons (applying Hardness normally)."
 				],
 				[
 					"12",
-					"{@b Missing Digits} Normal damage. The target loses {@dice 1d4} fingers on one hand and becomes {@condition clumsy} 1 until subject to {@spell regeneration} spell or similar effect."
+					"{@b Missing Digits} Normal damage. {@i Crit Effect:} The target loses {@dice 1d4} fingers on one hand and becomes {@condition clumsy} 1 until subject to {@spell regeneration} spell or similar effect."
 				],
 				[
 					"13",
-					"{@b Throat Slash} Normal damage. The target takes {@damage 1d8} {@condition persistent damage||persistent bleed damage}. The target can't talk, cast spells with a verbal component, or breathe while subject to this {@condition persistent damage||bleed damage}."
+					"{@b Overhand Chop} {@i Crit Effect:} {@damage 1d8} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"14",
-					"{@b Stand Aside} Push the target 5 feet."
+					"{@b Throat Slash} Normal damage. {@i Crit Effect:} The target takes {@damage 1d8} {@condition persistent damage||persistent bleed damage}. The target can't talk, cast spells with a verbal component, or breathe while subject to this {@condition persistent damage||bleed damage}."
 				],
 				[
 					"15",
-					"{@b Overhand Chop} {@damage 1d8} {@condition persistent damage||persistent bleed damage}."
+					"{@b Stand Aside} Push the target 5 feet."
+
 				],
 				[
 					"16",
-					"{@b Cut Straps} The target's armor check penalty doubles until the armor is {@action repair||Repaired} (DC 15)."
+					"{@b Cut Straps} {@i Crit Effect:} The target's armor check penalty doubles until the armor is {@action repair||Repaired} (DC 15)."
 				],
 				[
 					"17",
@@ -330,11 +331,11 @@
 				],
 				[
 					"18",
-					"{@b Severed Tendon} Until healed, the target is {@condition clumsy} 1 and takes a -5-foot status penalty to its land Speed."
+					"{@b Severed Tendon} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 1 and takes a -5-foot status penalty to its land Speed."
 				],
 				[
 					"19",
-					"{@b That'll Leave a Mark!} Normal damage. The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
+					"{@b That'll Leave a Mark!} Normal damage. {@i Crit Effect:} The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"20",
@@ -342,7 +343,7 @@
 				],
 				[
 					"21",
-					"{@b Rupture Abdominal Cavity} Triple damage. The target is {@condition fatigued}."
+					"{@b Rupture Abdominal Cavity} Triple damage. {@i Crit Effect:} The target is {@condition fatigued}."
 				],
 				[
 					"22",
@@ -366,7 +367,7 @@
 				],
 				[
 					"27",
-					"{@b Long Gash} Normal damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. The DC of the flat check to remove this bleed damage is 5 higher than normal."
+					"{@b Long Gash} Normal damage. {@i Crit Effect:} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. The DC of the flat check to remove this bleed damage is 5 higher than normal."
 				],
 				[
 					"28",
@@ -382,15 +383,15 @@
 				],
 				[
 					"31",
-					"{@b Across the Eyes} Normal damage. The target is {@condition blinded} until healed."
+					"{@b Across the Eyes} Normal damage. {@i Crit Effect:} The target is {@condition blinded} until healed."
 				],
 				[
 					"32",
-					"{@b From Chops to Groin} Triple damage. The target must succeed at a Fortitude save or die."
+					"{@b From Chops to Groin} Triple damage. {@i Crit Effect:} The target must succeed at a Fortitude save or die."
 				],
 				[
 					"33",
-					"{@b Never Slice} The target is {@condition slowed} 2 for 1 round."
+					"{@b Nerve Slice} {@i Crit Effect:} The target is {@condition slowed} 2 for 1 round."
 				],
 				[
 					"34",
@@ -398,7 +399,7 @@
 				],
 				[
 					"35",
-					"{@b Decapitation} Triple damage. The target must succeed at a Fortitude save or die."
+					"{@b Decapitation} Triple damage. {@i Crit Effect:} The target must succeed at a Fortitude save or die."
 				],
 				[
 					"36",
@@ -422,11 +423,11 @@
 				],
 				[
 					"41",
-					"{@b Swing Through} Make an additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
+					"{@b Swing Through} {@i Crit Effect:} Make an additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
 				],
 				[
 					"42",
-					"{@b Muscle Wound} The target is {@condition enfeebled} 2 until healed."
+					"{@b Muscle Wound} {@i Crit Effect:} The target is {@condition enfeebled} 2 until healed."
 				],
 				[
 					"43",
@@ -438,23 +439,23 @@
 				],
 				[
 					"45",
-					"{@b Bad Parry} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
+					"{@b Bad Parry} {@i Crit Effect:} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
 				],
 				[
 					"46",
-					"{@b Sapping Slash} The target is {@condition fatigued}."
+					"{@b Sapping Slash} {@i Crit Effect:} The target is {@condition fatigued}."
 				],
 				[
 					"47",
-					"{@b Brow Cut} Normal damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. Until the bleed ends, all creatures are {@condition concealed} to the target."
+					"{@b Brow Cut} Normal damage. {@i Crit Effect:} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}. Until the bleed ends, all creatures are {@condition concealed} to the target."
 				],
 				[
 					"48",
-					"{@b Sapping Slash} The target is {@condition fatigued}."
+					"{@b Sapping Slash} {@i Crit Effect:} The target is {@condition fatigued}."
 				],
 				[
 					"49",
-					"{@b Parrying Strike} Gain a +2 circumstance bonus to AC until the end of your next turn."
+					"{@b Parrying Strike} {@i Crit Effect:} Gain a +2 circumstance bonus to AC until the end of your next turn."
 				],
 				[
 					"50",
@@ -466,15 +467,15 @@
 				],
 				[
 					"52",
-					"{@b Bewildering Display} The target is {@condition flat-footed} until the end of its next turn."
+					"{@b Bewildering Display} {@i Crit Effect:} The target is {@condition flat-footed} until the end of its next turn."
 				],
 				[
 					"53",
-					"{@b Delayed Wound} Normal damage. The target takes the same amount of damage at the end of its next two turns."
+					"{@b Delayed Wound} Normal damage. {@i Crit Effect:} The target takes the same amount of damage at the end of its next two turns."
 				],
 				[
 					"54",
-					"{@b Bad Parry} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
+					"{@b Bad Parry} {@i Crit Effect:} The target must succeed at a Reflex save or drop one weapon it is holding (determined randomly by the GM)."
 				]
 			]
 		},
@@ -501,11 +502,11 @@
 				],
 				[
 					"1",
-					"{@b Forearm Piercing} The target drops one weapon it's holding (chosen randomly by the GM)."
+					"{@b Forearm Piercing} {@i Crit Effect:} The target drops one weapon it's holding (chosen randomly by the GM)."
 				],
 				[
 					"2",
-					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
+					"{@b Surprise Opening} {@i Crit Effect:} You gain 1 action that you can use before the end of your turn to use an attack action against the target."
 				],
 				[
 					"3",
@@ -517,19 +518,19 @@
 				],
 				[
 					"5",
-					"{@b Shoulder Wound} Until healed, the target is {@condition clumsy} 1 and {@condition enfeebled} 2."
+					"{@b Shoulder Wound} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 1 and {@condition enfeebled} 2."
 				],
 				[
 					"6",
-					"{@b Calf Jab} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to land Speed."
+					"{@b Calf Jab} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to land Speed."
 				],
 				[
 					"7",
-					"{@b Skewered} Triple damage. The target is {@condition slowed} 1 for 1 round."
+					"{@b Skewered} Triple damage. {@i Crit Effect:} The target is {@condition slowed} 1 for 1 round."
 				],
 				[
 					"8",
-					"{@b Send 'em Reeling} The target is {@condition flat-footed} until the end of its next turn."
+					"{@b Send 'em Reeling} {@i Crit Effect:} The target is {@condition flat-footed} until the end of its next turn."
 				],
 				[
 					"9",
@@ -537,11 +538,11 @@
 				],
 				[
 					"10",
-					"{@b Pinhole} The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target is healed."
+					"{@b Pinhole} {@i Crit Effect:} The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target is healed."
 				],
 				[
 					"11",
-					"{@b Two in a Row} Deal normal damage to an additional target adjacent to the original target."
+					"{@b Two in a Row} {@i Crit Effect:} Deal normal damage to an additional target adjacent to the original target."
 				],
 				[
 					"12",
@@ -569,7 +570,7 @@
 				],
 				[
 					"18",
-					"{@b Guarded Strike} Gain +2 circumstance bonus to AC until the end of your next turn."
+					"{@b Guarded Strike} {@i Crit Effect:} Gain +2 circumstance bonus to AC until the end of your next turn."
 				],
 				[
 					"19",
@@ -581,19 +582,19 @@
 				],
 				[
 					"21",
-					"{@b Never Cluster} Normal damage. The target is {@condition stunned} 2."
+					"{@b Nerve Cluster} Normal damage. {@i Crit Effect:} The target is {@condition stunned} 2."
 				],
 				[
 					"22",
-					"{@b Punctured Lung} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing."
+					"{@b Punctured Lung} {@i Crit Effect:} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing."
 				],
 				[
 					"23",
-					"{@b Nicked an Artery} Normal damage. {@b Crit Effect:} The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
+					"{@b Nicked an Artery} Normal damage. {@i Crit Effect:} The target takes {@damage 2d6} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"24",
-					"{@b Muscle Severed} Normal damage. Until healed, the target is {@condition clumsy} 3 and {@condition enfeebled} 3."
+					"{@b Muscle Severed} Normal damage. {@i Crit Effect:} Until healed, the target is {@condition clumsy} 3 and {@condition enfeebled} 3."
 				],
 				[
 					"25",
@@ -601,7 +602,7 @@
 				],
 				[
 					"26",
-					"{@b Lodged in the Bone} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+					"{@b Lodged in the Bone} {@i Crit Effect:} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"27",
@@ -609,7 +610,7 @@
 				],
 				[
 					"28",
-					"{@b hand Wound} Until healed, the target is {@condition clumsy} 2 and can't use one of its hands (determined randomly by the GM)."
+					"{@b Hand Wound} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 2 and can't use one of its hands (determined randomly by the GM)."
 				],
 				[
 					"29",
@@ -625,15 +626,15 @@
 				],
 				[
 					"32",
-					"{@b Head Shot} Triple damage. The target must succeed at a Fortitude save or die."
+					"{@b Head Shot} Triple damage. {@i Crit Effect:} The target must succeed at a Fortitude save or die."
 				],
 				[
 					"33",
-					"{@b Spinal Tap} Normal damage. The target is {@condition sickened} 3."
+					"{@b Spinal Tap} Normal damage. {@i Crit Effect:} The target is {@condition sickened} 3."
 				],
 				[
 					"34",
-					"{@b Heart Shot} Triple damage. The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
+					"{@b Heart Shot} Triple damage. {@i Crit Effect:} The target takes {@damage 1d4} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"35",
@@ -649,7 +650,7 @@
 				],
 				[
 					"38",
-					"{@b Eye patch for you} Triple damage. The target is {@condition dazzled} until healed."
+					"{@b Eye Patch for You} Triple damage. {@i Crit Effect:} The target is {@condition dazzled} until healed."
 				],
 				[
 					"39",
@@ -661,7 +662,7 @@
 				],
 				[
 					"41",
-					"{@b Grazing Hit} Normal damage. The target is {@condition stunned} 3."
+					"{@b Grazing Hit} Normal damage. {@i Crit Effect:} The target is {@condition stunned} 3."
 				],
 				[
 					"42",
@@ -673,11 +674,11 @@
 				],
 				[
 					"44",
-					"{@b Deep Hurting} The target is {@condition fatigued}."
+					"{@b Deep Hurting} {@i Crit Effect:} The target is {@condition fatigued}."
 				],
 				[
 					"45",
-					"{@b Hobbled} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
+					"{@b Hobbled} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
 				],
 				[
 					"46",
@@ -685,7 +686,7 @@
 				],
 				[
 					"47",
-					"{@b Deep Wound} The target is {@condition sickened} 3."
+					"{@b Deep Wound} {@i Crit Effect:} The target is {@condition sickened} 3."
 				],
 				[
 					"48",
@@ -693,15 +694,15 @@
 				],
 				[
 					"49",
-					"{@b Tenacious Wound} Normal damage. The target can't heal this damage until it has rested at least 8 hours."
+					"{@b Tenacious Wound} Normal damage. {@i Crit Effect:} The target can't heal this damage until it has rested at least 8 hours."
 				],
 				[
 					"50",
-					"{@b Leg Wound} The target takes a -5-foot status penalty to its land Speed until healed."
+					"{@b Leg Wound} {@i Crit Effect:} The target takes a -5-foot status penalty to its land Speed until healed."
 				],
 				[
 					"51",
-					"{@b Organ Scramble} Triple damage. The target is {@condition fatigued}."
+					"{@b Organ Scramble} Triple damage. {@i Crit Effect:} The target is {@condition fatigued}."
 				],
 				[
 					"52",
@@ -713,7 +714,7 @@
 				],
 				[
 					"54",
-					"{@b Hobbled} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
+					"{@b Hobbled} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 2 and takes a -10-foot status penalty to all Speeds."
 				]
 			]
 		},
@@ -740,15 +741,15 @@
 				],
 				[
 					"1",
-					"{@b Crunch} The target is {@condition sickened} 3."
+					"{@b Crunch} {@i Crit Effect:} The target is {@condition sickened} 3."
 				],
 				[
 					"2",
-					"{@b Where Am I?} Normal damage. The target is {@condition stunned} 2."
+					"{@b Where Am I?} Normal damage. {@i Crit Effect:} The target is {@condition stunned} 2."
 				],
 				[
 					"3",
-					"{@b Surprise Opening} You gain 1 action that you can use before the end of your turn to use an {@trait attack} action against the target."
+					"{@b Surprise Opening} {@i Crit Effect:} You gain 1 action that you can use before the end of your turn to use an {@trait attack} action against the target."
 				],
 				[
 					"4",
@@ -756,19 +757,19 @@
 				],
 				[
 					"5",
-					"{@b Feeble Parry} The target drops one weapon it's wielding determined by the GM."
+					"{@b Feeble Parry} {@i Crit Effect:} The target drops one weapon it's wielding determined by the GM."
 				],
 				[
 					"6",
-					"{@b Cracked Knee} Until healed, the target is {@condition clumsy} 2 and takes a -5-foot status penalty to land Speed."
+					"{@b Cracked Knee} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 2 and takes a -5-foot status penalty to land Speed."
 				],
 				[
 					"7",
-					"{@b Bell Ringer} The target is {@condition sickened} 2, and it is {@condition stupefied} 2 until it is no longer {@condition sickened}."
+					"{@b Bell Ringer} {@i Crit Effect:} The target is {@condition sickened} 2, and it is {@condition stupefied} 2 until it is no longer {@condition sickened}."
 				],
 				[
 					"8",
-					"{@b Split Open} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
+					"{@b Split Open} {@i Crit Effect:} The target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage}."
 				],
 				[
 					"9",
@@ -776,7 +777,7 @@
 				],
 				[
 					"10",
-					"{@b I See Stars} Normal damage. The target is {@condition dazzled} until healed."
+					"{@b I See Stars} Normal damage. {@i Crit Effect:} The target is {@condition dazzled} until healed."
 				],
 				[
 					"11",
@@ -796,23 +797,23 @@
 				],
 				[
 					"15",
-					"{@b Numbing Blow} Normal damage. The target is {@condition clumsy} 1 for 1 minute and must succeed at a Reflex save or drop one item it holds at random."
+					"{@b Numbing Blow} Normal damage. {@i Crit Effect:} The target is {@condition clumsy} 1 for 1 minute and must succeed at a Reflex save or drop one item it holds at random."
 				],
 				[
 					"16",
-					"{@b Two for One} Deal normal damage to one target adjacent to the original target."
+					"{@b Two for One} {@i Crit Effect:} Deal normal damage to one target adjacent to the original target."
 				],
 				[
 					"17",
-					"{@b And Stay Down} Normal damage. The target is knocked {@condition prone} and {@condition stunned} 2."
+					"{@b And Stay Down} Normal damage. {@i Crit Effect:} The target is knocked {@condition prone} and {@condition stunned} 2."
 				],
 				[
 					"18",
-					"{@b Rattled} Normal damage. The target is {@condition confused} for 1 round."
+					"{@b Rattled} Normal damage. {@i Crit Effect:} The target is {@condition confused} for 1 round."
 				],
 				[
 					"19",
-					"{@b Nighty Night} Normal damage. The target falls {@condition unconscious} and can't wake up until the of its next turn."
+					"{@b Nighty Night} Normal damage. {@i Crit Effect:} The target falls {@condition unconscious} and can't wake up until the of its next turn."
 				],
 				[
 					"20",
@@ -820,11 +821,11 @@
 				],
 				[
 					"21",
-					"{@b Collapsed Lung} Normal damage. Until healed, t he target is {@condition enfeebled} 2 and {@condition fatigued}."
+					"{@b Collapsed Lung} Normal damage. {@i Crit Effect:} Until healed, t he target is {@condition enfeebled} 2 and {@condition fatigued}."
 				],
 				[
 					"22",
-					"{@b Bony Masher} Normal damage. Either the target is {@condition clumsy} 2 and takes a -10-foot status penalty to land Speed or is {@condition clumsy} 2 and can't use one of its arms (your choice). Either effect last until healed."
+					"{@b Bony Masher} Normal damage. {@i Crit Effect:} Either the target is {@condition clumsy} 2 and takes a -10-foot status penalty to land Speed or is {@condition clumsy} 2 and can't use one of its arms (your choice). Either effect last until healed."
 				],
 				[
 					"23",
@@ -832,7 +833,7 @@
 				],
 				[
 					"24",
-					"{@b Ruptured Spleen} Normal damage. The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target has been subject to {@trait magical} healing."
+					"{@b Ruptured Spleen} Normal damage. {@i Crit Effect:} The target takes 1 {@condition persistent damage||persistent bleed damage} that can't be removed until the target has been subject to {@trait magical} healing."
 				],
 				[
 					"25",
@@ -840,23 +841,23 @@
 				],
 				[
 					"26",
-					"{@b Crushed Intestines} Normal damage. The target is {@condition wounded} 2 and {@condition enfeebled} 2 until it is no longer wounded."
+					"{@b Crushed Intestines} Normal damage. {@i Crit Effect:} The target is {@condition wounded} 2 and {@condition enfeebled} 2 until it is no longer wounded."
 				],
 				[
 					"27",
-					"{@b Crushed Trachea} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing. It can't speak while it is {@quickref suffocating|CRB|3|Drowning and Suffocating}."
+					"{@b Crushed Trachea} {@i Crit Effect:} The target is {@quickref suffocating|CRB|3|Drowning and Suffocating} until subject to magical healing. It can't speak while it is {@quickref suffocating|CRB|3|Drowning and Suffocating}."
 				],
 				[
 					"28",
-					"{@b Skull Crush} The target is {@condition stupefied} 3 until healed."
+					"{@b Skull Crush} {@i Crit Effect:} The target is {@condition stupefied} 3 until healed."
 				],
 				[
 					"29",
-					"{@b Caved Skull} Triple damage. The target must succeed at a Fortitude save or die."
+					"{@b Caved Skull} Triple damage. {@i Crit Effect:} The target must succeed at a Fortitude save or die."
 				],
 				[
 					"30",
-					"{@b To Your Thinky Bits} The target is {@condition stupefied} 2 until healed."
+					"{@b To Your Thinky Bits} {@i Crit Effect:} The target is {@condition stupefied} 2 until healed."
 				],
 				[
 					"31",
@@ -868,15 +869,15 @@
 				],
 				[
 					"33",
-					"{@b Broken Ribs} Normal damage. The target is {@condition slowed} 1 until healed."
+					"{@b Broken Ribs} Normal damage. {@i Crit Effect:} The target is {@condition slowed} 1 until healed."
 				],
 				[
 					"34",
-					"{@b Staggering Blow} The target is {@condition stunned} 2."
+					"{@b Staggering Blow} {@i Crit Effect:} The target is {@condition stunned} 2."
 				],
 				[
 					"35",
-					"{@b Thunder Strike} The target is {@condition deafened} until healed."
+					"{@b Thunder Strike} {@i Crit Effect:} The target is {@condition deafened} until healed."
 				],
 				[
 					"36",
@@ -888,11 +889,11 @@
 				],
 				[
 					"38",
-					"{@b Armor Dent} Normal damage. Deal the same amount of damage to the target's armor, ignoring that armor's Hardness."
+					"{@b Armor Dent} Normal damage. {@i Crit Effect:} Deal the same amount of damage to the target's armor, ignoring that armor's Hardness."
 				],
 				[
 					"39",
-					"{@b Soul-Crushing Blow} The target is {@condition doomed} 1 and is {@condition stupefied} 1 for as long as it is {@condition doomed}."
+					"{@b Soul-Crushing Blow} {@i Crit Effect:} The target is {@condition doomed} 1 and is {@condition stupefied} 1 for as long as it is {@condition doomed}."
 				],
 				[
 					"40",
@@ -900,11 +901,11 @@
 				],
 				[
 					"41",
-					"{@b Broken Leg} The target takes a -15-foot status penalty to its land Speed until healed."
+					"{@b Broken Leg} {@i Crit Effect:} The target takes a -15-foot status penalty to its land Speed until healed."
 				],
 				[
 					"42",
-					"{@b Shield Smack} The target must succeed at a Reflex save or drop a shield it's holding."
+					"{@b Shield Smack} {@i Crit Effect:} The target must succeed at a Reflex save or drop a shield it's holding."
 				],
 				[
 					"43",
@@ -912,23 +913,23 @@
 				],
 				[
 					"44",
-					"{@b Knockback} The target is pushed {@dice 1d4x5} feet away."
+					"{@b Knockback} {@i Crit Effect:} The target is pushed {@dice 1d4x5} feet away."
 				],
 				[
 					"45",
-					"{@b Low Blow} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
+					"{@b Low Blow} {@i Crit Effect:} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
 				],
 				[
 					"46",
-					"{@b Busted Shin} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
+					"{@b Busted Shin} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
 				],
 				[
 					"47",
-					"{@b Back Breaker} Until healed, the target is {@condition clumsy} 2 and {@condition enfeebled} 2."
+					"{@b Back Breaker} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 2 and {@condition enfeebled} 2."
 				],
 				[
 					"48",
-					"{@b Busted Shin} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
+					"{@b Busted Shin} {@i Crit Effect:} Until healed, the target is {@condition clumsy} 1 and takes a -10-foot status penalty to its land Speed."
 				],
 				[
 					"49",
@@ -944,15 +945,15 @@
 				],
 				[
 					"52",
-					"{@b Lights Out} The target is {@condition blinded} until the end of its next turn."
+					"{@b Lights Out} {@i Crit Effect:} The target is {@condition blinded} until the end of its next turn."
 				],
 				[
 					"53",
-					"{@b Roundhouse} Make one additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
+					"{@b Roundhouse} {@i Crit Effect:} Make one additional attack against a foe adjacent to the original target, using the same attack modifier as the original attack."
 				],
 				[
 					"54",
-					"{@b Low Blow} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
+					"{@b Low Blow} {@i Crit Effect:} The target is {@condition sickened} 2 and {@condition slowed} 1 as long as it remains {@condition sickened}."
 				]
 			]
 		},
@@ -1848,7 +1849,7 @@
 				],
 				[
 					"39",
-					"{@b On the receiving End} You deal damage to yourself instead of the target."
+					"{@b On the Receiving End} You deal damage to yourself instead of the target."
 				],
 				[
 					"40",
@@ -1908,7 +1909,7 @@
 				],
 				[
 					"54",
-					"{@b Pointy End goes There} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
+					"{@b Pointy End Goes There} You become {@condition wounded} 1 or your {@condition wounded} value increases by 1."
 				]
 			]
 		},

--- a/js/deities.js
+++ b/js/deities.js
@@ -158,11 +158,11 @@ function renderStatblock (deity) {
 		() => {},
 		buildImageTab,
 	);
-	const tabs = [statTab]
+	const tabs = [statTab];
 	if (deity.intercession) tabs.push(intercessionTab);
 	if (deity.hasLore) tabs.push(loreTab);
 	if (deity.images) tabs.push(imageTab);
-	tabs.push(infoTab)
+	tabs.push(infoTab);
 	Renderer.utils.bindTabButtons(...tabs);
 }
 

--- a/js/filter.js
+++ b/js/filter.js
@@ -5,7 +5,7 @@ FilterUtil.SUB_HASH_PREFIX_LENGTH = 4;
 
 class PageFilter {
 	static defaultSourceSelFn (val) {
-		return !SourceUtil.isNonstandardSource(val) && !SourceUtil.isAdventure(val);
+		return !SourceUtil.isNonstandardSource(val) && !SourceUtil.isAdventure(val) && !SourceUtil.isAccessory(val);
 	}
 
 	constructor (opts) {

--- a/js/parser.js
+++ b/js/parser.js
@@ -1325,6 +1325,8 @@ SRC_SoT5 = "SoT5"
 SRC_SoT6 = "SoT6"
 SRC_TiO = "TiO"
 SRC_ToK = "ToK"
+SRC_CHD = "CHD"
+SRC_CFD = "CFD"
 Parser.SOURCE_JSON_TO_FULL[SRC_AAWS] = "Azarketi Ancestry Web Supplement"
 Parser.SOURCE_JSON_TO_FULL[SRC_APG] = "Advanced Player's Guide"
 Parser.SOURCE_JSON_TO_FULL[SRC_AV0] = "Abomination Vaults Player's Guide"
@@ -1415,6 +1417,8 @@ Parser.SOURCE_JSON_TO_FULL[SRC_SoT5] = "Strength of Thousands #5: Doorway to the
 Parser.SOURCE_JSON_TO_FULL[SRC_SoT6] = "Strength of Thousands #6: Shadows of the Ancients"
 Parser.SOURCE_JSON_TO_FULL[SRC_TiO] = "Troubles in Otari"
 Parser.SOURCE_JSON_TO_FULL[SRC_ToK] = "Threshold of Knowledge"
+Parser.SOURCE_JSON_TO_FULL[SRC_CHD] = "Critical Hit Deck"
+Parser.SOURCE_JSON_TO_FULL[SRC_CFD] = "Critical Fumble Deck"
 Parser.SOURCE_JSON_TO_ABV[SRC_AAWS] = "AAWS"
 Parser.SOURCE_JSON_TO_ABV[SRC_APG] = "APG"
 Parser.SOURCE_JSON_TO_ABV[SRC_AV0] = "AV0"
@@ -1505,6 +1509,8 @@ Parser.SOURCE_JSON_TO_ABV[SRC_SoT5] = "SoT5"
 Parser.SOURCE_JSON_TO_ABV[SRC_SoT6] = "SoT6"
 Parser.SOURCE_JSON_TO_ABV[SRC_TiO] = "TiO"
 Parser.SOURCE_JSON_TO_ABV[SRC_ToK] = "ToK"
+Parser.SOURCE_JSON_TO_ABV[SRC_CHD] = "CHD"
+Parser.SOURCE_JSON_TO_ABV[SRC_CFD] = "CFD"
 Parser.SOURCE_JSON_TO_DATE[SRC_AAWS] = "2021-02-24"
 Parser.SOURCE_JSON_TO_DATE[SRC_APG] = "2020-07-30"
 Parser.SOURCE_JSON_TO_DATE[SRC_AV0] = "2021-01-15"
@@ -1595,6 +1601,8 @@ Parser.SOURCE_JSON_TO_DATE[SRC_SoT5] = "2021-11-10"
 Parser.SOURCE_JSON_TO_DATE[SRC_SoT6] = "2021-07-26"
 Parser.SOURCE_JSON_TO_DATE[SRC_TiO] = "2020-12-09"
 Parser.SOURCE_JSON_TO_DATE[SRC_ToK] = "2021-11-19"
+Parser.SOURCE_JSON_TO_DATE[SRC_CHD] = "2019-10-16"
+Parser.SOURCE_JSON_TO_DATE[SRC_CFD] = "2019-10-16"
 Parser.SOURCE_JSON_TO_STORE[SRC_AAWS] = "https://paizo-images.s3-us-west-2.amazonaws.com/image/download/Azarketi+Ancestry.pdf"
 Parser.SOURCE_JSON_TO_STORE[SRC_APG] = "https://paizo.com/products/btq023ih"
 Parser.SOURCE_JSON_TO_STORE[SRC_AV0] = "https://paizo.com/community/blog/v5748dyo6shjm"
@@ -1685,14 +1693,17 @@ Parser.SOURCE_JSON_TO_STORE[SRC_SoT5] = "https://paizo.com/products/btq027s2"
 Parser.SOURCE_JSON_TO_STORE[SRC_SoT6] = "https://paizo.com/products/btq027u1"
 Parser.SOURCE_JSON_TO_STORE[SRC_TiO] = "https://paizo.com/products/btq026k1"
 Parser.SOURCE_JSON_TO_STORE[SRC_ToK] = "https://paizo.com/products/btq027qf"
-Parser.SOURCES_ADVENTURES = new Set([SRC_AV0, SRC_AV1, SRC_AV2, SRC_AV3, SRC_AVH, SRC_AoA0, SRC_AoA1, SRC_AoA2, SRC_AoA3, SRC_AoA4, SRC_AoA5, SRC_AoA6, SRC_AoE0, SRC_AoE1, SRC_AoE2, SRC_AoE3, SRC_AoE4, SRC_AoE5, SRC_AoE6, SRC_BL0, SRC_BL1, SRC_BL2, SRC_BL3, SRC_BL4, SRC_BL5, SRC_BL6, SRC_EC0, SRC_EC1, SRC_EC2, SRC_EC3, SRC_EC4, SRC_EC5, SRC_EC6, SRC_FRP0, SRC_FRP1, SRC_FRP2, SRC_FRP3, SRC_FoP, SRC_GW0, SRC_GW1, SRC_GW2, SRC_LTiBA, SRC_Mal, SRC_NGD, SRC_OoA0, SRC_OoA1, SRC_OoA2, SRC_OoA3, SRC_QFF0, SRC_QFF1, SRC_QFF2, SRC_QFF3, SRC_SaS, SRC_AFoF, SRC_Sli, SRC_SoT0, SRC_SoT1, SRC_SoT2, SRC_SoT3, SRC_SoT4, SRC_SoT5, SRC_SoT6, SRC_TiO, SRC_ToK ])
-Parser.SOURCES_VANILLA = new Set([SRC_APG, SRC_B1, SRC_B2, SRC_B3, SRC_BotD, SRC_CRB, SRC_DA, SRC_GnG, SRC_GMG, SRC_SoM ])
+Parser.SOURCE_JSON_TO_STORE[SRC_CHD] = "https://paizo.com/products/btq01zpt"
+Parser.SOURCE_JSON_TO_STORE[SRC_CFD] = "https://paizo.com/products/btq01zpu"
+Parser.SOURCES_ADVENTURES = new Set([SRC_AV0, SRC_AV1, SRC_AV2, SRC_AV3, SRC_AVH, SRC_AoA0, SRC_AoA1, SRC_AoA2, SRC_AoA3, SRC_AoA4, SRC_AoA5, SRC_AoA6, SRC_AoE0, SRC_AoE1, SRC_AoE2, SRC_AoE3, SRC_AoE4, SRC_AoE5, SRC_AoE6, SRC_BL0, SRC_BL1, SRC_BL2, SRC_BL3, SRC_BL4, SRC_BL5, SRC_BL6, SRC_EC0, SRC_EC1, SRC_EC2, SRC_EC3, SRC_EC4, SRC_EC5, SRC_EC6, SRC_FRP0, SRC_FRP1, SRC_FRP2, SRC_FRP3, SRC_FoP, SRC_GW0, SRC_GW1, SRC_GW2, SRC_LTiBA, SRC_Mal, SRC_NGD, SRC_OoA0, SRC_OoA1, SRC_OoA2, SRC_OoA3, SRC_QFF0, SRC_QFF1, SRC_QFF2, SRC_QFF3, SRC_SaS, SRC_AFoF, SRC_Sli, SRC_SoT0, SRC_SoT1, SRC_SoT2, SRC_SoT3, SRC_SoT4, SRC_SoT5, SRC_SoT6, SRC_TiO, SRC_ToK ]);
+Parser.SOURCES_VANILLA = new Set([SRC_APG, SRC_B1, SRC_B2, SRC_B3, SRC_BotD, SRC_CRB, SRC_DA, SRC_GnG, SRC_GMG, SRC_SoM ]);
+Parser.SOURCES_ACCESSORIES = new Set([SRC_CHD, SRC_CFD]);
 Parser.TAG_TO_DEFAULT_SOURCE = {"versatileHeritage": SRC_APG, "familiar": SRC_APG, "optfeature": SRC_APG, "creatureTemplate": SRC_B1, "ability": SRC_B1, "creature": SRC_B1, "spell": SRC_CRB, "item": SRC_CRB, "class": SRC_CRB, "condition": SRC_CRB, "background": SRC_CRB, "ancestry": SRC_CRB, "archetype": SRC_CRB, "feat": SRC_CRB, "trap": SRC_CRB, "hazard": SRC_CRB, "deity": SRC_CRB, "action": SRC_CRB, "classFeature": SRC_CRB, "subclassFeature": SRC_CRB, "table": SRC_CRB, "language": SRC_CRB, "ritual": SRC_CRB, "trait": SRC_CRB, "group": SRC_CRB, "domain": SRC_CRB, "skill": SRC_CRB, "familiarAbility": SRC_CRB, "companion": SRC_CRB, "companionAbility": SRC_CRB, "disease": SRC_GMG, "curse": SRC_GMG, "variantrule": SRC_GMG, "vehicle": SRC_GMG, "place": SRC_GMG, "plane": SRC_GMG, "settlement": SRC_GMG, "nation": SRC_GMG, "organization": SRC_LOCG, "eidolon": SRC_SoM };
 [SRC_AAWS, SRC_APG, SRC_B1, SRC_B2, SRC_B3, SRC_BotD, SRC_CRB, SRC_DA, SRC_GnG, SRC_GMG, SRC_LOACLO, SRC_LOAG, SRC_LOCG, SRC_LOGM, SRC_LOGMWS, SRC_LOIL, SRC_LOKL, SRC_LOL, SRC_LOME, SRC_LOMM, SRC_LOPSG, SRC_LOTG, SRC_LOTGB, SRC_LOWG, SRC_PFUM, SRC_SoM ].forEach(src => { Parser.SOURCES_AVAILABLE_DOCS_BOOK[src] = src; Parser.SOURCES_AVAILABLE_DOCS_BOOK[src.toLowerCase()] = src; });
 [SRC_AV0, SRC_AV1, SRC_AV2, SRC_AV3, SRC_AVH, SRC_AoA0, SRC_AoA1, SRC_AoA2, SRC_AoA3, SRC_AoA4, SRC_AoA5, SRC_AoA6, SRC_AoE0, SRC_AoE1, SRC_AoE2, SRC_AoE3, SRC_AoE4, SRC_AoE5, SRC_AoE6, SRC_BL0, SRC_BL1, SRC_BL2, SRC_BL3, SRC_BL4, SRC_BL5, SRC_BL6, SRC_EC0, SRC_EC1, SRC_EC2, SRC_EC3, SRC_EC4, SRC_EC5, SRC_EC6, SRC_FRP0, SRC_FRP1, SRC_FRP2, SRC_FRP3, SRC_FoP, SRC_GW0, SRC_GW1, SRC_GW2, SRC_LTiBA, SRC_Mal, SRC_NGD, SRC_OoA0, SRC_OoA1, SRC_OoA2, SRC_OoA3, SRC_QFF0, SRC_QFF1, SRC_QFF2, SRC_QFF3, SRC_SaS, SRC_AFoF, SRC_Sli, SRC_SoT0, SRC_SoT1, SRC_SoT2, SRC_SoT3, SRC_SoT4, SRC_SoT5, SRC_SoT6, SRC_TiO, SRC_ToK ].forEach(src => { Parser.SOURCES_AVAILABLE_DOCS_ADVENTURE[src] = src; Parser.SOURCES_AVAILABLE_DOCS_ADVENTURE[src.toLowerCase()] = src; });
 /* PF2ETOOLS_SOURCE__CLOSE */
 
-Parser.SOURCES_CORE_SUPPLEMENTS = new Set(Object.keys(Parser.SOURCE_JSON_TO_FULL).filter(it => !Parser.SOURCES_ADVENTURES.has(it)));
+Parser.SOURCES_CORE_SUPPLEMENTS = new Set(Object.keys(Parser.SOURCE_JSON_TO_FULL).filter(it => !Parser.SOURCES_ADVENTURES.has(it) && !Parser.SOURCES_ACCESSORIES.has(it)));
 
 Parser.getTagSource = function (tag, source) {
 	if (source && source.trim()) return source;

--- a/js/render.js
+++ b/js/render.js
@@ -3294,7 +3294,7 @@ Renderer.utils = {
 		opts = opts || {};
 		return `<p class="pf2-stat pf2-stat__source">
 					${opts.prefix ? opts.prefix : ""}
-					${it.source != null ? `<a href="${Parser.sourceJsonToStore(it.source)}"><strong>${Parser.sourceJsonToFull(it.source)}</strong></a>${it.page != null ? `, page ${it.page}.` : ""}` : ""}
+					${it.source != null ? `<a href="${Parser.sourceJsonToStore(it.source)}"><strong>${Parser.sourceJsonToFull(it.source)}</strong></a>${it.page ? `, page ${it.page}` : ""}.` : ""}
 					${opts.noReprints || !it.otherSources ? "" : Renderer.utils.getOtherSourceHtml(it.otherSources)}
 				</p>`;
 	},

--- a/js/tables.js
+++ b/js/tables.js
@@ -81,15 +81,40 @@ class TablesPage extends ListPage {
 	}
 
 	doLoadHash (id) {
-		Renderer.get().setFirstSection(true);
 		const it = this._dataList[id];
 		it.type = it.type || "table";
-		const rendered = $$`
-		${Renderer.utils.getExcludedDiv(it, "table")}
-		${Renderer.get().setFirstSection(true).render(it)}
-		${Renderer.utils.getPageP(it)}`;
-
-		$("#pagecontent").empty().append(rendered);
+		const $pgContent = $("#pagecontent").empty();
+		const buildStatsTab = () => {
+			$pgContent.append(Renderer.table.getRenderedString(it));
+			$pgContent.append(Renderer.utils.getPageP(it));
+		};
+		const buildInfoTab = async () => {
+			let quickRulesType;
+			if (it.source === "CHD") {
+				quickRulesType = "criticalHitDeck";
+			} else if (it.source === "CFD") {
+				quickRulesType = "criticalFumbleDeck";
+			} else {
+				return;
+			}
+			const quickRules = await Renderer.utils.pGetQuickRules(quickRulesType);
+			$pgContent.append(quickRules);
+		}
+		const statsTab = Renderer.utils.tabButton(
+			"Table",
+			() => {},
+			buildStatsTab,
+		);
+		const tabs = [statsTab];
+		if (it.source === "CFD" || it.source === "CHD") {
+			const infoTab = Renderer.utils.tabButton(
+				"Quick Rules",
+				() => {},
+				buildInfoTab,
+			);
+			tabs.push(infoTab);
+		}
+		Renderer.utils.bindTabButtons(...tabs);
 
 		ListUtil.updateSelected();
 	}

--- a/js/utils.js
+++ b/js/utils.js
@@ -357,6 +357,11 @@ SourceUtil = {
 		if (source instanceof FilterItem) source = source.item;
 		return Parser.SOURCES_ADVENTURES.has(source);
 	},
+	
+	isAccessory (source) {
+		if (source instanceof FilterItem) source = source.item;
+		return Parser.SOURCES_ACCESSORIES.has(source);
+	},
 
 	isCoreOrSupplement (source) {
 		if (source instanceof FilterItem) source = source.item;

--- a/scss/source.scss
+++ b/scss/source.scss
@@ -15,7 +15,7 @@
 	$rgb-source-LOME: #9b7c27;
 	$rgb-source-LOTGB: #ac408b;
 	$rgb-source-BotD: #2b4625;
-	$rgb-source-LOTG: #66a5ca;
+	$rgb-source-LOTG: #4a95c1;
 	$rgb-source-DA: #5c8ba9;
 	$rgb-source-LOKL: #556168;
 

--- a/tables.html
+++ b/tables.html
@@ -113,7 +113,7 @@
 					</ul>
 				</div>
 
-				<div class="wrp-stat-tab">
+				<div class="wrp-stat-tab" id="stat-tabs">
 					<div id="tabs-right"></div>
 				</div>
 

--- a/test/schema-template/schema.json
+++ b/test/schema-template/schema.json
@@ -178,6 +178,9 @@
 		},
 		"quickRules": {
 			"$ref": "quickRules.json#/properties/quickRules"
+		},
+		"event": {
+			"$ref": "events.json#/properties/events"
 		}
 	},
 	"additionalProperties": false,


### PR DESCRIPTION
Oh, you thought you were done with me? 😏

Smaller one this time

- **Add Critical Hit Deck and Critical Fumble Deck** as sets of rollable tables
   - Added the rules for the above into the Quick Rules tab because, well, it's too small to really count as a book. Updated the table page so it can render the Quick Rules tab for those tables.
- Update `parser.js` sources + licenses
   - Since this isn't a main-line release, I've followed the pattern in `parser.js` and created an 'accessory' group. If/when more accessories get added, it may be preferable to have them hidden by default or quick-toggleable in the blacklist. I honestly don't know all the steps to have them get displayed separately but there isn't much point right now, with just two (that only show up on one page), so just think of it as a placeholder.
- Made LOTG colour slightly bluer since it was nigh indistinguishable from LOGM on second glance.
- Made the source-page renderer `Renderer.utils.getPageP()` not display ", page 0" if the `page` is 0 (since the schema enforces integers no further checks should be needed).

No issues formally resolved but you can stick it on the completed side of the project to make the percentage go up 😏