### PR TITLE
Various small creature rendering & minor schema improvements

### DIFF
--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -3300,8 +3300,11 @@
 					"common",
 					"draconic"
 				],
+				"notes": [
+					"one or more planar languages"
+				],
 				"abilities": [
-					"one or"
+					"tongues"
 				]
 			},
 			"skills": {

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -3316,7 +3316,13 @@
 				},
 				"intimidation": {
 					"std": 15
-				}
+				},
+				"desert lore": {
+					"std": 14
+				},
+				"notes": [
+					"one or more Lore skills related to a specific plane"
+				]
 			},
 			"abilityMods": {
 				"str": 3,

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -20168,7 +20168,7 @@
 				"languages": [
 					"common"
 				],
-				"abilities": [
+				"notes": [
 					"two other languages"
 				]
 			},
@@ -48823,7 +48823,7 @@
 				"languages": [
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"plus any one ancient language"
 				]
 			},
@@ -48979,7 +48979,7 @@
 				"languages": [
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"plus any two ancient languages"
 				]
 			},
@@ -64840,10 +64840,12 @@
 					"common",
 					"draconic"
 				],
+				"notes": [
+					"three additional mortal languages"
+				],
 				"abilities": [
 					"telepathy 100 feet",
-					"tongues",
-					"three additional mortal languages"
+					"tongues"
 				]
 			},
 			"skills": {
@@ -68072,7 +68074,7 @@
 					"common",
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"plus one regional language"
 				]
 			},
@@ -68323,7 +68325,7 @@
 					"common",
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"plus one regional language"
 				]
 			},
@@ -68684,7 +68686,7 @@
 				"languages": [
 					"common"
 				],
-				"abilities": [
+				"notes": [
 					"plus one regional language"
 				]
 			},

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -58732,7 +58732,10 @@
 				},
 				"desert lore": {
 					"std": 14
-				}
+				},
+				"notes": [
+					"one or more Lore skills related to a specific plane"
+				]
 			},
 			"abilityMods": {
 				"str": 3,

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -58713,8 +58713,11 @@
 					"common",
 					"draconic"
 				],
+				"notes": [
+					"one or more planar languages"
+				],
 				"abilities": [
-					"one or more planar"
+					"tongues"
 				]
 			},
 			"skills": {

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -33,7 +33,7 @@
 					"common",
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"one regional language"
 				]
 			},
@@ -59160,7 +59160,7 @@
 				"languages": [
 					"common"
 				],
-				"abilities": [
+				"notes": [
 					"plus one regional language"
 				]
 			},
@@ -59899,9 +59899,11 @@
 					"common",
 					"yithian"
 				],
-				"abilities": [
-					"telepathy",
+				"notes": [
 					"20 other languages"
+				],
+				"abilities": [
+					"telepathy"
 				]
 			},
 			"skills": {

--- a/data/bestiary/creatures-botd.json
+++ b/data/bestiary/creatures-botd.json
@@ -944,7 +944,7 @@
 					"common",
 					"necril"
 				],
-				"abilities": [
+				"notes": [
 					"one other language"
 				]
 			},
@@ -7982,7 +7982,9 @@
 			"languages": {
 				"languages": [
 					"common",
-					"necril",
+					"necril"
+				],
+				"notes": [
 					"plus any one language"
 				]
 			},
@@ -9327,7 +9329,9 @@
 			"languages": {
 				"languages": [
 					"common",
-					"necril",
+					"necril"
+				],
+				"notes": [
 					"one additional language"
 				]
 			},

--- a/data/bestiary/creatures-loil.json
+++ b/data/bestiary/creatures-loil.json
@@ -931,7 +931,9 @@
 			"languages": {
 				"languages": [
 					"aklo",
-					"common",
+					"common"
+				],
+				"notes": [
 					"two other languages"
 				]
 			},

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -276,7 +276,7 @@
 		{
 			"ver": "0.8.0",
 			"date": "2023-03-??",
-			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering:\n - show skill notes\n - fix display of multiple ACs and AC abilities\n - show ability cost entries\n - support ability entries on individual saving throws\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- (A lot of Typos/Tags)"
+			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering:\n - show notes on individual skills\n - fix display of multiple ACs and AC abilities\n - show ability cost entries\n - support ability entries on individual saving throws\n - add skills notes & languages notes to add non-standard entries to the respective lists\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- (A lot of Typos/Tags)"
 		}
 	]
 }

--- a/data/changelog.json
+++ b/data/changelog.json
@@ -276,7 +276,7 @@
 		{
 			"ver": "0.8.0",
 			"date": "2023-03-??",
-			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering to show skill notes and fix display of multiple ACs and AC abilities.\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- (A lot of Typos/Tags)"
+			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering:\n - show skill notes\n - fix display of multiple ACs and AC abilities\n - show ability cost entries\n - support ability entries on individual saving throws\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- (A lot of Typos/Tags)"
 		}
 	]
 }

--- a/js/render.js
+++ b/js/render.js
@@ -4398,7 +4398,7 @@ Renderer.creature = {
 		if (!arr || arr.length === 0) return null;
 		const renderer = Renderer.get();
 		const vals = arr.map(it => `${it.name}${it.amount ? ` ${it.amount}` : ""}${it.note ? ` ${renderer.render(it.note)}` : ""}`);
-		return `<strong>${prop}&nbsp;</strong>${renderer.render(vals.join("; "))}`;
+		return `<strong>${prop}&nbsp;</strong>${renderer.render(vals.join(", "))}`;
 	},
 
 	getSpeed (cr) {

--- a/js/render.js
+++ b/js/render.js
@@ -4511,8 +4511,9 @@ Renderer.creature = {
 					${ability.traits && ability.traits.length ? `(${ability.traits.map(t => renderer.render(`{@trait ${t.toLowerCase()}}`)).join(", ")}) ` : ""}
 					${ability.frequency ? `<strong>Frequency&nbsp;</strong>${renderer.render_addTerm(Parser.freqToFullEntry(ability.frequency))}` : ""}
 					${ability.trigger ? `<strong>Trigger&nbsp;</strong>${renderer.render_addTerm(ability.trigger)}` : ""}
+					${ability.cost ? `<strong>Cost&nbsp;</strong>${renderer.render_addTerm(ability.cost)}` : ""}
 					${ability.requirements ? `<strong>Requirements&nbsp;</strong>${renderer.render_addTerm(ability.requirements)}` : ""}
-					${ability.frequency || ability.requirements || ability.trigger ? "<strong>Effect</strong>" : ""}
+					${ability.frequency || ability.requirements || ability.trigger || ability.cost ? "<strong>Effect</strong>" : ""}
 					${(ability.entries || []).map(it => renderer.render(it)).join(" ")}
 					</p>
 					${/* renderedGenericAbility || null */ ""}`;

--- a/js/render.js
+++ b/js/render.js
@@ -4297,12 +4297,14 @@ Renderer.creature = {
 			renderStack.push(`<p class="pf2-stat pf2-stat__section">`)
 			renderStack.push(`<strong>Skills&nbsp;</strong>`)
 			let skills = []
-			Object.keys(cr.skills).forEach(skill => {
+			Object.keys(cr.skills).filter(k => k !== "notes").forEach(skill => {
 				let renderedSkill = `${skill.toTitleCase()} ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std"], raw: ["note"], dice: { name: skill } })}`;
 				skills.push(renderedSkill)
 			});
+			let notes = cr.skills["notes"] || [];
 
 			renderStack.push(skills.sort().join("<span>, </span>"))
+			renderStack.push(notes.length !== 0 ? `<span>, </span>${notes.join("<span>, </span>")}` : "")
 			renderStack.push(`</p>`)
 
 			return renderStack.join("")

--- a/js/render.js
+++ b/js/render.js
@@ -4508,7 +4508,7 @@ Renderer.creature = {
 		const $ele = $$`<p class="pf2-stat pf2-stat__section ${buttonClass} ${opts.isRenderingGeneric ? "hidden" : ""}"><strong>${abilityName}</strong>
 					${ability.activity ? renderer.render(Parser.timeToFullEntry(ability.activity)) : ""}
 					${isRenderButton ? Renderer.creature.getAbilityTextButton(buttonClass, opts.isRenderingGeneric) : ""}
-					${ability.traits && ability.traits.length ? `(${ability.traits.map(t => renderer.render(`{@trait ${t.toLowerCase()}}`)).join(", ")}); ` : ""}
+					${ability.traits && ability.traits.length ? `(${ability.traits.map(t => renderer.render(`{@trait ${t.toLowerCase()}}`)).join(", ")}) ` : ""}
 					${ability.frequency ? `<strong>Frequency&nbsp;</strong>${renderer.render_addTerm(Parser.freqToFullEntry(ability.frequency))}` : ""}
 					${ability.trigger ? `<strong>Trigger&nbsp;</strong>${renderer.render_addTerm(ability.trigger)}` : ""}
 					${ability.requirements ? `<strong>Requirements&nbsp;</strong>${renderer.render_addTerm(ability.requirements)}` : ""}

--- a/js/render.js
+++ b/js/render.js
@@ -4458,7 +4458,7 @@ Renderer.creature = {
 								}
 								spells.push(`{@spell ${spell.name}|${spell.source || SRC_CRB}|${spell.name}}${bracket}`)
 							}
-							renderStack.push(renderer.render(`${spells.join(", ")}; `))
+							renderStack.push(renderer.render(`${spells.join(", ")}`))
 						});
 					}
 				});

--- a/js/render.js
+++ b/js/render.js
@@ -4474,7 +4474,7 @@ Renderer.creature = {
 		const renderRitual = (r) => {
 			return `{@ritual ${r.name}|${r.source || ""}}${r.notes == null && r.level == null ? "" : ` (${[Parser.getOrdinalForm(r.level)].concat(...(r.notes || [])).filter(Boolean).join(", ")})`}`;
 		};
-		return `${cr.rituals.map(rf => `<p class="pf2-stat pf2-stat__section"><strong>${rf.tradition ? `${rf.tradition.toTitleCase()} ` : ""}Rituals</strong> DC ${rf.DC}; ${renderer.render(rf.rituals.map(r => renderRitual(r)).join(", "))}`)}`;
+		return `${cr.rituals.map(rf => `<p class="pf2-stat pf2-stat__section"><strong>${rf.tradition ? `${rf.tradition.toTitleCase()} ` : ""}Rituals</strong>${rf.DC ? ` DC ${rf.DC};` : ""} ${renderer.render(rf.rituals.map(r => renderRitual(r)).join(", "))}`)}`;
 	},
 
 	getRenderedAbility (ability, opts) {

--- a/js/render.js
+++ b/js/render.js
@@ -4234,7 +4234,7 @@ Renderer.creature = {
 			${Renderer.utils.getTraitsDiv(cr.traits)}
 			${Renderer.creature.getDescription(cr.description)}
 			${Renderer.creature.getPerception(cr)}
-			${Renderer.creature.getLanguages(cr)}
+			${Renderer.creature.getLanguages(cr.languages)}
 			${Renderer.creature.getSkills(cr)}
 			${Renderer.creature.getAbilityMods(cr.abilityMods)}
 			${cr.abilities && cr.abilities.top ? cr.abilities.top.map(it => Renderer.creature.getRenderedAbility(it, { noButton: true })) : ""}
@@ -4269,18 +4269,28 @@ Renderer.creature = {
 		return `<p class="pf2-stat pf2-stat__section"><strong>Perception&nbsp;</strong>${rdPerception}${rdOtherPerception}${rdSenses.length ? "; " : ""}${rdSenses}</p>`;
 	},
 
-	getLanguages (cr) {
+	getLanguages (crLanguages) {
+		if (crLanguages == null) return ""
+
 		const renderer = Renderer.get()
-		if (cr.languages != null && cr.languages.languages != null && (cr.languages.languages.length !== 0 || (cr.languages.abilities && cr.languages.abilities.length !== 0))) {
+
+		const languages = crLanguages.languages || []
+		const notes = crLanguages.notes || []
+		const abilities = crLanguages.abilities || []
+
+		if (languages.length !== 0 || notes.length !== 0 || abilities.length !== 0) {
+			const langs = languages.map(t => t.toTitleCase()).concat(notes)
+
 			let renderStack = [];
 
 			renderStack.push(`<p class="pf2-stat pf2-stat__section">`)
 			renderStack.push(`<span><strong>Languages&nbsp;</strong></span>`)
 			renderStack.push(`<span>`)
-			renderStack.push(cr.languages.languages.length !== 0 ? cr.languages.languages.map(t => t.toTitleCase()).join(", ") : "— ")
-			if (cr.languages.abilities && cr.languages.abilities.length !== 0) {
-				if (cr.languages.languages.length !== 0) renderStack.push("; ")
-				renderStack.push(renderer.render(cr.languages.abilities.join(", ")))
+
+			renderStack.push(langs.length !== 0 ? langs.join(", ") : "— ")
+			if (abilities.length !== 0) {
+				if (langs !== 0) renderStack.push("; ")
+				renderStack.push(renderer.render(abilities.join(", ")))
 			}
 			renderStack.push(`</span>`)
 			renderStack.push(`</p>`)

--- a/js/render.js
+++ b/js/render.js
@@ -3330,7 +3330,8 @@ Renderer.utils = {
 		const renderer = Renderer.get();
 		const renderedNotes = Object.keys(obj).filter(it => !opts.exclude.includes(it)).map(key => {
 			if (opts.raw.includes(key)) {
-				return obj[key];
+				const items = obj[key];
+				return Array.isArray(items) ? obj[key].join(", ") : obj[key];
 			} else {
 				if (opts.dice) return renderer.render(`{@d20 ${Parser.numToBonus(obj[key])}||${opts.dice.name || key}} ${key}`);
 				else return `${obj[key]} ${key}`;
@@ -4367,7 +4368,7 @@ Renderer.creature = {
 			.map(k => {
 				const saveName = `${Parser.savingThrowAbvToFull(k)} Save`;
 				const std = renderer.render(`<strong>${k.uppercaseFirst()}&nbsp;</strong>{@d20 ${creature.defenses.savingThrows[k].std}||${saveName}}`);
-				const note = Renderer.utils.getNotes(creature.defenses.savingThrows[k], { exclude: ["std", "abilities"], dice: { name: saveName } });
+				const note = Renderer.utils.getNotes(creature.defenses.savingThrows[k], { exclude: ["std"], raw: ["abilities"], dice: { name: saveName } });
 				return `${std}${note}`;
 			})
 			.join(", ");

--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -357,8 +357,6 @@
 							},
 							"additionalProperties": false,
 							"required": [
-								"tradition",
-								"DC",
 								"rituals"
 							]
 						},

--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -76,6 +76,14 @@
 								"minItems": 1,
 								"uniqueItems": true
 							},
+							"notes": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"minItems": 1,
+								"uniqueItems": true
+							},
 							"abilities": {
 								"type": "array",
 								"items": {

--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -101,8 +101,21 @@
 								{
 									"type": "string",
 									"pattern": "([a-z]+ |)lore( \\(.+?\\)|)$"
+								},
+								{
+									"const": "notes"
 								}
 							]
+						},
+						"properties": {
+							"notes": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								},
+								"uniqueItems": true,
+								"minItems": 1
+							}
 						},
 						"additionalProperties": {
 							"type": "object",

--- a/test/schema-template/utils.json
+++ b/test/schema-template/utils.json
@@ -1875,6 +1875,13 @@
 								"std": {
 									"type": "integer",
 									"minimum": 0
+								},
+								"abilities": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									},
+									"minItems": 1
 								}
 							}
 						},
@@ -1884,6 +1891,13 @@
 								"std": {
 									"type": "integer",
 									"minimum": 0
+								},
+								"abilities": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									},
+									"minItems": 1
 								}
 							}
 						},
@@ -1893,6 +1907,13 @@
 								"std": {
 									"type": "integer",
 									"minimum": 0
+								},
+								"abilities": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									},
+									"minItems": 1
 								}
 							}
 						},


### PR DESCRIPTION
Creature rendering adjustments
* Comma separate individual weaknesses & resistances to match official statblocks
* Remove semicolon after ability traits to match official statblocks
* Remove trailing semicolon after constant spells in creature statblocks

Show existing creature data
* Render "Cost" entries on creature abilities

Adjust rendering & schema for creatures with reduced rituals entries
* Properly render creature rituals entries lacking a DC property

Add support for adding raw entries to creature skills & languages lists
* Add skill notes to schema & renderer
* Add languages notes to schema & renderer