### PR TITLE
missing closing '}' in melee weapons table

### DIFF
--- a/data/tables.json
+++ b/data/tables.json
@@ -2595,7 +2595,7 @@
 					"{@damage 1d4} S",
 					"L",
 					"1",
-					"{@group Knife]",
+					"{@group Knife}",
 					"{@trait Agile}, {@trait backstabber}, {@trait deadly <d8>}, {@trait finesse}"
 				]
 			]

--- a/data/tables.json
+++ b/data/tables.json
@@ -11000,7 +11000,7 @@
 					"1",
 					"1",
 					"Sword",
-					"{@trait Forceful}, {@trait sweep"
+					"{@trait Forceful}, {@trait sweep}"
 				],
 				[
 					"{@item Scythe}",


### PR DESCRIPTION
```
[
	"{@item Scimitar}",
	"1 gp",
	"{@dice 1d6} S",
	"1",
	"1",
	"Sword",
	"{@trait Forceful}, {@trait sweep"
],
```		

missing closing tag `}`