### PR TITLE
Minor text converter improvements

### DIFF
--- a/data/changelog.json
+++ b/data/changelog.json
@@ -276,7 +276,7 @@
 		{
 			"ver": "0.8.0",
 			"date": "2023-03-??",
-			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering:\n - show notes on individual skills\n - fix display of multiple ACs and AC abilities\n - show ability cost entries\n - support ability entries on individual saving throws\n - add skills notes & languages notes to add non-standard entries to the respective lists\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- (A lot of Typos/Tags)"
+			"txt": "- Added Treasure Vault.\n(Thanks to @Jnosh for the following!)\n- Added the following sources:\n - Beginner Box\n - A Fistful of Flowers\n - Torment and Legacy\n - Pathfinder One-Shot: Sundered Waves\n- Fixed creature scaler being run when disabled, leading to erroneous stats.\n- Minor improvements to creature statblock rendering:\n - show notes on individual skills\n - fix display of multiple ACs and AC abilities\n - show ability cost entries\n - support ability entries on individual saving throws\n - add skills notes & languages notes to add non-standard entries to the respective lists\n- Extend property path support to additional _copy modifier modes and add a new mode that sets object properties.\n- add text converter support for creature skill notes, language notes and per saving throw abilities\n- (A lot of Typos/Tags)"
 		}
 	]
 }

--- a/js/converter.js
+++ b/js/converter.js
@@ -836,13 +836,16 @@ class Converter {
 		const stdACToken = this._consumeToken(this._tokenizerUtils.sentences);
 		ac.std = Number(stdACToken.value.trim().replace(/[,;]/g, ""));
 		if (this._tokenIsType("PARENTHESIS")) {
-			const parenthesisText = this._renderToken(this._consumeToken("PARENTHESIS")).replace(/^\(|\)$/g, "");
-			const regexOtherAC = /.*(\d+)\s(.+)/g;
-			Array.from(parenthesisText.matchAll(regexOtherAC)).forEach(m => {
-				const num = Number(m[1]);
-				// small ACs are likely abilities like "+2 vs. magic"
-				if (num > 4) ac[m[2]] = Number(m[1]);
-				else (ac.abilities = ac.abilities || []).push(m[0]);
+			const parenthesisText = this._renderToken(this._consumeToken("PARENTHESIS")).replace(/^\(|\);?$/g, "");
+			const regexOtherAC = /^(\d+)\s+(.+)$/;
+			parenthesisText.split(",").map(t => t.trim()).forEach(t => {
+				const match = regexOtherAC.exec(t);
+				if (match) {
+					ac[match[2]] = Number(match[1]);
+				} else {
+					ac.abilities = ac.abilities || [];
+					ac.abilities.push(t)
+				}
 			});
 		}
 		this._getStatAbilities(ac);

--- a/js/converter.js
+++ b/js/converter.js
@@ -859,8 +859,16 @@ class Converter {
 			savingThrows[prop] = {std: bonus};
 			if (this._tokenIsType("PARENTHESIS")) {
 				const parenthesisText = this._getParenthesisInnerText(this._consumeToken("PARENTHESIS"));
-				const regexOtherST = /\+(\d+)\s(.+)/g;
-				Array.from(parenthesisText.matchAll(regexOtherST)).forEach(m => savingThrows[prop][m[2]] = Number(m[1]));
+				const regexOtherST = /^\+(\d+)\s+(.+)$/;
+				parenthesisText.split(",").map(t => t.trim()).forEach(t => {
+					const match = regexOtherST.exec(t);
+					if (match) {
+						savingThrows[prop][match[2]] = Number(match[1]);
+					} else {
+						savingThrows[prop].abilities = savingThrows[prop].abilities || [];
+						savingThrows[prop].abilities.push(t)
+					}
+				});
 			}
 		}
 		if (this._tokenIsType(this._tokenizerUtils.fort)) {


### PR DESCRIPTION
- improve parsing of extra AC values & abilities
  - ignore trailing ';'
  - simplify & improve detection of multiple entries by assuming entries are comma separated
 
- support per saving throw abilities
  - same approach as for AC, assume the extra modifiers & abilities are comma sepparated

- basic support for language notes
  - languages always start with uppercase characters so as a heuristic, assume entries containing words starting with a lowercase character are notes
  - lowercase the detected languages in the output but retain the formatting for notes

- basic support for skill notes
  - put remaining text entries after skills into skill notes
  - handle edge case where a skill note is accidentally matched as a skill entry by enforcing that a valid skill entry always contains a bonus
  - previously, the converter supported skill entries with parenthesis entries before the skill bonus, e.g. `Deception (+12 in court) +10`. I don't think that is a thing(?) so  instead always expect the bonus before any parenthesis entries to simplify the code.