### PR TITLE
Add renderer support for skill notes

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -3316,10 +3316,15 @@ Renderer.utils = {
 	getNotes: (obj, opts) => {
 		opts = opts || {};
 		opts.exclude = opts.exclude || [];
+		opts.raw = opts.raw || [];
 		const renderer = Renderer.get();
 		const renderedNotes = Object.keys(obj).filter(it => !opts.exclude.includes(it)).map(key => {
-			if (opts.dice) return renderer.render(`{@d20 ${Parser.numToBonus(obj[key])}||${opts.dice.name || key}} ${key}`);
-			else return `${obj[key]} ${key}`;
+			if (opts.raw.includes(key)) {
+				return obj[key];
+			} else {
+				if (opts.dice) return renderer.render(`{@d20 ${Parser.numToBonus(obj[key])}||${opts.dice.name || key}} ${key}`);
+				else return `${obj[key]} ${key}`;
+			}
 		}).join(", ");
 		return `${renderedNotes ? ` (${renderedNotes})` : ""}`
 	},
@@ -4274,7 +4279,7 @@ Renderer.creature = {
 			renderStack.push(`<strong>Skills&nbsp;</strong>`)
 			let skills = []
 			Object.keys(cr.skills).forEach(skill => {
-				let renderedSkill = `${skill.toTitleCase()} ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std"], dice: { name: skill } })}`;
+				let renderedSkill = `${skill.toTitleCase()} ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std"], raw: ["note"], dice: { name: skill } })}`;
 				skills.push(renderedSkill)
 			});
 

--- a/js/scalecreature.js
+++ b/js/scalecreature.js
@@ -574,7 +574,13 @@ class ScaleCreature {
 		});
 		["fort", "ref", "will"].forEach(st => Object.keys(creature.defenses.savingThrows[st]).forEach(key => creature.defenses.savingThrows[st][key] += opts.flatAddProf));
 		Object.keys(creature.perception).forEach(key => creature.perception[key] += opts.flatAddProf);
-		if (Object.keys(creature.skills).length) Object.keys(creature.skills).forEach(skill => Object.keys(creature.skills[skill]).forEach(key => creature.skills[skill][key] += opts.flatAddProf));
+		if (Object.keys(creature.skills).length) {
+			Object.keys(creature.skills).forEach(skill => {
+				Object.keys(creature.skills[skill]).forEach(key => {
+					if (key !== "note") creature.skills[skill][key] += opts.flatAddProf;
+				})
+			});
+		}
 		if (creature.spellcasting != null) {
 			creature.spellcasting.forEach(sc => {
 				if (sc.DC) sc.DC += opts.flatAddProf;
@@ -696,7 +702,7 @@ class ScaleCreature {
 				const defaultSkill = creature.skills[skill].std;
 				creature.skills[skill].std = this._scaleValue(lvlIn, toLvl, defaultSkill, this._LvlSkills) + opts.flatAddProf;
 				Object.keys(creature.skills[skill]).forEach(key => {
-					if (key !== "std") creature.skills[skill][key] += creature.skills[skill].std - defaultSkill;
+					if (key !== "std" && key !== "note") creature.skills[skill][key] += creature.skills[skill].std - defaultSkill;
 				});
 			})
 		}


### PR DESCRIPTION
Some skills have notes which are just text and don't include a modifier. The text converter already parses these and adds them to skills as `note` fields. This adds renderer support for these notes.

See `Raw Nerve` for an example creature with a skill note.