### PR TITLE
Bring creature AC rendering in line with the official statblocks

### DIFF
--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -6541,7 +6541,8 @@
 			"defenses": {
 				"ac": {
 					"std": 17,
-					"when broken": 13
+					"when broken": 13,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -6664,7 +6665,8 @@
 			"defenses": {
 				"ac": {
 					"std": 16,
-					"when broken": 14
+					"when broken": 14,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -6777,7 +6779,8 @@
 			"defenses": {
 				"ac": {
 					"std": 19,
-					"when broken": 15
+					"when broken": 15,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -29445,7 +29448,8 @@
 			"defenses": {
 				"ac": {
 					"std": 26,
-					"when broken": 22
+					"when broken": 22,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -5443,7 +5443,8 @@
 			"defenses": {
 				"ac": {
 					"std": 39,
-					"when broken": 35
+					"when broken": 35,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -5583,7 +5584,8 @@
 			"defenses": {
 				"ac": {
 					"std": 30,
-					"when broken": 26
+					"when broken": 26,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -5718,7 +5720,8 @@
 			"defenses": {
 				"ac": {
 					"std": 16,
-					"when broken": 12
+					"when broken": 12,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {
@@ -5885,7 +5888,8 @@
 			"defenses": {
 				"ac": {
 					"std": 36,
-					"when broken": 32
+					"when broken": 32,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {

--- a/data/bestiary/creatures-ltiba.json
+++ b/data/bestiary/creatures-ltiba.json
@@ -83,7 +83,8 @@
 			"defenses": {
 				"ac": {
 					"std": 17,
-					"when broken": 13
+					"when broken": 13,
+					"abilities": "construct armor"
 				},
 				"savingThrows": {
 					"fort": {

--- a/data/bestiary/creatures-sot4.json
+++ b/data/bestiary/creatures-sot4.json
@@ -3006,8 +3006,8 @@
 			"defenses": {
 				"ac": {
 					"std": 36,
+					"when broken": 32,
 					"abilities": [
-						"32 when broken);",
 						"construct armor"
 					]
 				},

--- a/data/hazards.json
+++ b/data/hazards.json
@@ -3047,7 +3047,7 @@
 			"defenses": {
 				"ac": {
 					"std": 35,
-					"note": "(40 vs. reactions and ranged weapon attacks)"
+					"vs. reactions and ranged weapon attacks": 40
 				},
 				"hp": {
 					"std": 220

--- a/js/render.js
+++ b/js/render.js
@@ -4332,12 +4332,14 @@ Renderer.creature = {
 	getDefenses_getACPart (creature) {
 		if (!creature.defenses.ac) return null;
 		const renderer = Renderer.get();
-		const mainPart = Object.keys(creature.defenses.ac).filter(k => k !== "note" && k !== "abilities")
-			.map(k => `<strong>${k === "std" ? "" : `${k} `}AC&nbsp;</strong>${creature.defenses.ac[k]}`).join(", ");
+		const mainPart = `<strong>AC&nbsp;</strong> ${creature.defenses.ac.std}`;
+		const extraACList = Object.keys(creature.defenses.ac).filter(k => k !== "std" && k !== "note" && k !== "abilities")
+			.map(k => `${creature.defenses.ac[k]} ${k}`).join(", ");
+		const extraACs = extraACList ? ` (${extraACList})` : "";
 		// TODO: deprecate ac.note
 		const notePart = creature.defenses.ac.note ? renderer.render(creature.defenses.ac.note) : "";
 		const abilitiesPart = creature.defenses.ac.abilities ? `; ${renderer.render(creature.defenses.ac.abilities)}` : "";
-		return `${mainPart}${notePart}${abilitiesPart}`;
+		return `${mainPart}${extraACs}${notePart}${abilitiesPart}`;
 	},
 	getDefenses_getSavingThrowPart (creature) {
 		if (!creature.defenses.savingThrows) return null;


### PR DESCRIPTION
The official statblocks show the additional ACs in braces after the main AC and before special abilities.

Also adds some missing `construct armor` abilities to several creatures and fixes a hazard with a secondary AC value.

Before:
<img width="433" alt="Before" src="https://user-images.githubusercontent.com/3801202/226940881-3c3c6576-4927-4124-9f3f-8759c77a9d9a.png">

After:
<img width="432" alt="After" src="https://user-images.githubusercontent.com/3801202/226941053-229980b3-07d3-452d-89b5-17c93a51986d.png">

