### PR TITLE
Fix BUG-158 Planes Omnisearch broken, issue#150

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -5626,7 +5626,7 @@ Renderer.plane = {
 		opts = opts || {}
 		const renderer = Renderer.get()
 		const renderStack = []
-		renderStack.push(Renderer.utils.getExcludedDiv(it, it.category.toLowerCase() ?? "plane", UrlUtil.PLACES))
+		renderStack.push(Renderer.utils.getExcludedDiv(it, it.category.toLowerCase() ?? "plane", UrlUtil.PG_PLACES))
 		renderStack.push(Renderer.utils.getNameDiv(it, { page: UrlUtil.PLACES, type: it.category.toUpperCase() ?? "PLANE", ...opts }))
 		renderStack.push(Renderer.utils.getDividerDiv())
 		renderStack.push(Renderer.utils.getTraitsDiv(it.traits || []))


### PR DESCRIPTION
Fix a typo on line 5629 of render.js.
Renderer.utils.getExludedDiv() was called with
UrlUtil.PLACES instead of UrlUtil_PG_Places.