### PR TITLE
Skip creature scaling during render when not needed

### DIFF
--- a/js/scalecreature.js
+++ b/js/scalecreature.js
@@ -483,6 +483,8 @@ class ScaleCreature {
 	}
 
 	applyVarRules (creature) {
+		if (!this.isProfNoLvl()) return creature;
+
 		const level = creature.level;
 		this._initRng(creature, level);
 		creature = JSON.parse(JSON.stringify(creature));


### PR DESCRIPTION
When rendering, the creature scaling is invoked to handle proficiency without level. Skip the scaling if proficiency without level is disabled to avoid unnecessary work and numerical changes.