### PR TITLE
Update _copy modes schema & support property paths with more modes

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -2796,44 +2796,53 @@ DataUtil = {
 				});
 			}
 
-			function doMod_prependArr (modInfo, prop) {
+			function doMod_prependArr (modInfo, path) {
 				doEnsureArray(modInfo, "items");
-				copyTo[prop] = copyTo[prop] ? modInfo.items.concat(copyTo[prop]) : modInfo.items
+				if (!getPropertyFromPath(copyTo, path)) throw new Error(`Could not find "${path}" array`);
+				const current = getPropertyFromPath(copyTo, path);
+				const replacement = current ? modInfo.items.concat(current) : modInfo.items;
+				setPropertyFromPath(copyTo, replacement, path);
 			}
 
-			function doMod_appendArr (modInfo, prop) {
+			function doMod_appendArr (modInfo, path) {
 				doEnsureArray(modInfo, "items");
-				copyTo[prop] = copyTo[prop] ? copyTo[prop].concat(modInfo.items) : modInfo.items
+				if (!getPropertyFromPath(copyTo, path)) throw new Error(`Could not find "${path}" array`);
+				const current = getPropertyFromPath(copyTo, path);
+				const replacement = current ? current.concat(modInfo.items) : modInfo.items;
+				setPropertyFromPath(copyTo, replacement, path);
 			}
 
-			function doMod_appendIfNotExistsArr (modInfo, prop) {
+			function doMod_appendIfNotExistsArr (modInfo, path) {
 				doEnsureArray(modInfo, "items");
-				if (!copyTo[prop]) return copyTo[prop] = modInfo.items;
-				copyTo[prop] = copyTo[prop].concat(modInfo.items.filter(it => !copyTo[prop].some(x => CollectionUtil.deepEquals(it, x))));
+				const current = getPropertyFromPath(copyTo, path);
+				if (!current) return setPropertyFromPath(copyTo, modInfo.items, path);
+				const replacement = arr.concat(modInfo.items.filter(it => !current.some(x => CollectionUtil.deepEquals(it, x))));
+				setPropertyFromPath(copyTo, replacement, path);
 			}
 
-			function doMod_replaceArr (modInfo, prop, isThrow = true) {
+			function doMod_replaceArr (modInfo, path, isThrow = true) {
 				doEnsureArray(modInfo, "items");
+				const current = getPropertyFromPath(copyTo, path);
 
-				if (!copyTo[prop]) {
-					if (isThrow) throw new Error(`Could not find "${prop}" array`);
+				if (!current) {
+					if (isThrow) throw new Error(`Could not find "${path}" array`);
 					return false;
 				}
 
 				let ixOld;
 				if (modInfo.replace.regex) {
 					const re = new RegExp(modInfo.replace.regex, modInfo.replace.flags || "");
-					ixOld = copyTo[prop].findIndex(it => it.idName || it.name ? re.test(it.idName || it.name) : typeof it === "string" ? re.test(it) : false);
+					ixOld = current.findIndex(it => it.idName || it.name ? re.test(it.idName || it.name) : typeof it === "string" ? re.test(it) : false);
 				} else if (modInfo.replace.index != null) {
 					ixOld = modInfo.replace.index;
 				} else {
-					ixOld = copyTo[prop].findIndex(it => it.idName || it.name ? it.idName || it.name === modInfo.replace : it === modInfo.replace);
+					ixOld = current.findIndex(it => it.idName || it.name ? it.idName || it.name === modInfo.replace : it === modInfo.replace);
 				}
 
 				if (~ixOld) {
-					copyTo[prop].splice(ixOld, 1, ...modInfo.items);
+					current.splice(ixOld, 1, ...modInfo.items);
 					return true;
-				} else if (isThrow) throw new Error(`Could not find "${prop}" item with name or title "${modInfo.replace}" to replace`);
+				} else if (isThrow) throw new Error(`Could not find "${path}" item with name or title "${modInfo.replace}" to replace`);
 				return false;
 			}
 

--- a/test/schema-template/utils.json
+++ b/test/schema-template/utils.json
@@ -2329,28 +2329,6 @@
 					"type": "object",
 					"properties": {
 						"mode": {
-							"const": "replaceName"
-						},
-						"replace": {
-							"type": "string"
-						},
-						"with": {
-							"type": "string"
-						},
-						"flags": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"replace",
-						"with"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
 							"const": "appendStr"
 						},
 						"str": {
@@ -2619,43 +2597,6 @@
 					"type": "object",
 					"properties": {
 						"mode": {
-							"const": "calculateProp"
-						},
-						"prop": {
-							"type": "string"
-						},
-						"formula": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"prop",
-						"formula"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "replaceSpells"
-						},
-						"spells": {
-							"type": "object"
-						},
-						"daily": {
-							"type": "object"
-						}
-					},
-					"required": [
-						"mode"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
 							"const": "addSpells"
 						},
 						"spells": {
@@ -2676,93 +2617,6 @@
 					},
 					"required": [
 						"mode"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "addSkills"
-						},
-						"skills": {
-							"type": "object"
-						}
-					},
-					"required": [
-						"mode",
-						"skills"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "addSaves"
-						},
-						"saves": {
-							"type": "object"
-						}
-					},
-					"required": [
-						"mode",
-						"saves"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "addAllSkills"
-						},
-						"skills": {
-							"type": "integer"
-						}
-					},
-					"required": [
-						"mode",
-						"skills"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "addAllSaves"
-						},
-						"saves": {
-							"type": "integer"
-						}
-					},
-					"required": [
-						"mode",
-						"saves"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "addSenses"
-						},
-						"senses": {
-							"anyOf": [
-								{
-									"type": "object"
-								},
-								{
-									"type": "array"
-								}
-							]
-						}
-					},
-					"required": [
-						"mode",
-						"senses"
 					],
 					"additionalProperties": false
 				},
@@ -2806,73 +2660,6 @@
 						"mode",
 						"scalar",
 						"prop"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "scalarAddHit"
-						},
-						"scalar": {
-							"type": "number"
-						}
-					},
-					"required": [
-						"mode",
-						"scalar"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "scalarAddDc"
-						},
-						"scalar": {
-							"type": "number"
-						}
-					},
-					"required": [
-						"mode",
-						"scalar"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "maxSize"
-						},
-						"max": {
-							"type": "string"
-						}
-					},
-					"required": [
-						"mode",
-						"max"
-					],
-					"additionalProperties": false
-				},
-				{
-					"type": "object",
-					"properties": {
-						"mode": {
-							"const": "scalarMultXp"
-						},
-						"scalar": {
-							"type": "number"
-						},
-						"floor": {
-							"type": "boolean"
-						}
-					},
-					"required": [
-						"mode",
-						"scalar"
 					],
 					"additionalProperties": false
 				}


### PR DESCRIPTION
* Remove unimplemented _copy modes from the schema 

* Support property paths with prependArr, appendArr, appendIfNotExistsArr and replaceArr
Add support property paths (e.g. "propA.propB") with additional _copy modes.
This was already implemented for insertArr and removeArr which can be confusing and slightly limiting.