### PR TITLE
Archetype rarity cleanup

### DIFF
--- a/data/archetypes.json
+++ b/data/archetypes.json
@@ -48,7 +48,8 @@
 			"entries": [
 				"The mental landscape of the psychic duel rises to meet your steps and reshapes at your touch. You understand the binary mindscape links two minds, making its foundation only as strong as the wills of those involved. Two psychic castles in a siege\u2014patch every loose brick in your walls and single out every flaw in your foe's defenses."
 			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "rare"
 		},
 		{
 			"name": "Chronoskimmer",
@@ -59,7 +60,8 @@
 				"Now you stand on the banks of the river, watching the flow, choosing where to dive in, or even defying the current, at least for a short while, as you skim its surface and skip from moment to moment. As a chronoskimmer, time is yours to exploit.",
 				"You have the means to see the timelines of all creatures, including your own. You can use this insight to manipulate the flow of time for creatures, much like you can pluck the leaf from the river and place it elsewhere. Manipulating timelines can be dangerous, however, and the {@place Dimension of Time} won't allow these transgressions against time to stand forever. The threat always looms of time dimensionals coming to correct your actions or of you becoming removed from time forever."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Time Mage",
@@ -76,7 +78,8 @@
 				"16|Plot the Future|APG",
 				"20|Echoing Spell|APG"
 			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Curse Maelstrom",
@@ -95,7 +98,8 @@
 				"Living with a curse every day, you become intimately familiar with the workings of curses, getting a sense of when bad luck is about to befall those around you. You might try to avoid further bad fortune\u2014which rarely pans out as you'd like\u2014or you could come to terms with your lot in life and regard your curse as something akin to an old friend. Either way, fate cares little.",
 				"Misery loves company, so your curse can even be a beacon for more misfortune. You might have multiple curses all tied to you, all fighting to make your life as hellish as possible."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Pactbinder",
@@ -106,7 +110,8 @@
 				"As a pactbinder, you make deals with strange entities, otherworldly beings, and all sorts of multiversal denizens, amiable and unapproachable alike. Over the course of your many negotiations, you've learned something important: while such beings always seek a bargain tilted in their own favor, sometimes your definition of value differs enough from theirs that you can still come out ahead. In fact, sometimes, those who don't understand pacts like you do might mistake the payment for the benefit, or vice versa. Perhaps an ancient being of nightmare demanded to consume something you sought to be rid of, like a painful memory or a negative personality trait, priding itself on how it was taking something personal from you. Little did it know, you let it win on haggling your end of the deal. Of course, this practice isn't without its own risks, as who knows what you might become without that part of you.",
 				"All these things, you can and must consider in every pact. In addition to pacts, you might also pursue magical contracts. While less of a metaphysical commitment than a pact, contracts offer similar benefits you just can't resist\u2014 and you can employ your skill set as a pactbinder to manipulate the precise wording of the bargain."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Living Vessel",
@@ -118,7 +123,8 @@
 				"Beings of any alignment can inhabit a living vessel. Evil-aligned beings, especially demons, are most likely to be interested in such an arrangement, especially if it involves forcefully taking over and changing the body and mind of a sapient being. Part of being a living vessel is learning more about your entity and finding what assuages them best and what their ultimate plans might be for your body and the world. Few vessels can fully dictate the terms of the arrangement, but the fact that you give the entity a corporeal form does give you some amount of leverage. Use it wisely.",
 				"{@b Additional Feats:} Your GM might determine that you can take a pact feat from the {@archetype pactbinder|DA} archetype as an additional feat, as long as the pact is made to the entity within you. For instance, if you're hosting a fey, you could make a pact involving fey. These pact feats are at the same level as for a pactbinder. "
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Alter Ego",
@@ -137,7 +143,8 @@
 				"A highly guarded castle in the middle of an extravagant ball, the headquarters of a city's infamous thieves' guild, the locked room in the back of a cultist hideout\u2014all perfect targets for you to use your expertise at blending in. Rather than skulking through the shadows, you use your training and latent supernatural abilities to become a mirror, playing on the perceptions of others and taking on whatever role necessary to get in and out of your destination before anyone has a chance to think something is amiss.",
 				"Performing an alter ego means going unregarded. Passing as just a face in the crowd is crucial, and accolades come as the gratitude from your leaders or coin from your clients, rather than the awed adoration from a crowd. This arrangement might suit you fine, as you thrive in a job well done and on the thrill of walking flagrantly past your duped adversaries. Or it might become pent up, until you can't resist a dramatic reveal or a signature calling card that shows you were there. One final word before speeding away from the castle, a gloating message left behind, or some other sign reveals your skill\u2014usually too late for your victims to do anything about it."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Thaumaturge",
@@ -220,10 +227,8 @@
 			"entries": [
 				"You have sworn the Aldori swordpact and study the art of Aldori dueling, a famed school of bladecraft which has been passed down for over a millennium from the teachings of Baron Sirian Aldori. One day, you hope to demonstrate your skill at swordplay in order to become acknowledged as a true swordlord."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Animal Trainer",
@@ -232,10 +237,8 @@
 			"entries": [
 				"You have befriended an animal to serve as an able assistant and loyal guardian."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Archaeologist",
@@ -335,7 +338,8 @@
 				"10|Snap Shot|CRB",
 				"18|Instant Opening|CRB"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Clockwork Reanimator",
@@ -347,7 +351,8 @@
 				"The secret to your success is a combination of alchemy and clockwork, machines and magic, science and spellcasting. Of course, crafting the shell of a wind-up zombie is one matter\u2014your primary focus is on the craftwork necessary to make the whole thing work together. To you, the magic involved is only a means to an end, a way to make science more efficient through necromancy and potentially a little bit of evocation for some electric power.",
 				"While some think your creations are vile, you see beauty in utility and believe animated corpses are tools that can be used for good or ill. For better or worse, when it comes to results, the science you've cobbled together fulfills the most important criterium for any new innovation: it works, plain and simple. Your reanimated clockwork corpses are stable, effective, and, more importantly, they don't rampage or crave the flesh of the living in the same way an undead would. Plus, they aren't vulnerable to positive energy, making them easier to use around good clerics and their ilk without your minions taking friendly fire. (Except Pharasmins, always so inconveniently up in arms about the whole \"desecrating the bodies of the dead\" thing. They can't learn the difference between the stench of undeath and the smell of progress.)"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Bard",
@@ -407,10 +412,8 @@
 			"extraFeats": [
 				"8|Call Gun|G&G"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Beastmaster",
@@ -453,10 +456,8 @@
 			"entries": [
 				"Bellflower tillers handle most of the ground-level efforts of freeing slaves and escorting them to safety. They use farming-related code words to hide their work: a tiller's freed slaves are her \"crop,\" which she moves along secretive paths termed \"rows,\" taking shelter in secret hideouts referred to as \"barns.\""
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Blessed One",
@@ -497,7 +498,8 @@
 			"entries": [
 				"You are one of the Bright Lions, part revolutionary warrior, part undercover spy."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Bullet Dancer",
@@ -515,10 +517,8 @@
 				"16|Showstopper|G&G",
 				"16|Two-Weapon Fusillade|G&G"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Butterfly Blade",
@@ -533,10 +533,8 @@
 				"4|Quick Draw (Ranger)|CRB",
 				"4|Dread Striker|CRB"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Captivator",
@@ -778,10 +776,8 @@
 			"benefits": [
 				"Spellcasting"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Cavalier",
@@ -866,10 +862,8 @@
 			"entries": [
 				"In the era before Earthfall, the elven people of Golarion exhibited a wide range of mastery over magic. A sect of elves who venerated the goddess Yuelral first developed the techniques of the crystal keeper, but this tradition has since been long forgotten by most of the world. There are those who still remember, though\u2014PCs can gain access to the crystal keeper archetype from the tragic figure that haunts Jewelgate waystation in \"Fires of the Haunted City.\""
 			],
-			"traits": [
-				"rare"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "rare"
 		},
 		{
 			"name": "Dandy",
@@ -893,10 +887,8 @@
 				"8|Directional Bombs|CRB",
 				"12|Expanded Splash|CRB"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Dragon Disciple",
@@ -915,10 +907,8 @@
 					]
 				}
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Drow Shootist",
@@ -927,10 +917,8 @@
 			"entries": [
 				"Some drow take skill with the hand crossbow to new heights. You've learned the secrets of these fabled drow shootists. With fearlessness and swagger, you can accomplish amazing deeds with hand crossbows."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Druid",
@@ -994,10 +982,8 @@
 			"entries": [
 				"You're a specially trained detective for the Edgewatch guard precinct in Absalom."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Eldritch Archer",
@@ -1032,10 +1018,8 @@
 				"You've been particularly enlightened by the accumulated lore in Thresholds of Truth, and you know Zarmavdian was a kindred soul in occult research. With this book in hand, you feel like you stand at the doorway to unprecedented occult discoveries.",
 				"You scoff at those fools who claim you meddle in things mortals aren't meant to know\u2014for isn't it the duty of the enlightened to gather the universe's deepest truths?"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Elementalist",
@@ -1117,10 +1101,8 @@
 			"entries": [
 				"Many Firebrands travel the Inner Sea region drawing attention to themselves, making great shows of their exploits, and proclaiming their great deeds."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Firework Technician",
@@ -1138,10 +1120,8 @@
 					]
 				}
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Flexible Spellcaster",
@@ -1217,10 +1197,8 @@
 			"entries": [
 				"Folklorists are welcome across the Mwangi Expanse for the entertaining stories they tell and the counsel they impart. However, those who take the art of storytelling to the next level can produce magical effects based on their understanding of stories and their firm belief that life conforms to the contours of these tales. While many such folklorists are benevolent, terms like hero and villain are notoriously relative, changing to fit the perspective of the storyteller."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Geomancer",
@@ -1239,10 +1217,8 @@
 			"entries": [
 				"The warriors of Minata frequently contend with lost spirits of the Taumatan people that haunt their shattered lands to this day. These Minatan warriors, known as ghost eaters around Bonmu, travel the countless islands of Minata and offer their skills to exorcists and priests. When working in such a partnership, ghost eater's main task is to destroy a spirit in order to give their holy comrade time to learn about the individual soul and finally put it to rest."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Ghost Hunter",
@@ -1252,10 +1228,8 @@
 				"Ghosts have a wide range of capabilities and features\u2014 no two ghosts are exactly alike, as the nature of their abilities depends as much upon who they were in life as on how they died. Haunts, the spectral phenomena remaining in a site of death or powerful emotions, are related to but distinct from ghosts.",
 				"The ghost hunter knows that ghosts and haunts share many features. By focusing on these similarities, they can track down, confront, and defeat all manner of unquiet souls, helping them to find peace and move on to the afterlife."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Gladiator",
@@ -1274,10 +1248,8 @@
 			"entries": [
 				"You've become a xun, a powerful gang enforcer."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 8
+			"dedicationLevel": 8,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Golem Grafter",
@@ -1286,10 +1258,8 @@
 			"entries": [
 				"You have replaced a portion of your body with artifice of the kind used to create golems, fortifying your flesh with the unyielding might of magical constructs."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 8
+			"dedicationLevel": 8,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Gray Gardener",
@@ -1300,10 +1270,8 @@
 				"The following is suitable for heroes to take after the events of Night of the Gray Death. You might be a member of the old organization who tried to uphold order despite vindictive directives from above, or you might be someone who recently donned a mask to enforce the law in Galt's new age. Either way, as a Gray Gardener you draw power and authority from being masked and have a reputation for dispassionate justice.",
 				"Your vigilante identity is that of a Gray Gardener, and you must be wearing a mask to use any of your vigilante feats or you risk exposing your social identity, as described in the {@archetype vigilante|APG} archetype."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Gunslinger",
@@ -1322,7 +1290,8 @@
 			"miscTags": [
 				"Multiclass"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Halcyon Speaker",
@@ -1331,10 +1300,8 @@
 			"entries": [
 				"One of Old-Mage Jatembe's central lessons was that magic was magic, no matter what the source. Though the Magaambya seeks to hold true to Jatembe's teachings by aiming to understand magic of all kinds, the mages of the Magaambya have found the most success with magic rooted in the material world. Halcyon speakers are powerful conversants who epitomize the Magaambyan practice of blending arcane and primal magic, seeing both traditions as flowing from the same wellspring."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Hellknight",
@@ -1343,10 +1310,8 @@
 			"entries": [
 				"Hellknights are among the fiercest warriors in the Inner Sea region, as they have emerged from hell-forged trials ready to serve as faceless bastions of law wherever chaos might threaten to rear."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Hellknight Armiger",
@@ -1355,10 +1320,8 @@
 			"entries": [
 				"You have presented yourself to a Hellknight citadel as a candidate to become a fearsome Hellknight. You believe that all who live must be forced to obey law, and you adventure as a test of your loyalty, discipline, and courage. Someday you will take the Hellknight test and battle a devil in single combat to prove your strength and join the Hellknight ranks."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Hellknight Signifer",
@@ -1367,10 +1330,8 @@
 			"entries": [
 				"Signifers are the powerful and enigmatic Hellknight spellcasters who support and sometimes lead other Hellknights on their missions to enforce unwavering law. Formidable in their own right, signifers are trained to be unstoppable forces of order and authority when they stand alongside their martial counterparts."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Herbalist",
@@ -1415,7 +1376,8 @@
 			"miscTags": [
 				"Multiclass"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Investigator",
@@ -1443,10 +1405,8 @@
 			"entries": [
 				"Certain martial artists dedicate themselves to fighting in Jalmeray's Challenge of Sky and Heaven; these individuals devote themselves to the esoteric mysteries of the sky and incorporate these lofty abilities into their martial arts maneuvers. You may have learned these skills from the Houses of Perfection in Jalmeray, or from a practitioner of this style who left Jalmeray bearing its secrets (such as Shristi Melipdra). The Houses of Perfection focus on honing elemental powers, but the Jalmeri heavenseeker isn't limited by the powers of air alone. This style's attacks emulate darting flashes of lightning and the crash of thunder from roiling storm clouds. A true practitioner masters control even over dense matter, causing the air to support its weight or bring it crashing down."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Juggler",
@@ -1455,10 +1415,8 @@
 			"entries": [
 				"You're a skilled performer, with impressive balance and coordination that help you greatly in battle."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Knight Reclaimant",
@@ -1466,9 +1424,6 @@
 			"page": 74,
 			"entries": [
 				"Knights reclaimant spend much of their time amid the horrors of the Gravelands, rescuing civilians that remain and striking back against the Whispering Tyrant's agents. Accomplishing these goals requires the adoption of subtle tactics, with a focus on stealth and survival."
-			],
-			"traits": [
-				"uncommon"
 			],
 			"otherSources": {
 				"Expanded": [
@@ -1481,7 +1436,8 @@
 				"12|Camouflage|CRB",
 				"12|Sneak Savant|CRB"
 			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Knight Vigilant",
@@ -1489,9 +1445,6 @@
 			"page": 94,
 			"entries": [
 				"Taking their lead from heroic stories of the Shining Crusade, the knights vigilant stand as a courageous example of morality and honor."
-			],
-			"traits": [
-				"uncommon"
 			],
 			"otherSources": {
 				"Expanded": [
@@ -1502,7 +1455,8 @@
 				"8|Shield Warden (Fighter)|CRB",
 				"12|Mirror Shield|CRB"
 			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Lastwall Sentry",
@@ -1511,10 +1465,8 @@
 			"entries": [
 				"While the nation of Lastwall is gone, leaving only the horror of the Gravelands behind, you refuse to give up and renounce your oaths. You've renewed your vows, swearing to combat the influence of the Whispering Tyrant wherever it might strike across Golarion."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Linguist",
@@ -1532,10 +1484,8 @@
 			"entries": [
 				"You've trained as a spy in service of Taldor, learning secrets of disguise, manipulating crowds, and deceiving various sorts of magic users with ease. You likely dropped out of the Kitharodian Academy, Taldor's premier bardic college, in order to train at one of the Lion Blade's elite Shadow Schools."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Living Monolith",
@@ -1544,10 +1494,8 @@
 			"entries": [
 				"You have delved into ancient sphinx magic to imbue your body and soul with the patience and strength of stone, as you work to create a special magical ka stone to finalize your oaths."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Loremaster",
@@ -1571,10 +1519,8 @@
 			"entries": [
 				"Magaambyans attendants have become full members of the Magaambya and begun to learn the secrets of the university. Not all Magaambyan attendants necessarily have this archetype, and this archetype doesn't represent the abilities of all attendants; rather, the archetype represents many of those who have affiliated with a branch and are pursuing conversant rank."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Magic Warrior",
@@ -1583,10 +1529,8 @@
 			"entries": [
 				"You mix magic and martial prowess, following in the tradition of the Ten Magic Warriors of Old-Mage Jatembe."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Magus",
@@ -1703,10 +1647,8 @@
 			"entries": [
 				"The Chime-Ringers serve as Nantambu's elite town guard, keeping the peace while carrying on ancient traditions of crafting chimes in metal, bamboo, or glass."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Oozemorph",
@@ -1715,10 +1657,8 @@
 			"entries": [
 				"You have suffered from the deadly touch of an ooze or other amorphous creature, like a gibbering mouther or a shoggoth, and have come away changed. Alternatively, you might have been exposed to some alchemical accident involving experiments with oozes, such as those performed in the city of Oenopion in Nex. Parts of your body occasionally liquefy and threaten to slough off, and only through force of will can you keep your natural form intact. Your affliction is plainly supernatural in origin and distressingly permanent."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Oracle",
@@ -1744,10 +1684,8 @@
 				"As a group's overwatch, you might let the position go to your head. In such cases, you might think of yourself as the mastermind behind the chessboard and feel detached from your allies, thinking of them as little more than pawns on the field.",
 				"But more likely your role allows you to feel a deeper connection to your allies, and your coordination and heroics stand out most when you subsume your individual ego to serve the group's needs. In that case, you might think of yourself as a part of a functional whole\u2014if your party was a single living body, you serve as the eyes, but that doesn't mean you're the brain, the heart, or other vital organs. Everyone has a crucial role to play."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Pathfinder Agent",
@@ -1756,10 +1694,8 @@
 			"entries": [
 				"You're a field agent of the globe-trotting Pathfinder Society, sworn to report, explore, and cooperate. You explore the world, gathering artifacts and antiquities, and record your adventures for posterity."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Pirate",
@@ -1799,10 +1735,8 @@
 				"12|Trick Shot|G&G",
 				"16|Showstopper|G&G"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Poisoner",
@@ -1834,10 +1768,8 @@
 			"entries": [
 				"The provocator is a gladiator who mixes brilliant performance with mastery of weapons."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 10
+			"dedicationLevel": 10,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Ranger",
@@ -1875,10 +1807,8 @@
 			"entries": [
 				"You are a Red Mantis assassin, inducted by the mantis god and sworn to chase your prey to the end of the world and beyond."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Ritualist",
@@ -1887,10 +1817,8 @@
 			"entries": [
 				"While some learn the art of ritual casting through rigorous study, other gifted individuals may find that a combination of natural talent and luck gives them surprising skill at performing rituals, whether they want that power or not."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Rogue",
@@ -2020,10 +1948,8 @@
 			"miscTags": [
 				"Class Archetype"
 			],
-			"traits": [
-				"rare"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Runescarred",
@@ -2032,10 +1958,8 @@
 			"entries": [
 				"The rune magic of Thassilon and its descendant nations has left its mark on your very flesh. As a runescarred, you have an unusually close connection to this ancient magic, which has become a newly emerging field of study for small pockets of interested scholars in both Varisia and New Thassilon."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Scout",
@@ -2068,10 +1992,8 @@
 			"entries": [
 				"Members who align themselves with the Scrolls branch of the Pathfinder Society are fervent seekers of lore, experts in esoterica, and masters of the wealth of knowledge at the Society's disposal. In addition to maintaining and researching the Society's massive collection of tomes and artifacts, these scholars are also eager to adventure in order to add to the Pathfinder's archives. They take tremendous pride in their ability to thoroughly observe, research, and catalog creatures and events. Members of the Scrolls value knowledge and preparation above strength and cunning, and they work to hone their intellectual skills. As a Scrollmaster, you are an elite member of this arm of the Society."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Scrounger",
@@ -2080,10 +2002,8 @@
 			"entries": [
 				"You have spent countless hours disassembling and rebuilding complex items to learn how they work, giving you the skill to create just about anything from the most unlikely materials. While your improvised items don't last long, they tend to be just what you need in a pinch, and your enemies find that while they might be able to disarm you, the real challenge is keeping you that way. Locked rooms, diabolical traps, and desperate situations are each their own sort of puzzle to you, and the mundane objects around you are the pieces you use to improvise your own solution."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Sentinel",
@@ -2113,10 +2033,8 @@
 				"14|Shadow Illusion|APG",
 				"16|Shadow Power|APG"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Shadowdancer",
@@ -2151,10 +2069,8 @@
 			"entries": [
 				"The Sixth Pillar follows a tradition that blends martial arts with magic. Traditionally, this is a way to better focus and harness innate or bloodline magic, but it can be used by anyone who can cast spells."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 8
+			"dedicationLevel": 8,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Snarecrafter",
@@ -2248,10 +2164,8 @@
 					]
 				}
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Spell Trickster",
@@ -2278,10 +2192,8 @@
 			"entries": [
 				"Those who train under the Master of Spells concern themselves with all matters related to magic. Though not all members of the School of Spells are spellcasters, those who would become Spellmasters of the highest rank and influence have at least some spellcasting capabilities."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Spellshot",
@@ -2511,10 +2423,8 @@
 			"miscTags": [
 				"Class Archetype"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Staff Acrobat",
@@ -2523,10 +2433,8 @@
 			"entries": [
 				"You can perform amazing acts in and out of combat when you have a spear, staff, or polearm."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Sterling Dynamo",
@@ -2538,10 +2446,8 @@
 				"With the sterling dynamo archetype, you both use a sterling dynamo prosthesis and truly understand its advantages, limitations, and limitless potential. You don't have to literally be your own mechanic, as there's no requirement for a sterling dynamo to be particularly skilled at crafting, but even if you aren't, you can still \"feel\" what's right when it comes to adjusting and optimizing your dynamo. Whether you implement these improvements yourself or present your mechanic with ideas and insights that allow them to achieve something special on your behalf, your strength and ingenuity are what make you a sterling dynamo.",
 				"As you train to use your dynamo in all sorts of adventures, you may become capable of feats its original inventors never dreamed possible. In fact, as you progress in the archetype and explore the possibilities, you might find that these inventors want to interview you in order to apply your insights and help them create a new generation of the technology with even greater capabilities. The sterling dynamo's adaptability grants it vast potential, so the sky's the limit!"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Student of Perfection",
@@ -2550,10 +2456,8 @@
 			"entries": [
 				"You studied martial arts at Jalmeray's Houses of Perfection."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Summoner",
@@ -2620,10 +2524,8 @@
 			"entries": [
 				"Though the ultimate goal of the Pathfinder society is to learn, knowledge cannot be spread if those who discover it fail to come back alive. The Master of Swords teaches recruits to survive, to defend other Pathfinders, and to defeat the Society's enemies. The swordmaster embodies these skills, focusing on practicality and ignoring ideals or methods that interfere with their ability to overcome any challenge."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 6
+			"dedicationLevel": 6,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Talisman Dabbler",
@@ -2642,10 +2544,8 @@
 				"Wielding a wrench or blowtorch, you manufacture snares that whir and tick with delicate precision. Your best work requires the right materials\u2014a glorious set of brass fittings and cogwheels\u2014with which you create snares that are as elegantly lethal as they are subtle. As a trapsmith, you're always improving your snares: adjusting timing, tweaking triggers, and finding new ways to hide them from foes.",
 				"You can select the dedication feat for the trapsmith archetype even if you haven't yet gained three feats from the {@archetype snarecrafter|APG} archetype."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 4
+			"dedicationLevel": 4,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Trick Driver",
@@ -2654,10 +2554,8 @@
 			"entries": [
 				"While cavaliers follow an old and tired tradition of mounted combat, you take a more modern road. Through aggressive use of vehicles, you roll across the battlefield, taking down your opponents. You go beyond simply operating a vehicle, pushing it to perform stunts that its builders never intended, transforming the vehicle into something much greater than a mere conveyance."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Turpin Rowe Lumberjack",
@@ -2666,10 +2564,8 @@
 			"entries": [
 				"You are a feller of trees and a skilled axe wielder, trained in the art of forestry by the hard-working loggers of Turpin Rowe."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Unexpected Sharpshooter",
@@ -2700,10 +2596,8 @@
 				"4|Risky Reload|G&G",
 				"10|Trick Shot|G&G"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Vehicle Mechanic",
@@ -2713,10 +2607,8 @@
 				"You have always felt that vehicles are as much works of art as they are means of transportation. It doesn't matter if it's as common as a chariot or as complex as an airship, there's always some aspect of the vehicle you can improve upon. Pilots, drivers, and sailors alike value your expertise, and many seek you out to work on their vehicles. While you can make a great profit working on custom vehicles for wealthy clients, you still keep a vehicle of your own to tinker with as your personal passion project.",
 				"You might be part of a vehicle mechanic union, working with other mechanics and engineers to find fair jobs and support each other's labor. While some vehicle mechanic unions are secular, many realize the benefits of organizing alongside a sympathetic religion, and so they typically adopt the ideals of economically-focused gods like Abadar or deities interested in crafting such as the goddess Brigh\u2014the Whisper in Bronze\u2014the goddess of invention. Whether religious or secular, vehicle mechanic unions take the bonds between fellow union members seriously. While this might mean your character becomes obligated to help a fellow union member who needs your help, it also means you have steadfast allies you can fall back on in your own time of need. In dire straits, such a connection can be worth its weight in gold."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Vigilante",
@@ -2728,10 +2620,8 @@
 			"extraFeats": [
 				"4|Quick Draw (Rogue)|CRB"
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Viking",
@@ -2917,10 +2807,8 @@
 			"miscTags": [
 				"Class Archetype"
 			],
-			"traits": [
-				"rare"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Witch",
@@ -2991,10 +2879,8 @@
 			"entries": [
 				"You are one of the Zephyr Guard, professional soldiers who protect Katapesh from military threats, economic sabotage, and elite thieves."
 			],
-			"traits": [
-				"uncommon"
-			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Undead Master",
@@ -3013,7 +2899,8 @@
 				"14|Specialized Beastmaster Companion|APG",
 				"16|Lead the Pack|APG"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Exorcist",
@@ -3086,7 +2973,8 @@
 				"The exact origin of hallowed necromancers' abilities may vary from one to the next. Some are granted their gifts directly by a sympathetic deity such as {@deity Sarenrae} or {@deity Pharasma}, while others might use their knowledge of religion and the planes to learn such abilities on their own. Though rarer, it's even possible these practitioners might discover they possess an intuitive understanding and control over abilities that manifest spontaneously as their capabilities grow. Despite this variance, all share a fundamental understanding that undeath is an aberration to be quickly remedied.",
 				"Though the majority of hallowed necromancers have similar goals and are willing to work together, they tend not to form their own organizations. More often, these necromancers attach themselves to existing groups\u2014such as the {@organization Knights of Lastwall} or Voices of the Spire\u2014and use their powers in support of those groups' causes. Otherwise, they plan and carry out their own personal vendettas against the forces of undeath, often enlisting the help of trusted friends and allies."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "uncommon"
 		},
 		{
 			"name": "Soul Warden",
@@ -3153,7 +3041,8 @@
 				},
 				"Your ties to the living world cling to you in death, your unfinished business reducing you to a spirit. Your soul carries on, but your body is gone. Your mind, too, may have changed: though death can impact thoughts and desires in all sorts of ways, most ghosts experience stronger, more volatile emotions and are frequently overcome by their past ties. A need to reconcile the past overwhelms other needs. Motivations can change over time but are always strong. Pragmatism, compassion, and foresight fall before a ghost's fundamental desires. "
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Ghoul",
@@ -3181,7 +3070,8 @@
 				"6|Reactive Pursuit|CRB",
 				"10|Wall Run|CRB"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Lich",
@@ -3206,7 +3096,8 @@
 			"extraFeats": [
 				"14|Magic Sense (Wizard)|CRB"
 			],
-			"dedicationLevel": 12
+			"dedicationLevel": 12,
+			"rarity": "rare"
 		},
 		{
 			"name": "Mummy",
@@ -3219,7 +3110,8 @@
 				"Very rarely, mummies are created by natural processes occurring in locations that are cursed or inundated by negative energy. These mummies most often rise in deserts, bogs, swamps, at high altitudes, or in frigid locales. Although the process through which they are created is less painful and far shorter in duration, the spiritual shift from living to undead is no less traumatizing.",
 				"Mummies are most commonly found in Geb and Osirion, as well as the surrounding nations of Thuvia, Katapesh, and Qadira. They have a foothold in the Gravelands, the Realm of the Mammoth Lords, and the Mwangi Expanse, particularly around Mzali. Outside the Inner Sea, mummies are found in Vudra and Arcadia, particularly in places once ruled by the Razatlani empire."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Vampire",
@@ -3239,7 +3131,8 @@
 				},
 				"After being exsanguinated by a vampire, you've risen again, pulling yourself from the earth as an immortal undead. You're a creature of the night, harmed by the light of day and thirsting for blood."
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		},
 		{
 			"name": "Zombie",
@@ -3257,7 +3150,8 @@
 				"4|Crushing Grab|CRB",
 				"14|Corpse Stench|BotD"
 			],
-			"dedicationLevel": 2
+			"dedicationLevel": 2,
+			"rarity": "rare"
 		}
 	]
 }

--- a/data/feats/feats-apg.json
+++ b/data/feats/feats-apg.json
@@ -16108,7 +16108,8 @@
 			"level": 2,
 			"featType": {
 				"archetype": [
-					"Vigilante"
+					"Vigilante",
+					"Gray Gardener"
 				]
 			},
 			"traits": [

--- a/data/feats/feats-g&g.json
+++ b/data/feats/feats-g&g.json
@@ -4403,6 +4403,7 @@
 				]
 			},
 			"traits": [
+				"uncommon",
 				"archetype",
 				"class",
 				"dedication"

--- a/data/feats/feats-locg.json
+++ b/data/feats/feats-locg.json
@@ -1665,7 +1665,7 @@
 			"level": 6,
 			"featType": {
 				"archetype": [
-					"Hellknight Armiger"
+					"Hellknight Signifer"
 				]
 			},
 			"traits": [

--- a/data/feats/feats-loil.json
+++ b/data/feats/feats-loil.json
@@ -2268,6 +2268,7 @@
 			},
 			"level": 2,
 			"traits": [
+				"uncommon",
 				"archetype",
 				"dedication"
 			],

--- a/js/render.js
+++ b/js/render.js
@@ -4060,7 +4060,7 @@ Renderer.archetype = {
 
 		return `${Renderer.utils.getNameDiv(arc, { page: UrlUtil.PG_ARCHETYPES, type: "ARCHETYPE" })}
 		${Renderer.utils.getDividerDiv()}
-		${Renderer.utils.getTraitsDiv(arc.traits || [])}
+		${Renderer.utils.getTraitsDiv(arc.rarity ? [arc.rarity] : [])}
 		${renderer.render({ type: "pf2-h4", entries: arc.entries })}
 		${Renderer.utils.getPageP(arc)}
 		`;

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -309,6 +309,15 @@ function updateFolder (folder) {
 					return r;
 				});
 			}
+			if (json.archetype) {
+				json.archetype = json.archetype.map(a => {
+					if (a.traits && Array.isArray(a.traits) && a.traits.length) {
+						a.rarity = a.traits[0]
+						delete a.traits;
+					}
+					return a
+				})
+			}
 			if (json.background) {
 				json.background = json.background.map(b => {
 					if (b.feat) {

--- a/test/schema-template/archetypes.json
+++ b/test/schema-template/archetypes.json
@@ -50,14 +50,8 @@
 							]
 						}
 					},
-					"traits": {
-						"type": "array",
-						"items": {
-							"type": "string",
-							"$ref": "utils.json#/definitions/anyTrait"
-						},
-						"minItems": 1,
-						"uniqueItems": true
+					"rarity": {
+						"$ref": "utils.json#/definitions/rarity"
 					},
 					"benefits": {
 						"type": "array",


### PR DESCRIPTION
* Consistently use `rarity` field in archetypes (previously both `rarity` and `traits` were used)
* Ensure both archetypes & respective dedication feats have the same rarity (trait)
* Fix a couple dedication feats that weren't correctly linked to their archetypes