### PR TITLE
Improve creature spellcasting & ritual tradition/type data & filters

### DIFF
--- a/data/bestiary/creatures-afof.json
+++ b/data/bestiary/creatures-afof.json
@@ -435,7 +435,7 @@
 			"spellcasting": [
 				{
 					"name": "Primal Innate",
-					"tradition": "Primal",
+					"tradition": "primal",
 					"type": "Innate",
 					"DC": 16,
 					"entry": {
@@ -600,7 +600,7 @@
 			"spellcasting": [
 				{
 					"name": "Primal Innate",
-					"tradition": "Primal",
+					"tradition": "primal",
 					"type": "Innate",
 					"DC": 16,
 					"entry": {
@@ -738,7 +738,7 @@
 			"spellcasting": [
 				{
 					"name": "Primal Innate",
-					"tradition": "Primal",
+					"tradition": "primal",
 					"type": "Innate",
 					"DC": 16,
 					"entry": {
@@ -889,7 +889,7 @@
 			"spellcasting": [
 				{
 					"name": "Primal Innate",
-					"tradition": "Primal",
+					"tradition": "primal",
 					"type": "Innate",
 					"DC": 16,
 					"entry": {

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -122,7 +122,7 @@
 			"spellcasting": [
 				{
 					"name": "Occult Spontaneous",
-					"tradition": "Occult",
+					"tradition": "occult",
 					"type": "Spontaneous",
 					"DC": 33,
 					"attack": 25,

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -31978,7 +31978,7 @@
 			"spellcasting": [
 				{
 					"name": "Divine Innate",
-					"tradition": "Divine",
+					"tradition": "divine",
 					"type": "Innate",
 					"DC": 42,
 					"entry": {

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -1791,7 +1791,7 @@
 			"spellcasting": [
 				{
 					"name": "Divine Innate",
-					"tradition": "Divine",
+					"tradition": "divine",
 					"type": "Innate",
 					"DC": 26,
 					"entry": {

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -1827,7 +1827,7 @@
 			],
 			"rituals": [
 				{
-					"tradition": "Divine",
+					"tradition": "divine",
 					"DC": 26,
 					"rituals": [
 						{

--- a/data/bestiary/creatures-ec6.json
+++ b/data/bestiary/creatures-ec6.json
@@ -569,7 +569,7 @@
 			"spellcasting": [
 				{
 					"name": "Divine Innate",
-					"tradition": "Divine",
+					"tradition": "divine",
 					"type": "Innate",
 					"DC": 38,
 					"entry": {

--- a/data/bestiary/creatures-tal.json
+++ b/data/bestiary/creatures-tal.json
@@ -30,7 +30,7 @@
 			"spellcasting": [
 				{
 					"name": "Primal Prepared",
-					"tradition": "Primal",
+					"tradition": "primal",
 					"type": "Prepared",
 					"DC": 21,
 					"attack": 11,

--- a/data/bestiary/creatures-tio.json
+++ b/data/bestiary/creatures-tio.json
@@ -461,7 +461,7 @@
 			"spellcasting": [
 				{
 					"name": "Divine Prepared",
-					"tradition": "Divine",
+					"tradition": "divine",
 					"type": "Prepared",
 					"DC": 21,
 					"attack": 13,
@@ -1040,7 +1040,7 @@
 				{
 					"name": "Arcane Prepared",
 					"type": "Prepared",
-					"tradition": "Arcane",
+					"tradition": "arcane",
 					"DC": 21,
 					"attack": 13,
 					"entry": {

--- a/js/converter.js
+++ b/js/converter.js
@@ -1044,7 +1044,7 @@ class Converter {
 		casting.name = name;
 		const tradition = this._tokenizerUtils.spellTraditions.find(it => it.regex.test(name));
 		const type = this._tokenizerUtils.spellTypes.find(it => it.regex.test(name));
-		if (tradition) casting.tradition = tradition.unit;
+		if (tradition) casting.tradition = tradition.unit.toLowerCase();
 		if (type) casting.type = type.unit;
 		else casting.type = "Focus";
 		this._parseSpells_parseProperties(casting);

--- a/js/converter.js
+++ b/js/converter.js
@@ -1194,7 +1194,7 @@ class Converter {
 		const reRitualCast = this._tokenizerUtils.ritualCasting.find(it => it.regex.test(castingToken.value)).regex;
 		const name = reRitualCast.exec(castingToken.value)[1].trim();
 		const tradition = this._tokenizerUtils.spellTraditions.find(it => it.regex.test(name));
-		if (tradition) ritualCasting.tradition = tradition.unit;
+		if (tradition) ritualCasting.tradition = tradition.unit.toLowerCase();
 		this._parseSpells_parseProperties(ritualCasting);
 		ritualCasting.rituals = [...this._parseSpells_parseSpells()];
 		creature.rituals.push(ritualCasting);

--- a/js/converter.js
+++ b/js/converter.js
@@ -1045,7 +1045,7 @@ class Converter {
 		const tradition = this._tokenizerUtils.spellTraditions.find(it => it.regex.test(name));
 		const type = this._tokenizerUtils.spellTypes.find(it => it.regex.test(name));
 		if (tradition) casting.tradition = tradition.unit.toLowerCase();
-		if (type) casting.type = type.unit;
+		if (type) casting.type = type.unit.toTitleCase();
 		else casting.type = "Focus";
 		this._parseSpells_parseProperties(casting);
 		casting.entry = this._parseSpellEntry();

--- a/js/filter-bestiary.js
+++ b/js/filter-bestiary.js
@@ -178,7 +178,7 @@ class PageFilterBestiary extends PageFilter {
 		if (cr.skills) {
 			Object.keys(cr.skills).forEach((k) => {
 				if (k.match(/lore/i)) cr._fskills.add("Lore");
-				else cr._fskills.add(k);
+				else if (k !== "notes") cr._fskills.add(k.toTitleCase());
 			})
 		}
 		cr._fskills = Array.from(cr._fskills);

--- a/js/filter-bestiary.js
+++ b/js/filter-bestiary.js
@@ -205,7 +205,9 @@ class PageFilterBestiary extends PageFilter {
 		if (cr.spellcasting) {
 			cr.spellcasting.forEach((f) => {
 				if (f.type !== "Focus") {
-					cr._fSpellTypes.push(`${f.type} ${f.tradition}`)
+					if (f.type && f.tradition) cr._fSpellTypes.push(`${f.type} ${f.tradition}`.toTitleCase())
+					else if (f.type) cr._fSpellTypes.push(`${f.type}`.toTitleCase())
+					else cr._fSpellTypes.push(`${f.tradition}`.toTitleCase())
 				} else cr._fSpellTypes.push(f.type)
 				Object.keys(f.entry).forEach((k) => {
 					if (k.isNumeric() && Number(k) > cr._fHighestSpell) cr._fHighestSpell = Number(k)
@@ -216,7 +218,7 @@ class PageFilterBestiary extends PageFilter {
 		cr._fRitualTraditions = []
 		if (cr.rituals != null) {
 			cr.rituals.forEach((r) => {
-				cr._fRitualTraditions.push(r.tradition)
+				if (r.tradition) cr._fRitualTraditions.push(r.tradition.toTitleCase())
 			});
 		}
 		cr._fCreatureType = []

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -216,6 +216,14 @@ function updateFolder (folder) {
 							return k
 						})
 					}
+					if (cr.spellcasting && cr.spellcasting.length) {
+						cr.spellcasting = cr.spellcasting.map(k => {
+							if (k.tradition) {
+								k.tradition = k.tradition.toLowerCase();
+							}
+							return k
+						})
+					}
 					return cr;
 				});
 			}

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -218,6 +218,9 @@ function updateFolder (folder) {
 					}
 					if (cr.spellcasting && cr.spellcasting.length) {
 						cr.spellcasting = cr.spellcasting.map(k => {
+							if (k.type) {
+								k.type = k.type.toTitleCase();
+							}
 							if (k.tradition) {
 								k.tradition = k.tradition.toLowerCase();
 							}

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -227,6 +227,14 @@ function updateFolder (folder) {
 							return k
 						})
 					}
+					if (cr.rituals && cr.rituals.length) {
+						cr.rituals = cr.rituals.map(k => {
+							if (k.tradition) {
+								k.tradition = k.tradition.toLowerCase();
+							}
+							return k
+						})
+					}
 					return cr;
 				});
 			}


### PR DESCRIPTION
Ensure spellcasting/ritual traditions are stored as lowercase and spellcasting type is stored as title case to match schema.
* Adjust text converter to ensure correct case for these
* Add these to update-jsons as well
* Show related filters in title case to match statblock display
* Adjust existing data



