### PR TITLE
Fix spell notes

### DIFF
--- a/data/bestiary/creatures-aoa2.json
+++ b/data/bestiary/creatures-aoa2.json
@@ -4002,13 +4002,13 @@
 							"spells": [
 								{
 									"name": "inspire competence",
-									"notes": [
+									"note": [
 										"Pathfinder Core Rulebook 386"
 									]
 								},
 								{
 									"name": "inspire courage",
-									"notes": [
+									"note": [
 										"Pathfinder Core Rulebook 386"
 									]
 								}

--- a/data/bestiary/creatures-aoa3.json
+++ b/data/bestiary/creatures-aoa3.json
@@ -115,7 +115,7 @@
 							"spells": [
 								{
 									"name": "read omens",
-									"notes": [
+									"note": [
 										"once per week"
 									]
 								}
@@ -1465,7 +1465,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only",
 										"to the Material or Shadow Plane only"
 									]
@@ -3000,7 +3000,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -3677,7 +3677,7 @@
 								},
 								{
 									"name": "summon elemental",
-									"notes": [
+									"note": [
 										"living waterfall only"
 									]
 								}

--- a/data/bestiary/creatures-aoa4.json
+++ b/data/bestiary/creatures-aoa4.json
@@ -1965,13 +1965,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -3535,13 +3535,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -772,7 +772,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"good only"
 										]
 									}
@@ -1296,13 +1296,13 @@
 							"spells": [
 								{
 									"name": "cry of destruction",
-									"notes": [
+									"note": [
 										"Pathfinder Core Rulebook 390"
 									]
 								},
 								{
 									"name": "destructive aura",
-									"notes": [
+									"note": [
 										"Pathfinder Core Rulebook 390"
 									]
 								}

--- a/data/bestiary/creatures-aoa6.json
+++ b/data/bestiary/creatures-aoa6.json
@@ -5200,7 +5200,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"to and from the vazgorlu's demiplane only"
 									]
 								},
@@ -5453,7 +5453,7 @@
 							"spells": [
 								{
 									"name": "charm",
-									"notes": [
+									"note": [
 										"undead targets only"
 									]
 								}

--- a/data/bestiary/creatures-aoe1.json
+++ b/data/bestiary/creatures-aoe1.json
@@ -1665,7 +1665,7 @@
 								},
 								{
 									"name": "mage armor",
-									"notes": [
+									"note": [
 										"already cast"
 									]
 								},

--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -153,7 +153,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},

--- a/data/bestiary/creatures-aoe4.json
+++ b/data/bestiary/creatures-aoe4.json
@@ -1637,7 +1637,7 @@
 							"spells": [
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"spiders only"
 									]
 								}
@@ -1648,7 +1648,7 @@
 								"spells": [
 									{
 										"name": "speak with animals",
-										"notes": [
+										"note": [
 											"spiders only"
 										]
 									}
@@ -2196,7 +2196,7 @@
 								},
 								{
 									"name": "imp sting",
-									"notes": [
+									"note": [
 										"page 80"
 									]
 								}
@@ -2227,7 +2227,7 @@
 								},
 								{
 									"name": "swarming wasp stings",
-									"notes": [
+									"note": [
 										"page 81"
 									]
 								}
@@ -2241,7 +2241,7 @@
 								},
 								{
 									"name": "wyvern sting",
-									"notes": [
+									"note": [
 										"page 81"
 									]
 								}
@@ -3464,7 +3464,7 @@
 								{
 									"name": "summon animal",
 									"amount": 3,
-									"notes": [
+									"note": [
 										"scorpions only"
 									]
 								}

--- a/data/bestiary/creatures-aoe5.json
+++ b/data/bestiary/creatures-aoe5.json
@@ -3378,7 +3378,7 @@
 								{
 									"name": "shadow blast",
 									"amount": 2,
-									"notes": [
+									"note": [
 										"from heartstone"
 									]
 								}
@@ -3395,13 +3395,13 @@
 							"spells": [
 								{
 									"name": "bind soul",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								},
 								{
 									"name": "ethereal jaunt",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								}
@@ -3631,7 +3631,7 @@
 								},
 								{
 									"name": "mask of terror",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -3650,7 +3650,7 @@
 								},
 								{
 									"name": "project image",
-									"notes": [
+									"note": [
 										"at will; see illusory persona"
 									]
 								}
@@ -4489,7 +4489,7 @@
 								},
 								{
 									"name": "elemental form",
-									"notes": [
+									"note": [
 										"water only"
 									]
 								},

--- a/data/bestiary/creatures-aoe6.json
+++ b/data/bestiary/creatures-aoe6.json
@@ -135,7 +135,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -403,7 +403,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -817,7 +817,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -865,7 +865,7 @@
 								},
 								{
 									"name": "prismatic shield",
-									"notes": [
+									"note": [
 										"page 75"
 									]
 								},
@@ -1829,7 +1829,7 @@
 							"spells": [
 								{
 									"name": "project image",
-									"notes": [
+									"note": [
 										"at will; see project false image"
 									]
 								}
@@ -3396,7 +3396,7 @@
 								},
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; evil only"
 									]
 								},
@@ -3433,7 +3433,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -3942,7 +3942,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -3974,7 +3974,7 @@
 								},
 								{
 									"name": "teleport",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -3998,7 +3998,7 @@
 								},
 								{
 									"name": "divine aura",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								}
@@ -4263,7 +4263,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -4300,7 +4300,7 @@
 							"spells": [
 								{
 									"name": "teleport",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -4339,13 +4339,13 @@
 							"spells": [
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
 								{
 									"name": "prismatic shield",
-									"notes": [
+									"note": [
 										"page 75"
 									]
 								},
@@ -4624,7 +4624,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -4650,7 +4650,7 @@
 							"spells": [
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic"
 									]
 								},
@@ -5361,7 +5361,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -5386,7 +5386,7 @@
 								},
 								{
 									"name": "hallucinatory terrain",
-									"notes": [
+									"note": [
 										"at will; see Reshape Reality"
 									]
 								}
@@ -5396,7 +5396,7 @@
 							"spells": [
 								{
 									"name": "teleport",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -5435,7 +5435,7 @@
 							"spells": [
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
@@ -6196,7 +6196,7 @@
 								{
 									"name": "teleport",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only and only within Terimor's Tower"
 									]
 								}
@@ -6504,7 +6504,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -6562,7 +6562,7 @@
 								},
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic"
 									]
 								},
@@ -7077,7 +7077,7 @@
 								{
 									"name": "plane shift",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -7113,7 +7113,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"good only"
 										]
 									},
@@ -7493,7 +7493,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -7753,7 +7753,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -7807,7 +7807,7 @@
 								},
 								{
 									"name": "shattering gem",
-									"notes": [
+									"note": [
 										"Pathfinder Lost Omens Gods & Magic 109"
 									]
 								}

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -638,7 +638,7 @@
 							"spells": [
 								{
 									"name": "speak with animals",
-									"notes": [
+									"note": [
 										"at will; arthropods only"
 									]
 								}

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -1676,13 +1676,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -2664,7 +2664,7 @@
 								},
 								{
 									"name": "fear",
-									"notes": [
+									"note": [
 										"2"
 									]
 								}
@@ -3853,7 +3853,7 @@
 								{
 									"name": "scrying",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"see right of inspection"
 									]
 								}
@@ -4077,7 +4077,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -593,7 +593,7 @@
 								},
 								{
 									"name": "ectoplasmic expulsion",
-									"notes": [
+									"note": [
 										"page 75"
 									]
 								},
@@ -3294,7 +3294,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -4715,7 +4715,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -4823,7 +4823,7 @@
 							"spells": [
 								{
 									"name": "call the blood",
-									"notes": [
+									"note": [
 										"page 75"
 									]
 								},
@@ -5031,7 +5031,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -5051,7 +5051,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -5231,7 +5231,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -779,7 +779,7 @@
 							"spells": [
 								{
 									"name": "create water",
-									"notes": [
+									"note": [
 										"at will; see desert thirst"
 									]
 								}
@@ -1801,7 +1801,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -1811,7 +1811,7 @@
 							"spells": [
 								{
 									"name": "locate",
-									"notes": [
+									"note": [
 										"gems only"
 									]
 								}
@@ -2612,7 +2612,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -3946,7 +3946,7 @@
 							"spells": [
 								{
 									"name": "create water",
-									"notes": [
+									"note": [
 										"at will; see desert thirst"
 									]
 								}
@@ -3956,7 +3956,7 @@
 							"spells": [
 								{
 									"name": "project image",
-									"notes": [
+									"note": [
 										"see mirage"
 									]
 								}
@@ -5084,7 +5084,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -5094,7 +5094,7 @@
 							"spells": [
 								{
 									"name": "locate",
-									"notes": [
+									"note": [
 										"gems only"
 									]
 								}
@@ -5971,7 +5971,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -7300,7 +7300,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
@@ -7872,7 +7872,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -8116,7 +8116,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -8127,7 +8127,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -8531,7 +8531,7 @@
 								},
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"lawful"
 									]
 								},
@@ -8908,7 +8908,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -8919,7 +8919,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -10303,7 +10303,7 @@
 								},
 								{
 									"name": "dimension door",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -12609,7 +12609,7 @@
 							"spells": [
 								{
 									"name": "detect magic",
-									"notes": [
+									"note": [
 										"at will"
 									]
 								}
@@ -12619,7 +12619,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								},
@@ -12632,7 +12632,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -13406,7 +13406,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								},
@@ -14349,7 +14349,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -14923,13 +14923,13 @@
 								},
 								{
 									"name": "inspire competence",
-									"notes": [
+									"note": [
 										"Core Rulebook 386"
 									]
 								},
 								{
 									"name": "inspire courage",
-									"notes": [
+									"note": [
 										"Core Rulebook 386"
 									]
 								}
@@ -14939,7 +14939,7 @@
 							"spells": [
 								{
 									"name": "counter performance",
-									"notes": [
+									"note": [
 										"at will; Core Rulebook 386"
 									]
 								}
@@ -14950,7 +14950,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -20014,7 +20014,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -20044,7 +20044,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"at will; to Astral Plane",
 										"Elemental Planes",
 										"or Material Plane only"
@@ -22043,7 +22043,7 @@
 							"spells": [
 								{
 									"name": "impaling briars",
-									"notes": [
+									"note": [
 										"Core Rulebook 400"
 									]
 								}
@@ -22293,13 +22293,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -22477,13 +22477,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -22642,7 +22642,7 @@
 								},
 								{
 									"name": "Cantrips",
-									"notes": [
+									"note": [
 										"1st"
 									]
 								},
@@ -22663,13 +22663,13 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -23298,7 +23298,7 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -23507,7 +23507,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": "Elemental Planes, or {@place Material Plane} only"
+									"note": "Elemental Planes, or {@place Material Plane} only"
 								}
 							]
 						},
@@ -24830,7 +24830,7 @@
 								},
 								{
 									"name": "retributive pain",
-									"notes": [
+									"note": [
 										"Core Rulebook 396"
 									]
 								}
@@ -25479,7 +25479,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -27979,7 +27979,7 @@
 								},
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; evil only"
 									]
 								},
@@ -28016,7 +28016,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -35038,13 +35038,13 @@
 							"spells": [
 								{
 									"name": "ethereal jaunt",
-									"notes": [
+									"note": [
 										"self and rider only"
 									]
 								},
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self and rider only"
 									]
 								}
@@ -35770,7 +35770,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -39451,7 +39451,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"good only"
 									]
 								}
@@ -39462,7 +39462,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -40068,7 +40068,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"to Astral Plane",
 										"Elemental Planes",
 										"or Material Plane only"
@@ -40627,7 +40627,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -40664,7 +40664,7 @@
 							"spells": [
 								{
 									"name": "teleport",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -40703,7 +40703,7 @@
 							"spells": [
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
@@ -41470,7 +41470,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -41684,7 +41684,7 @@
 							"spells": [
 								{
 									"name": "dominate",
-									"notes": [
+									"note": [
 										"animals only"
 									]
 								}
@@ -42585,7 +42585,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; evil only"
 									]
 								},
@@ -43722,7 +43722,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								}
@@ -45758,7 +45758,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; evil only"
 									]
 								},
@@ -46286,7 +46286,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"at will; to Astral Plane",
 										"Elemental Planes",
 										"or Material Plane only"
@@ -46299,7 +46299,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"evil or good only"
 										]
 									}
@@ -47845,7 +47845,7 @@
 							"spells": [
 								{
 									"name": "speak with animals",
-									"notes": [
+									"note": [
 										"at will; arthropods only"
 									]
 								}
@@ -49270,7 +49270,7 @@
 								},
 								{
 									"name": "tidal surge",
-									"notes": [
+									"note": [
 										"Core Rulebook 397"
 									]
 								}
@@ -49547,7 +49547,7 @@
 							"spells": [
 								{
 									"name": "tidal surge",
-									"notes": [
+									"note": [
 										"at will; Core Rulebook 397"
 									]
 								}
@@ -49817,7 +49817,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -50280,7 +50280,7 @@
 								{
 									"name": "shadow blast",
 									"amount": 2,
-									"notes": [
+									"note": [
 										"from heartstone"
 									]
 								}
@@ -50297,13 +50297,13 @@
 							"spells": [
 								{
 									"name": "bind soul",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								},
 								{
 									"name": "ethereal jaunt",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								}
@@ -50314,7 +50314,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"all alignments simultaneously"
 										]
 									}
@@ -50540,7 +50540,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self and rider only"
 									]
 								}
@@ -50741,7 +50741,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -50902,7 +50902,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -52812,7 +52812,7 @@
 								{
 									"name": "scrying",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"see infernal investment"
 									]
 								}
@@ -53401,7 +53401,7 @@
 								},
 								{
 									"name": "miracle",
-									"notes": [
+									"note": [
 										"once per year"
 									]
 								},
@@ -53745,7 +53745,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -55227,14 +55227,14 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								},
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -60045,7 +60045,7 @@
 							"spells": [
 								{
 									"name": "veil",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -60058,7 +60058,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"to Astral Plane",
 										"Elemental Planes",
 										"or Material Plane only"
@@ -60427,7 +60427,7 @@
 							"spells": [
 								{
 									"name": "divine decree",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -60908,7 +60908,7 @@
 							"spells": [
 								{
 									"name": "dimension door",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -63278,7 +63278,7 @@
 								},
 								{
 									"name": "one additional spell depending on the donor soul's alignment",
-									"notes": "{@b Lawful Good:} {@spell zone of truth}; {@b Neutral Good:} {@spell heroism}; {@b Chaotic Good:} {@spell heal}; {@b Lawful Neutral:} {@spell nondetection}; {@b Neutral:} {@spell wall of thorns}; {@b Chaotic Neutral:} {@spell grease}; {@b Lawful Evil:} {@spell chilling darkness}; {@b Neutral Evil:} {@spell harm}; {@b Chaotic Evil:} {@spell vampiric touch}"
+									"note": "{@b Lawful Good:} {@spell zone of truth}; {@b Neutral Good:} {@spell heroism}; {@b Chaotic Good:} {@spell heal}; {@b Lawful Neutral:} {@spell nondetection}; {@b Neutral:} {@spell wall of thorns}; {@b Chaotic Neutral:} {@spell grease}; {@b Lawful Evil:} {@spell chilling darkness}; {@b Neutral Evil:} {@spell harm}; {@b Chaotic Evil:} {@spell vampiric touch}"
 								}
 							]
 						}
@@ -67656,7 +67656,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"good only"
 									]
 								}
@@ -69502,7 +69502,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -69512,7 +69512,7 @@
 							"spells": [
 								{
 									"name": "blur",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -71172,7 +71172,7 @@
 							"spells": [
 								{
 									"name": "nightmare",
-									"notes": [
+									"note": [
 										"see dream haunting"
 									]
 								}
@@ -74067,7 +74067,7 @@
 							"spells": [
 								{
 									"name": "create water",
-									"notes": [
+									"note": [
 										"at will; see desert thirst"
 									]
 								}
@@ -75007,7 +75007,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -75017,7 +75017,7 @@
 							"spells": [
 								{
 									"name": "locate",
-									"notes": [
+									"note": [
 										"gems only"
 									]
 								}
@@ -75752,7 +75752,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -2035,7 +2035,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"lawful only"
 									]
 								}
@@ -5530,7 +5530,7 @@
 							"spells": [
 								{
 									"name": "read omens",
-									"notes": [
+									"note": [
 										"once per week"
 									]
 								}
@@ -5921,7 +5921,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"lawful only"
 									]
 								}
@@ -7160,7 +7160,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -10174,7 +10174,7 @@
 							"spells": [
 								{
 									"name": "dimension door",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -11409,7 +11409,7 @@
 								{
 									"name": "levitate",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -12131,7 +12131,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -12844,7 +12844,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -14394,7 +14394,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"lawful only"
 									]
 								},
@@ -15043,7 +15043,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"good only; at will"
 									]
 								}
@@ -17930,7 +17930,7 @@
 								},
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"to Material Plane or Shadow Plane only"
 									]
 								},
@@ -19192,7 +19192,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -27125,7 +27125,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -27650,7 +27650,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -28468,7 +28468,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; lawful only"
 									]
 								}
@@ -28514,7 +28514,7 @@
 								},
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"chaotic"
 									]
 								},
@@ -28788,7 +28788,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -29212,7 +29212,7 @@
 							"spells": [
 								{
 									"name": "possession",
-									"notes": [
+									"note": [
 										"range touch"
 									]
 								}
@@ -31481,7 +31481,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -31666,7 +31666,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": "to the {@place Material Plane}, {@place Plane of Fire}, or {@place Plane of Earth} only"
+									"note": "to the {@place Material Plane}, {@place Plane of Fire}, or {@place Plane of Earth} only"
 								}
 							]
 						},
@@ -32817,7 +32817,7 @@
 							"spells": [
 								{
 									"name": "dimension door",
-									"notes": [
+									"note": [
 										"only when in bright light",
 										"and only to an area in bright light"
 									]
@@ -33509,7 +33509,7 @@
 								},
 								{
 									"name": "tree shape",
-									"notes": [
+									"note": [
 										"at will; appears as a burnt",
 										"dead tree"
 									]
@@ -33520,7 +33520,7 @@
 							"spells": [
 								{
 									"name": "elemental form",
-									"notes": [
+									"note": [
 										"fire elemental only"
 									]
 								},
@@ -34444,7 +34444,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"good only; at will"
 									]
 								}
@@ -35171,7 +35171,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -35182,7 +35182,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -35771,7 +35771,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -35782,7 +35782,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -37069,7 +37069,7 @@
 								{
 									"name": "elemental form",
 									"amount": 3,
-									"notes": [
+									"note": [
 										"water only"
 									]
 								}
@@ -37079,7 +37079,7 @@
 							"spells": [
 								{
 									"name": "summon elemental",
-									"notes": [
+									"note": [
 										"water elementals only"
 									]
 								}
@@ -38491,7 +38491,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"good only; at will"
 									]
 								}
@@ -38763,7 +38763,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -39659,7 +39659,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -40880,7 +40880,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"at will; good only"
 									]
 								},
@@ -41129,7 +41129,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -41210,7 +41210,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"evil only"
 										]
 									},
@@ -41564,7 +41564,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"good only; at will"
 									]
 								}
@@ -41810,7 +41810,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -41852,7 +41852,7 @@
 								},
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -51966,7 +51966,7 @@
 							"spells": [
 								{
 									"name": "detect alignment",
-									"notes": [
+									"note": [
 										"good only; at will"
 									]
 								}
@@ -52005,7 +52005,7 @@
 								},
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"at will; self plus skiff and passengers only; Astral",
 										"Ethereal",
 										"and evil planes only"
@@ -52569,13 +52569,13 @@
 								},
 								{
 									"name": "divine aura",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
 								{
 									"name": "divine decree",
-									"notes": [
+									"note": [
 										"chaotic only"
 									]
 								},
@@ -55243,7 +55243,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -55813,7 +55813,7 @@
 								},
 								{
 									"name": "primal phenomenon",
-									"notes": [
+									"note": [
 										"once per year"
 									]
 								},
@@ -57832,7 +57832,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -58570,7 +58570,7 @@
 							"spells": [
 								{
 									"name": "summon entity",
-									"notes": [
+									"note": [
 										"will-o'-wisp only"
 									]
 								}
@@ -60016,7 +60016,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"to Ethereal Plane or Material Plane only",
 										"self only"
 									]
@@ -62424,13 +62424,13 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"swarm creatures only"
 									]
 								}
@@ -62894,7 +62894,7 @@
 							"spells": [
 								{
 									"name": "charm",
-									"notes": [
+									"note": [
 										"plant creatures only"
 									]
 								}

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -101,7 +101,7 @@
 							"spells": [
 								{
 									"name": "zealous conviction",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -1114,7 +1114,7 @@
 								"spells": [
 									{
 										"name": "pass without trace",
-										"notes": [
+										"note": [
 											"forest terrain only"
 										]
 									}
@@ -1421,7 +1421,7 @@
 								},
 								{
 									"name": "endure elements",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -1993,7 +1993,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"good or evil only"
 									]
 								}
@@ -3298,7 +3298,7 @@
 								},
 								{
 									"name": "tree shape",
-									"notes": [
+									"note": [
 										"see forest shape"
 									]
 								},
@@ -3320,7 +3320,7 @@
 								"spells": [
 									{
 										"name": "pass without trace",
-										"notes": [
+										"note": [
 											"forest terrain only"
 										]
 									}
@@ -3630,7 +3630,7 @@
 							"spells": [
 								{
 									"name": "endure elements",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -4253,7 +4253,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"good or evil only"
 									]
 								}
@@ -8532,7 +8532,7 @@
 								{
 									"name": "phantasmal killer",
 									"amount": 3,
-									"notes": [
+									"note": [
 										"image resembles the brainchild"
 									]
 								}
@@ -10008,7 +10008,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -14187,7 +14187,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -15236,7 +15236,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -15400,13 +15400,13 @@
 							"spells": [
 								{
 									"name": "charm",
-									"notes": [
+									"note": [
 										"animals only"
 									]
 								},
 								{
 									"name": "command",
-									"notes": [
+									"note": [
 										"animals only"
 									]
 								},
@@ -16193,7 +16193,7 @@
 								},
 								{
 									"name": "shape stone",
-									"notes": [
+									"note": [
 										"see idols of stone below"
 									]
 								},
@@ -17607,7 +17607,7 @@
 							"spells": [
 								{
 									"name": "chill touch",
-									"notes": [
+									"note": [
 										"undead only"
 									]
 								},
@@ -20177,7 +20177,7 @@
 							"spells": [
 								{
 									"name": "goodberry",
-									"notes": [
+									"note": [
 										"Core Rulebook 399"
 									]
 								},
@@ -27359,13 +27359,13 @@
 								"spells": [
 									{
 										"name": "magic aura",
-										"notes": [
+										"note": [
 											"self only"
 										]
 									},
 									{
 										"name": "nondetection",
-										"notes": [
+										"note": [
 											"self only"
 										]
 									},
@@ -28591,7 +28591,7 @@
 								"spells": [
 									{
 										"name": "air walk",
-										"notes": [
+										"note": [
 											"self only"
 										]
 									}
@@ -35022,7 +35022,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -35056,7 +35056,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -38038,7 +38038,7 @@
 								},
 								{
 									"name": "divine decree",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								},
@@ -38055,7 +38055,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -40275,7 +40275,9 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": "to or from the {@place Shadow Plane} only"
+									"note": [
+										"to or from the {@place Shadow Plane} only"
+									]
 								}
 							]
 						}
@@ -40479,7 +40481,7 @@
 								{
 									"name": "shadow walk",
 									"amount": 3,
-									"notes": [
+									"note": [
 										"see shadow's swiftness"
 									]
 								}
@@ -40716,7 +40718,7 @@
 								},
 								{
 									"name": "misdirection",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -41000,7 +41002,7 @@
 							"spells": [
 								{
 									"name": "mask of terror",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -42390,7 +42392,7 @@
 								},
 								{
 									"name": "take its course",
-									"notes": [
+									"note": [
 										"Core Rulebook 397"
 									]
 								}
@@ -43397,7 +43399,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -44027,7 +44029,7 @@
 								},
 								{
 									"name": "divine lance",
-									"notes": [
+									"note": [
 										"chaos or evil"
 									]
 								}
@@ -44044,7 +44046,7 @@
 								},
 								{
 									"name": "hurtling stone",
-									"notes": [
+									"note": [
 										"Core Rulebook 393"
 									]
 								}
@@ -44058,7 +44060,7 @@
 								},
 								{
 									"name": "destructive aura",
-									"notes": [
+									"note": [
 										"Core Rulebook 391"
 									]
 								}
@@ -44461,7 +44463,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only; at will"
 									]
 								},
@@ -44772,7 +44774,7 @@
 							"spells": [
 								{
 									"name": "wall of fire",
-									"notes": [
+									"note": [
 										"at will; see Unstable Magic"
 									]
 								}
@@ -45807,7 +45809,7 @@
 								{
 									"name": "comprehend language",
 									"amount": 3,
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -46146,7 +46148,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self-only"
 									]
 								},
@@ -46407,7 +46409,7 @@
 							"spells": [
 								{
 									"name": "comprehend language",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}
@@ -46435,13 +46437,13 @@
 								},
 								{
 									"name": "misdirection",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
 								{
 									"name": "nondetection",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -46968,7 +46970,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only; to Shadow Plane or Material Plane only"
 									]
 								}
@@ -47481,13 +47483,13 @@
 								"spells": [
 									{
 										"name": "magic aura",
-										"notes": [
+										"note": [
 											"shaukeen and its items only"
 										]
 									},
 									{
 										"name": "nondetection",
-										"notes": [
+										"note": [
 											"self only"
 										]
 									}
@@ -47692,7 +47694,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -49385,7 +49387,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only; Astral or Material Plane only"
 									]
 								}
@@ -50151,7 +50153,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -50353,7 +50355,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								}
@@ -53332,7 +53334,7 @@
 							"spells": [
 								{
 									"name": "maze",
-									"notes": [
+									"note": [
 										"once per week"
 									]
 								}
@@ -53524,7 +53526,7 @@
 								{
 									"name": "haste",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -54238,7 +54240,7 @@
 								{
 									"name": "tree stride",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"cherry trees only"
 									]
 								}
@@ -54262,7 +54264,7 @@
 								"spells": [
 									{
 										"name": "foresight",
-										"notes": [
+										"note": [
 											"self only"
 										]
 									}
@@ -55962,7 +55964,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self and mount only"
 									]
 								}
@@ -56192,7 +56194,7 @@
 							"spells": [
 								{
 									"name": "pest form",
-									"notes": [
+									"note": [
 										"monkey only"
 									]
 								}
@@ -57154,14 +57156,14 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								},
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -58946,7 +58948,7 @@
 							"spells": [
 								{
 									"name": "charm",
-									"notes": [
+									"note": [
 										"undead targets only"
 									]
 								}
@@ -59662,7 +59664,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -59723,7 +59725,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -59979,7 +59981,7 @@
 							"spells": [
 								{
 									"name": "possession",
-									"notes": [
+									"note": [
 										"see mind swap"
 									]
 								}
@@ -60178,7 +60180,7 @@
 							"spells": [
 								{
 									"name": "fear",
-									"notes": [
+									"note": [
 										"animals",
 										"fungi",
 										"and plants only"
@@ -60191,7 +60193,7 @@
 								"spells": [
 									{
 										"name": "pass without trace",
-										"notes": [
+										"note": [
 											"forest terrain only"
 										]
 									}
@@ -60474,7 +60476,7 @@
 							"spells": [
 								{
 									"name": "endure elements",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -60806,7 +60808,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								},
@@ -61096,7 +61098,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"good or evil only"
 									]
 								}
@@ -61988,7 +61990,7 @@
 								{
 									"name": "detect alignment",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"evil only"
 									]
 								},

--- a/data/bestiary/creatures-ec1.json
+++ b/data/bestiary/creatures-ec1.json
@@ -2430,7 +2430,7 @@
 							"spells": [
 								{
 									"name": "charm",
-									"notes": [
+									"note": [
 										"3",
 										"targets animals only"
 									]
@@ -2441,7 +2441,7 @@
 							"spells": [
 								{
 									"name": "paranoia",
-									"notes": [
+									"note": [
 										"targets animals only"
 									]
 								}
@@ -2451,7 +2451,7 @@
 							"spells": [
 								{
 									"name": "animal vision",
-									"notes": [
+									"note": [
 										"at will; target must be a rodent",
 										"serpent",
 										"or similar animal considered troublesome by humans"

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -2564,7 +2564,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								}

--- a/data/bestiary/creatures-ec3.json
+++ b/data/bestiary/creatures-ec3.json
@@ -1372,7 +1372,7 @@
 							"spells": [
 								{
 									"name": "ravening maw",
-									"notes": [
+									"note": [
 										"page 67"
 									]
 								}
@@ -1383,7 +1383,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"good only"
 										]
 									}
@@ -1818,7 +1818,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -2613,13 +2613,13 @@
 								{
 									"name": "shadow blast",
 									"amount": 2,
-									"notes": [
+									"note": [
 										"from heartstone"
 									]
 								},
 								{
 									"name": "spirit blast",
-									"notes": [
+									"note": [
 										"from heartstone"
 									]
 								}
@@ -2636,13 +2636,13 @@
 							"spells": [
 								{
 									"name": "bind soul",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								},
 								{
 									"name": "ethereal jaunt",
-									"notes": [
+									"note": [
 										"at will; from heartstone"
 									]
 								}

--- a/data/bestiary/creatures-ec4.json
+++ b/data/bestiary/creatures-ec4.json
@@ -1517,7 +1517,7 @@
 							"spells": [
 								{
 									"name": "blood feast",
-									"notes": [
+									"note": [
 										"page 74"
 									]
 								},
@@ -1552,7 +1552,7 @@
 							"spells": [
 								{
 									"name": "entrancing eyes",
-									"notes": [
+									"note": [
 										"page 74"
 									]
 								},
@@ -2277,7 +2277,7 @@
 								{
 									"name": "teleport",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -3431,7 +3431,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -3819,7 +3819,7 @@
 								},
 								{
 									"name": "downpour",
-									"notes": [
+									"note": [
 										"Core Rulebook 391"
 									]
 								}
@@ -4042,7 +4042,7 @@
 							"spells": [
 								{
 									"name": "teleport",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -132,7 +132,7 @@
 								"spells": [
 									{
 										"name": "detect alignment",
-										"notes": [
+										"note": [
 											"evil only"
 										]
 									},
@@ -390,7 +390,7 @@
 							"spells": [
 								{
 									"name": "gaseous form",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -412,7 +412,7 @@
 							"spells": [
 								{
 									"name": "veil",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -1524,7 +1524,7 @@
 							"spells": [
 								{
 									"name": "disappearance",
-									"notes": [
+									"note": [
 										"at will; self only"
 									]
 								},
@@ -1791,7 +1791,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -2108,7 +2108,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -2516,7 +2516,7 @@
 							"spells": [
 								{
 									"name": "enlarge",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -2526,7 +2526,7 @@
 							"spells": [
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -3293,7 +3293,7 @@
 							"spells": [
 								{
 									"name": "feather fall",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -3555,7 +3555,7 @@
 							"spells": [
 								{
 									"name": "feather fall",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -3616,7 +3616,7 @@
 								},
 								{
 									"name": "summon fiend",
-									"notes": [
+									"note": [
 										"daemons only"
 									]
 								}
@@ -3841,7 +3841,7 @@
 								{
 									"name": "feather fall",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -4335,7 +4335,7 @@
 								},
 								{
 									"name": "ravening maw",
-									"notes": [
+									"note": [
 										"Pathfinder Adventure Path #153 67"
 									]
 								}

--- a/data/bestiary/creatures-ec6.json
+++ b/data/bestiary/creatures-ec6.json
@@ -379,7 +379,7 @@
 							"spells": [
 								{
 									"name": "divine wrath",
-									"notes": [
+									"note": [
 										"lawful only"
 									]
 								}
@@ -2099,7 +2099,7 @@
 								},
 								{
 									"name": "devour life",
-									"notes": [
+									"note": [
 										"page 76"
 									]
 								},
@@ -2400,7 +2400,7 @@
 							"spells": [
 								{
 									"name": "animal vision",
-									"notes": [
+									"note": [
 										"at will; dinosaurs only"
 									]
 								}
@@ -2656,7 +2656,7 @@
 							"spells": [
 								{
 									"name": "animal vision",
-									"notes": [
+									"note": [
 										"at will; dinosaurs only"
 									]
 								}
@@ -2676,7 +2676,7 @@
 								},
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"dinosaur only"
 									]
 								},

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -3418,37 +3418,37 @@
 							"spells": [
 								{
 									"name": "abundant step",
-									"notes": [
+									"note": [
 										"Core Rulebook 401"
 									]
 								},
 								{
 									"name": "ki blast",
-									"notes": [
+									"note": [
 										"Core Rulebook 401"
 									]
 								},
 								{
 									"name": "ki rush",
-									"notes": [
+									"note": [
 										"Core Rulebook 401"
 									]
 								},
 								{
 									"name": "ki strike",
-									"notes": [
+									"note": [
 										"Core Rulebook 401"
 									]
 								},
 								{
 									"name": "wholeness of body",
-									"notes": [
+									"note": [
 										"Core Rulebook 402"
 									]
 								},
 								{
 									"name": "wind jump",
-									"notes": [
+									"note": [
 										"Core Rulebook 402"
 									]
 								}
@@ -3803,7 +3803,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -4918,7 +4918,7 @@
 							"spells": [
 								{
 									"name": "divine lance",
-									"notes": [
+									"note": [
 										"lawful"
 									]
 								}
@@ -4937,25 +4937,25 @@
 							"spells": [
 								{
 									"name": "athletic rush",
-									"notes": [
+									"note": [
 										"Core Rulebook 389"
 									]
 								},
 								{
 									"name": "enduring might",
-									"notes": [
+									"note": [
 										"Core Rulebook 392"
 									]
 								},
 								{
 									"name": "perfected form",
-									"notes": [
+									"note": [
 										"Core Rulebook 394"
 									]
 								},
 								{
 									"name": "perfected mind",
-									"notes": [
+									"note": [
 										"Core Rulebook 394"
 									]
 								}
@@ -7837,13 +7837,13 @@
 							"spells": [
 								{
 									"name": "dragon breath",
-									"notes": [
+									"note": [
 										"Core Rulebook 403"
 									]
 								},
 								{
 									"name": "dragon claws",
-									"notes": [
+									"note": [
 										"Core Rulebook 403"
 									]
 								}

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -2830,7 +2830,7 @@
 								},
 								{
 									"name": "blinding fury",
-									"notes": [
+									"note": [
 										"Advanced Player's Guide 216"
 									]
 								}
@@ -6276,7 +6276,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -6840,19 +6840,19 @@
 							"spells": [
 								{
 									"name": "elemental blast",
-									"notes": [
+									"note": [
 										"air; Core Rulebook 404"
 									]
 								},
 								{
 									"name": "elemental motion",
-									"notes": [
+									"note": [
 										"air; Core Rulebook 404"
 									]
 								},
 								{
 									"name": "elemental toss",
-									"notes": [
+									"note": [
 										"air; Core Rulebook 404"
 									]
 								}
@@ -7515,7 +7515,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}
@@ -8886,19 +8886,19 @@
 							"spells": [
 								{
 									"name": "dragon breath",
-									"notes": [
+									"note": [
 										"Core Rulebook 403"
 									]
 								},
 								{
 									"name": "dragon claws",
-									"notes": [
+									"note": [
 										"Core Rulebook 403"
 									]
 								},
 								{
 									"name": "dragon wings",
-									"notes": [
+									"note": [
 										"Core Rulebook 403"
 									]
 								}

--- a/data/bestiary/creatures-frp3.json
+++ b/data/bestiary/creatures-frp3.json
@@ -1084,7 +1084,7 @@
 								},
 								{
 									"name": "spirit link",
-									"notes": [
+									"note": [
 										"with Jin-Hae only"
 									]
 								}
@@ -3532,7 +3532,7 @@
 							"spells": [
 								{
 									"name": "obscuring mist",
-									"notes": [
+									"note": [
 										"manifests snowfall instead of mist"
 									]
 								}
@@ -4695,7 +4695,7 @@
 							"spells": [
 								{
 									"name": "plane shift",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -4961,7 +4961,7 @@
 								},
 								{
 									"name": "storm of vengeance",
-									"notes": [
+									"note": [
 										"hail only each round"
 									]
 								},

--- a/data/bestiary/creatures-gmg.json
+++ b/data/bestiary/creatures-gmg.json
@@ -7241,13 +7241,13 @@
 							"spells": [
 								{
 									"name": "inspire competence",
-									"notes": [
+									"note": [
 										"Core Rulebook 386"
 									]
 								},
 								{
 									"name": "inspire courage",
-									"notes": [
+									"note": [
 										"Core Rulebook 386"
 									]
 								}

--- a/data/bestiary/creatures-lomm.json
+++ b/data/bestiary/creatures-lomm.json
@@ -195,7 +195,7 @@
 							"spells": [
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"{@creature cave bear} or {@creature woolly rhinoceros|b2} only"
 									]
 								}
@@ -524,7 +524,7 @@
 							"spells": [
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"{@creature cave bear} or {@creature woolly rhinoceros|b2} only"
 									]
 								}
@@ -805,7 +805,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -1047,7 +1047,7 @@
 								{
 									"name": "invisibility",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								},
@@ -1394,7 +1394,7 @@
 								{
 									"name": "plane shift",
 									"amount": "at will",
-									"notes": [
+									"note": [
 										"only to the First World or the Material Plane"
 									]
 								},

--- a/data/bestiary/creatures-sot1.json
+++ b/data/bestiary/creatures-sot1.json
@@ -2515,7 +2515,7 @@
 							"spells": [
 								{
 									"name": "command",
-									"notes": [
+									"note": [
 										"animals only"
 									]
 								},
@@ -2547,7 +2547,7 @@
 								},
 								{
 									"name": "summon elemental",
-									"notes": [
+									"note": [
 										"earth only"
 									]
 								}

--- a/data/bestiary/creatures-sot2.json
+++ b/data/bestiary/creatures-sot2.json
@@ -1085,7 +1085,7 @@
 								},
 								{
 									"name": "summon animal",
-									"notes": [
+									"note": [
 										"giant cockroach",
 										"giant fly",
 										"or giant tick only"
@@ -1093,7 +1093,7 @@
 								},
 								{
 									"name": "vomit swarm",
-									"notes": [
+									"note": [
 										"Advanced Player's Guide 227"
 									]
 								}
@@ -3592,7 +3592,7 @@
 								},
 								{
 									"name": "noxious vapors",
-									"notes": [
+									"note": [
 										"Advanced Player's Guide 222"
 									]
 								}

--- a/data/bestiary/creatures-tio.json
+++ b/data/bestiary/creatures-tio.json
@@ -1564,7 +1564,7 @@
 								},
 								{
 									"name": "invisibility",
-									"notes": [
+									"note": [
 										"self only"
 									]
 								}


### PR DESCRIPTION
Spell schema & renderer expect "note" entry for notes but many creatures were providing "notes" instead