### PR TITLE
Bump node-sass minimum version to 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
 		"http-server": "^14.1.0",
 		"json": "^11.0.0",
 		"json-source-map": "^0.6.1",
-		"node-sass": "^7.0.1",
+		"node-sass": "^8.0.0",
 		"postcss": "^8.3.4",
 		"postcss-cli": "^8.3.1",
 		"postcss-syntax": "^0.36.2",


### PR DESCRIPTION
Fixes build issues on macOS