### PR TITLE
Don't _copy hasImages by default

### DIFF
--- a/data/bestiary/creatures-ltiba.json
+++ b/data/bestiary/creatures-ltiba.json
@@ -234,7 +234,6 @@
 			"name": "Camilla",
 			"source": "LTiBA",
 			"page": 5,
-			"hasImages": false,
 			"description": "NE {@creature soulbound doll}",
 			"_copy": {
 				"name": "soulbound doll",
@@ -279,7 +278,6 @@
 			"name": "Lawn Crawfish",
 			"source": "LTiBA",
 			"page": 9,
-			"hasImages": false,
 			"description": "Variant {@creature reefclaw}",
 			"perception": {
 				"std": 7

--- a/data/bestiary/creatures-sot6.json
+++ b/data/bestiary/creatures-sot6.json
@@ -695,7 +695,6 @@
 					}
 				]
 			},
-			"hasImages": false,
 			"defenses": {
 				"ac": {
 					"std": 40

--- a/data/bestiary/creatures-tio.json
+++ b/data/bestiary/creatures-tio.json
@@ -14,7 +14,6 @@
 			"name": "Arisson, Mimic Prankster",
 			"source": "TiO",
 			"page": 49,
-			"hasImages": false,
 			"_copy": {
 				"name": "Mimic",
 				"source": "BB",
@@ -88,7 +87,6 @@
 			"name": "Blue Finley, Ghost Commoner",
 			"source": "TiO",
 			"page": 20,
-			"hasImages": false,
 			"_copy": {
 				"name": "Ghost Commoner",
 				"source": "BB",
@@ -169,7 +167,6 @@
 			"name": "Bomela, Troll Enforcer",
 			"source": "TiO",
 			"page": 50,
-			"hasImages": false,
 			"_copy": {
 				"name": "Troll",
 				"source": "BB",
@@ -204,7 +201,6 @@
 			"name": "Brimstone Rat",
 			"source": "TiO",
 			"page": 37,
-			"hasImages": false,
 			"_copy": {
 				"name": "Rat, Giant",
 				"source": "BB",
@@ -366,7 +362,6 @@
 			"name": "Grimstone, Gargoyle Guardian",
 			"source": "TiO",
 			"page": 35,
-			"hasImages": false,
 			"_copy": {
 				"name": "Gargoyle",
 				"source": "BB"
@@ -558,7 +553,6 @@
 			"name": "Hermonia and Laraphis, Harpies",
 			"source": "TiO",
 			"page": 48,
-			"hasImages": false,
 			"_copy": {
 				"name": "Harpy",
 				"source": "BB"
@@ -568,7 +562,6 @@
 			"name": "Karstin Star-Hand, Shadow",
 			"source": "TiO",
 			"page": 29,
-			"hasImages": false,
 			"_copy": {
 				"name": "Shadow",
 				"source": "BB",
@@ -963,7 +956,6 @@
 			"name": "Lurok, Bugbear Marauder",
 			"source": "TiO",
 			"page": 30,
-			"hasImages": false,
 			"_copy": {
 				"name": "Bugbear Marauder",
 				"source": "BB"
@@ -1626,7 +1618,6 @@
 			"name": "Slate, Gargoyle Prankster",
 			"source": "TiO",
 			"page": 49,
-			"hasImages": false,
 			"_copy": {
 				"name": "Gargoyle",
 				"source": "BB"

--- a/js/utils.js
+++ b/js/utils.js
@@ -3050,6 +3050,7 @@ DataUtil = {
 		_MERGE_REQUIRES_PRESERVE: {
 			page: true,
 			otherSources: true,
+			hasImages: true,
 		},
 		_mergeCache: {},
 		async pMergeCopy (crList, cr, options) {


### PR DESCRIPTION
Require hasImages to be added or copied explicitly.

Most of the time, it doesn't make sense to `_copy` `hasImages` since the new creature doesn't use the same images. Having to set `hasImages` to `false` is a bit cumbersome and very easy to forget.

Even if one wants to use the same image as in the source creature, the fluff entry needs to be created/copied separately anyway and if no fluff entry is added, the automatically copied `hasImages` results in an empty images tab.