### PR TITLE
Exclude creature description from _copy by default

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -3056,6 +3056,7 @@ DataUtil = {
 			page: true,
 			otherSources: true,
 			hasImages: true,
+			description: true,
 		},
 		_mergeCache: {},
 		async pMergeCopy (crList, cr, options) {


### PR DESCRIPTION
Like `hasImages` before, exclude creature `description` from _copy by default.

The description usually only applies to the original creature and a creature that extends it using _copy generally has a separate description or none at all.
