### PR TITLE
Use "Effect" header for attacks that only produce effects and no damage

### DIFF
--- a/data/bestiary/creatures-aoa1.json
+++ b/data/bestiary/creatures-aoa1.json
@@ -2904,9 +2904,7 @@
 					],
 					"effects": [
 						"tongue pull"
-					],
-					"damage": "tongue pull",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",

--- a/data/bestiary/creatures-aoa4.json
+++ b/data/bestiary/creatures-aoa4.json
@@ -5432,9 +5432,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoa6.json
+++ b/data/bestiary/creatures-aoa6.json
@@ -2202,9 +2202,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe2.json
+++ b/data/bestiary/creatures-aoe2.json
@@ -2735,9 +2735,7 @@
 					],
 					"effects": [
 						"grabbing trunk"
-					],
-					"damage": "grabbing trunk",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",

--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -1207,9 +1207,7 @@
 					],
 					"effects": [
 						"incendiary spit"
-					],
-					"damage": "incendiary spit",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe4.json
+++ b/data/bestiary/creatures-aoe4.json
@@ -79,9 +79,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -1112,9 +1110,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -1606,9 +1602,7 @@
 					],
 					"effects": [
 						"Web"
-					],
-					"damage": "Web",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-aoe5.json
+++ b/data/bestiary/creatures-aoe5.json
@@ -3044,9 +3044,7 @@
 					],
 					"effects": [
 						"spit"
-					],
-					"damage": "spit",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -3181,9 +3181,7 @@
 					],
 					"effects": [
 						"ectoplasmic web trap"
-					],
-					"damage": "ectoplasmic web trap",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -3444,9 +3444,7 @@
 					],
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -3243,9 +3243,7 @@
 					],
 					"effects": [
 						"see Generate Bomb"
-					],
-					"damage": "see Generate Bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -10766,9 +10764,7 @@
 					],
 					"effects": [
 						"attach"
-					],
-					"damage": "attach",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -11005,9 +11001,7 @@
 					],
 					"effects": [
 						"tongue grab"
-					],
-					"damage": "tongue grab",
-					"types": []
+					]
 				},
 				{
 					"range": "Ranged",
@@ -11167,9 +11161,7 @@
 					],
 					"effects": [
 						"tongue grab"
-					],
-					"damage": "tongue grab",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -11405,9 +11397,7 @@
 					],
 					"effects": [
 						"tongue grab"
-					],
-					"damage": "tongue grab",
-					"types": []
+					]
 				},
 				{
 					"range": "Ranged",
@@ -20797,9 +20787,7 @@
 					],
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -22392,9 +22380,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -24732,9 +24718,7 @@
 					],
 					"effects": [
 						"grabbing trunk"
-					],
-					"damage": "grabbing trunk",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",
@@ -24919,9 +24903,7 @@
 					],
 					"effects": [
 						"rope snare"
-					],
-					"damage": "rope snare",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -25118,9 +25100,7 @@
 					],
 					"effects": [
 						"ethereal web trap"
-					],
-					"damage": "ethereal web trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -34140,9 +34120,7 @@
 					],
 					"effects": [
 						"web tether"
-					],
-					"damage": "web tether",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -36850,9 +36828,7 @@
 					],
 					"effects": [
 						"guardian naga venom"
-					],
-					"damage": "guardian naga venom",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -38814,9 +38790,7 @@
 					],
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -46116,9 +46090,7 @@
 					],
 					"effects": [
 						"grabbing trunk"
-					],
-					"damage": "grabbing trunk",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",
@@ -54302,9 +54274,7 @@
 					],
 					"effects": [
 						"see Sphere of Oblivion"
-					],
-					"damage": "see Sphere of Oblivion",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -55243,9 +55213,7 @@
 					],
 					"effects": [
 						"varies (see ability)"
-					],
-					"damage": "varies (see ability)",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -56655,9 +56623,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -57962,9 +57928,7 @@
 					],
 					"effects": [
 						"sticky strand"
-					],
-					"damage": "sticky strand",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -58437,9 +58401,7 @@
 					],
 					"effects": [
 						"rust"
-					],
-					"damage": "rust",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",
@@ -63008,9 +62970,7 @@
 					],
 					"effects": [
 						"entangling slime"
-					],
-					"damage": "entangling slime",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -71143,9 +71103,7 @@
 					"attack": 11,
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -7173,9 +7173,7 @@
 					],
 					"effects": [
 						"dimensional tether"
-					],
-					"damage": "dimensional tether",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [
@@ -8771,9 +8769,7 @@
 					"attack": 6,
 					"effects": [
 						"Grab"
-					],
-					"damage": "Grab",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -12393,9 +12389,7 @@
 					],
 					"effects": [
 						"sticky filament"
-					],
-					"damage": "sticky filament",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -16700,11 +16694,8 @@
 						"range increment <10 feet>"
 					],
 					"effects": [
-						"web trap",
-						"dream spider venom"
-					],
-					"damage": "web trap plus dream spider venom",
-					"types": []
+						"web trap plus dream spider venom"
+					]
 				}
 			],
 			"abilities": {
@@ -23299,9 +23290,7 @@
 					],
 					"effects": [
 						"tongue grab"
-					],
-					"damage": "tongue grab",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -34309,9 +34298,7 @@
 					],
 					"effects": [
 						"grabbing trunk"
-					],
-					"damage": "grabbing trunk",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",
@@ -35172,9 +35159,7 @@
 					],
 					"effects": [
 						"paralysis"
-					],
-					"damage": "paralysis",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -38482,9 +38467,7 @@
 					],
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -9839,9 +9839,7 @@
 					"attack": 6,
 					"effects": [
 						"camel spit"
-					],
-					"damage": "camel spit",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -31958,9 +31956,7 @@
 					],
 					"effects": [
 						"barbed net"
-					],
-					"damage": "barbed net",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -34181,9 +34177,7 @@
 					],
 					"effects": [
 						"viscous trap"
-					],
-					"damage": "viscous trap",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -37747,9 +37741,7 @@
 					],
 					"effects": [
 						"tickle"
-					],
-					"damage": "tickle",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -1892,9 +1892,7 @@
 					],
 					"effects": [
 						"grabbing trunk"
-					],
-					"damage": "grabbing trunk",
-					"types": []
+					]
 				},
 				{
 					"range": "Melee",

--- a/data/bestiary/creatures-ec3.json
+++ b/data/bestiary/creatures-ec3.json
@@ -3191,9 +3191,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-ec4.json
+++ b/data/bestiary/creatures-ec4.json
@@ -510,10 +510,8 @@
 						"reach <15 feet>"
 					],
 					"effects": [
-						"Grab"
-					],
-					"damage": "Grab and Pull 10 feet",
-					"types": []
+						"Grab and Pull 10 feet"
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -623,9 +623,7 @@
 					],
 					"effects": [
 						"hungering web"
-					],
-					"damage": "hungering web",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -4519,9 +4517,7 @@
 					],
 					"effects": [
 						"web trap"
-					],
-					"damage": "web trap",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-fop.json
+++ b/data/bestiary/creatures-fop.json
@@ -2064,9 +2064,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -2249,9 +2247,7 @@
 					],
 					"effects": [
 						"as per bomb"
-					],
-					"damage": "as per bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -1029,9 +1029,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -7719,9 +7717,7 @@
 					],
 					"effects": [
 						"nagaji venom"
-					],
-					"damage": "nagaji venom",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -998,9 +998,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -8765,9 +8763,7 @@
 					],
 					"effects": [
 						"nagaji venom"
-					],
-					"damage": "nagaji venom",
-					"types": []
+					]
 				}
 			],
 			"spellcasting": [

--- a/data/bestiary/creatures-frp3.json
+++ b/data/bestiary/creatures-frp3.json
@@ -377,9 +377,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				},
 				{
 					"range": "Ranged",

--- a/data/bestiary/creatures-gmg.json
+++ b/data/bestiary/creatures-gmg.json
@@ -5477,9 +5477,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {
@@ -9557,9 +9555,7 @@
 					],
 					"effects": [
 						"varies by bomb"
-					],
-					"damage": "varies by bomb",
-					"types": []
+					]
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sli.json
+++ b/data/bestiary/creatures-sli.json
@@ -897,9 +897,7 @@
 					],
 					"effects": [
 						"tongue grab"
-					],
-					"damage": "tongue grab",
-					"types": []
+					]
 				},
 				{
 					"range": "Ranged",

--- a/js/render.js
+++ b/js/render.js
@@ -826,8 +826,16 @@ function Renderer () {
 		let MAP = -5;
 		if (entry.noMAP) MAP = 0;
 		if (entry.traits && entry.traits.map(t => t.toLowerCase()).includes("agile")) MAP = -4;
+
+		let onHit;
+		if (entry.effects && !entry.damage) {
+			onHit = `, <strong>Effect&nbsp;</strong>${entry.effects.map(e => this.render(e)).join(", ")}`;
+		} else {
+			onHit = `, <strong>Damage&nbsp;</strong>${this.render(entry.damage)}`;
+		}
+
 		textStack[0] += `<p class="pf2-stat pf2-stat__section attack">
-			<strong>${entry.range}&nbsp;</strong>${this.render("{@as 1}")} ${entry.name}${entry.attack ? this.render(` {@hit ${entry.attack}||${entry.name.uppercaseFirst()}|MAP=${MAP}}`) : ""}${entry.traits != null ? ` ${this.render(`(${entry.traits.map((t) => `{@trait ${t.toLowerCase()}}`).join(", ")})`)}` : ""}, <strong>Damage&nbsp;</strong>${this.render(entry.damage)}${entry.noMAP ? "; no multiple attack penalty" : ""}</p>`;
+			<strong>${entry.range}&nbsp;</strong>${this.render("{@as 1}")} ${entry.name}${entry.attack ? this.render(` {@hit ${entry.attack}||${entry.name.uppercaseFirst()}|MAP=${MAP}}`) : ""}${entry.traits != null ? ` ${this.render(`(${entry.traits.map((t) => `{@trait ${t.toLowerCase()}}`).join(", ")})`)}` : ""}${onHit}${entry.noMAP ? "; no multiple attack penalty" : ""}</p>`;
 	};
 
 	this._renderAbility = function (entry, textStack, meta, options) {

--- a/js/scalecreature.js
+++ b/js/scalecreature.js
@@ -765,13 +765,15 @@ class ScaleCreature {
 		if (creature.attacks == null) return;
 		creature.attacks.forEach(a => {
 			a.attack = this._scaleValue(lvlIn, toLvl, a.attack, this._LvlAttackBonus) + opts.flatAddProf;
-			const dpr = (a.damage.match(/\d+d\d+[+-]?\d*/g) || []).map(f => this._getDiceEV(f)).reduce((a, b) => a + b, 0);
-			const scaledDpr = this._scaleValue(lvlIn, toLvl, dpr, this._LvlExpectedDamage, 2);
-			a.damage = a.damage.replaceAll(/\d+d\d+([+-]?\d*)/g, (formula, mod) => {
-				const scaleTo = this._getDiceEV(formula) * scaledDpr / dpr;
-				const opts = mod ? {} : {noMod: true};
-				return this._scaleDice(formula, scaleTo, opts);
-			});
+			if (a.damage) {
+				const dpr = (a.damage.match(/\d+d\d+[+-]?\d*/g) || []).map(f => this._getDiceEV(f)).reduce((a, b) => a + b, 0);
+				const scaledDpr = this._scaleValue(lvlIn, toLvl, dpr, this._LvlExpectedDamage, 2);
+				a.damage = a.damage.replaceAll(/\d+d\d+([+-]?\d*)/g, (formula, mod) => {
+					const scaleTo = this._getDiceEV(formula) * scaledDpr / dpr;
+					const opts = mod ? {} : {noMod: true};
+					return this._scaleDice(formula, scaleTo, opts);
+				});
+			}
 		});
 	}
 


### PR DESCRIPTION
Currently the header "Damage" is always used for all attacks but the official statblocks differentiate here between attacks that do damage (and optional effects) and attacks that only create effects