### PR TITLE
A couple of minor render improvements

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -4460,7 +4460,8 @@ Renderer.creature = {
 						renderStack.push(renderer.render(spells.join(", ")))
 					} else {
 						renderStack.push(`<span>; <strong>Constant&nbsp;</strong></span>`)
-						Object.keys(sc.entry["constant"]).sort().reverse().forEach((clvl) => {
+						Object.keys(sc.entry["constant"]).sort().reverse().forEach((clvl, idx) => {
+							if (idx !== 0) renderStack.push("; ");
 							renderStack.push(`<span><strong>(${Parser.getOrdinalForm(clvl)})&nbsp;</strong></span>`)
 							let spells = []
 							for (let spell of sc.entry["constant"][clvl].spells) {

--- a/js/render.js
+++ b/js/render.js
@@ -5142,7 +5142,8 @@ Renderer.item = {
 			}
 			const activateTextIndex = renderStack.length; // This index is referenced to see if anything is appended after the action symbol
 			if (item.activate.components != null) {
-				renderStack.push(`${renderer.render(item.activate.components)}`);
+				const components = item.activate.components.map(c => renderer.render(c));
+				renderStack.push(components.join(", "));
 			}
 			if (item.activate.frequency != null) {
 				renderStack.push(`${renderStack[activateTextIndex] ? "; " : ""}<strong>Frequency&nbsp;</strong>${renderer.render(Parser.freqToFullEntry(item.activate.frequency))}`);

--- a/js/render.js
+++ b/js/render.js
@@ -947,28 +947,32 @@ function Renderer () {
 		if (entry.traits) entry.traits.forEach((t) => traits.push(`{@trait ${t.toLowerCase()}}`));
 		if (!options.isAbility) textStack[0] += `<p class="pf2-stat pf2-stat__section">`
 		if (entry.name) textStack[0] += `<strong>${entry.name}&nbsp;</strong>`;
-		if (traits.length) textStack[0] += `(${renderer.render(traits.join(", "))}); `;
+		if (traits.length) textStack[0] += `(${renderer.render(traits.join(", "))}) `;
 		if (entry.level != null) textStack[0] += `<strong>Level&nbsp;</strong>${entry.level}; `;
 		if (entry.note != null) textStack[0] += `${this.render(entry.note)} `;
 		if (entry.DC != null || entry.savingThrow != null) {
 			textStack[0] += `<strong>Saving Throw&nbsp;</strong>`
-			if (entry.DC != null) textStack[0] += `DC ${renderer.render(entry.DC)} `
-			textStack[0] += `${renderer.render(entry.savingThrow)}.`
+			if (entry.DC != null) textStack[0] += `DC ${renderer.render(entry.DC)}`
+			if (entry.DC != null && entry.savingThrow != null) textStack[0] += " "
+			if (entry.savingThrow != null) textStack[0] += `${renderer.render(entry.savingThrow)}`
+			textStack[0] += "; "
 		}
-		if (entry.onset != null) textStack[0] += ` <strong>Onset</strong> ${renderer.render(entry.onset)}`;
-		if (entry.maxDuration != null) textStack[0] += ` <strong>Maximum Duration</strong> ${entry.maxDuration}`;
+		if (entry.onset != null) textStack[0] += `<strong>Onset</strong> ${renderer.render(entry.onset)}; `;
+		if (entry.maxDuration != null) textStack[0] += `<strong>Maximum Duration</strong> ${entry.maxDuration}; `;
 		if (entry.stages) {
 			for (let stage of entry.stages) {
-				textStack[0] += ` <strong class="no-wrap">Stage ${stage.stage}&nbsp;</strong>`;
+				textStack[0] += `<strong class="no-wrap">Stage ${stage.stage}&nbsp;</strong>`;
 				this._recursiveRender(stage.entry, textStack, meta);
-				if (stage.duration != null) textStack[0] += ` (${renderer.render(stage.duration)});`;
+				if (stage.duration != null) textStack[0] += ` (${renderer.render(stage.duration)})`;
+				textStack[0] += "; ";
 			}
 		}
 		if (entry.entries) {
-			textStack[0] += ` <strong>Effect&nbsp;</strong>`;
+			textStack[0] += `<strong>Effect&nbsp;</strong>`;
 			entry.entries.forEach(it => this._recursiveRender(it, textStack, meta));
+		} else {
+			textStack[0] = textStack[0].replace(/; $/, "");
 		}
-		textStack[0] = textStack[0].replace(/;$/, ".");
 		if (!options.isAbility) textStack[0] += `</p>`;
 	};
 


### PR DESCRIPTION
* comma separate item activation components
---
* separate constant spell levels using ; in creature statblocks
  * I had accidentally removed all ; in the constant spell list when wanting to remove only the final trailing ; that isn't present in the official statblocks
---
* minor affliction rendering improvements
  * Don't add a ; after the traits list
  * fix rendering of Saving Throw block if a DC is specified but the targeted save is not
  * Don't add a trailing period if the affliction ends with a stage without a duration entry. Most official statblocks don't end in a period in that case and periods can still be added in the stage entry itself.
  * modify the code to be a bit more regular in how the ; separators are added