### PR TITLE
Remove unneeded isNpc, hasImages properties

### DIFF
--- a/data/bestiary/creatures-aoa1.json
+++ b/data/bestiary/creatures-aoa1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Alak Stagram",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 19,
 			"level": 2,
@@ -139,7 +138,6 @@
 		},
 		{
 			"name": "Anadi Elder",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 85,
 			"level": 6,
@@ -561,7 +559,6 @@
 		},
 		{
 			"name": "Anadi Sage",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 85,
 			"level": 4,
@@ -776,7 +773,6 @@
 		},
 		{
 			"name": "Bloody Blade Mercenary",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 50,
 			"level": 1,
@@ -920,7 +916,6 @@
 		},
 		{
 			"name": "Calmont",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 27,
 			"level": 3,
@@ -1106,7 +1101,6 @@
 		},
 		{
 			"name": "Dmiri Yoltosha",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 51,
 			"level": 4,
@@ -1298,7 +1292,6 @@
 		},
 		{
 			"name": "Doorwarden",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 86,
 			"level": 5,
@@ -1503,7 +1496,6 @@
 		},
 		{
 			"name": "Emperor Bird",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 87,
 			"level": 2,
@@ -1627,7 +1619,6 @@
 		},
 		{
 			"name": "Grauladon",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 88,
 			"level": 2,
@@ -1789,7 +1780,6 @@
 		},
 		{
 			"name": "Graveshell",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 89,
 			"level": 1,
@@ -1946,7 +1936,6 @@
 		},
 		{
 			"name": "Hellcrown",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 90,
 			"level": 1,
@@ -2064,7 +2053,6 @@
 		},
 		{
 			"name": "Malarunk",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 58,
 			"level": 5,
@@ -2313,7 +2301,6 @@
 		},
 		{
 			"name": "Renali",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 79,
 			"level": 4,
@@ -2512,7 +2499,6 @@
 		},
 		{
 			"name": "Skeletal Hellknight",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 40,
 			"level": 2,
@@ -2664,7 +2650,6 @@
 		},
 		{
 			"name": "Skorp And Venak",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 37,
 			"level": 1,
@@ -2814,7 +2799,6 @@
 		},
 		{
 			"name": "Tixitog",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 91,
 			"level": 3,
@@ -2966,7 +2950,6 @@
 		},
 		{
 			"name": "Voz Lirayne",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 81,
 			"level": 5,
@@ -3226,7 +3209,6 @@
 		},
 		{
 			"name": "Warbal Bumblebrasher",
-			"isNpc": false,
 			"source": "AoA1",
 			"page": 83,
 			"level": 1,

--- a/data/bestiary/creatures-aoa2.json
+++ b/data/bestiary/creatures-aoa2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Asanbosam",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 80,
 			"level": 6,
@@ -123,7 +122,6 @@
 		},
 		{
 			"name": "Belmazog",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 77,
 			"level": 9,
@@ -394,7 +392,6 @@
 		},
 		{
 			"name": "Bida",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 81,
 			"level": 8,
@@ -569,7 +566,6 @@
 		},
 		{
 			"name": "Biloko Veteran",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 83,
 			"level": 4,
@@ -749,7 +745,6 @@
 		},
 		{
 			"name": "Biloko Warrior",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 82,
 			"level": 1,
@@ -906,7 +901,6 @@
 		},
 		{
 			"name": "Charau-ka Acolyte Of Angazhan",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 85,
 			"level": 3,
@@ -1126,7 +1120,6 @@
 		},
 		{
 			"name": "Charau-ka Butcher",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 85,
 			"level": 6,
@@ -1339,7 +1332,6 @@
 		},
 		{
 			"name": "Charau-ka Dragon Priest",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 59,
 			"level": 6,
@@ -1616,7 +1608,6 @@
 		},
 		{
 			"name": "Charau-ka Warrior",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 84,
 			"level": 1,
@@ -1807,7 +1798,6 @@
 		},
 		{
 			"name": "Ekujae Guardian",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 11,
 			"level": 2,
@@ -1996,7 +1986,6 @@
 		},
 		{
 			"name": "Eloko",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 83,
 			"level": 7,
@@ -2199,7 +2188,6 @@
 		},
 		{
 			"name": "Gerhard Pendergrast",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 37,
 			"level": 8,
@@ -2400,7 +2388,6 @@
 		},
 		{
 			"name": "Grippli Archer",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 87,
 			"level": 3,
@@ -2534,7 +2521,6 @@
 		},
 		{
 			"name": "Grippli Greenspeaker",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 87,
 			"level": 5,
@@ -2737,7 +2723,6 @@
 		},
 		{
 			"name": "Grippli Scout",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 86,
 			"level": 1,
@@ -2872,7 +2857,6 @@
 		},
 		{
 			"name": "Hezle",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 50,
 			"level": 8,
@@ -3088,7 +3072,6 @@
 		},
 		{
 			"name": "Jahsi",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 11,
 			"level": 8,
@@ -3317,7 +3300,6 @@
 		},
 		{
 			"name": "Kishi",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 88,
 			"level": 8,
@@ -3492,7 +3474,6 @@
 		},
 		{
 			"name": "Living Sap",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 89,
 			"level": 6,
@@ -3623,7 +3604,6 @@
 		},
 		{
 			"name": "Mokele-mbembe",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 90,
 			"level": 9,
@@ -3771,7 +3751,6 @@
 		},
 		{
 			"name": "Nketiah",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 79,
 			"level": 6,
@@ -4078,7 +4057,6 @@
 		},
 		{
 			"name": "Racharak",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 34,
 			"level": 8,
@@ -4275,7 +4253,6 @@
 		},
 		{
 			"name": "Sabosan",
-			"isNpc": false,
 			"source": "AoA2",
 			"page": 91,
 			"level": 5,

--- a/data/bestiary/creatures-aoa3.json
+++ b/data/bestiary/creatures-aoa3.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Augur",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 82,
 			"level": 1,
@@ -228,7 +227,6 @@
 		},
 		{
 			"name": "Barushak Il-varashma",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 44,
 			"level": 11,
@@ -564,7 +562,6 @@
 		},
 		{
 			"name": "Blood Boar",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 76,
 			"level": 6,
@@ -712,7 +709,6 @@
 		},
 		{
 			"name": "Evangelist",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 83,
 			"level": 6,
@@ -912,7 +908,6 @@
 		},
 		{
 			"name": "Ghastly Bear",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 50,
 			"level": 9,
@@ -1106,7 +1101,6 @@
 		},
 		{
 			"name": "Heuberk Thropp",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 7,
 			"level": 9,
@@ -1369,7 +1363,6 @@
 		},
 		{
 			"name": "Interlocutor",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 84,
 			"level": 12,
@@ -1610,7 +1603,6 @@
 		},
 		{
 			"name": "Kalavakus",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 77,
 			"level": 10,
@@ -1853,7 +1845,6 @@
 		},
 		{
 			"name": "Laslunn",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 87,
 			"level": 13,
@@ -2074,7 +2065,6 @@
 		},
 		{
 			"name": "Mercenary Sailor",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 18,
 			"level": 5,
@@ -2210,7 +2200,6 @@
 		},
 		{
 			"name": "Mialari Docur",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 89,
 			"level": 10,
@@ -2470,7 +2459,6 @@
 		},
 		{
 			"name": "Nolly Peltry",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 91,
 			"level": 11,
@@ -2679,7 +2667,6 @@
 		},
 		{
 			"name": "One-eye Amnin",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 23,
 			"level": 10,
@@ -2865,7 +2852,6 @@
 		},
 		{
 			"name": "Osyluth",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 78,
 			"level": 9,
@@ -3130,7 +3116,6 @@
 		},
 		{
 			"name": "Precentor",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 85,
 			"level": 16,
@@ -3385,7 +3370,6 @@
 		},
 		{
 			"name": "Remnant Of Barzillai",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 80,
 			"level": 10,
@@ -3545,7 +3529,6 @@
 		},
 		{
 			"name": "Rusalka",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 81,
 			"level": 12,
@@ -3810,7 +3793,6 @@
 		},
 		{
 			"name": "Rusty Mae",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 14,
 			"level": 10,
@@ -4007,7 +3989,6 @@
 		},
 		{
 			"name": "Scarlet Triad Poisoner",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 41,
 			"level": 8,
@@ -4151,7 +4132,6 @@
 		},
 		{
 			"name": "Scarlet Triad Sneak",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 8,
 			"level": 6,
@@ -4338,7 +4318,6 @@
 		},
 		{
 			"name": "Scarlet Triad Sniper",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 56,
 			"level": 11,
@@ -4489,7 +4468,6 @@
 		},
 		{
 			"name": "Scarlet Triad Thug",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 16,
 			"level": 7,
@@ -4648,7 +4626,6 @@
 		},
 		{
 			"name": "Shadow Giant",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 79,
 			"level": 13,
@@ -4837,7 +4814,6 @@
 		},
 		{
 			"name": "Vaklish",
-			"isNpc": false,
 			"source": "AoA3",
 			"page": 54,
 			"level": 12,

--- a/data/bestiary/creatures-aoa4.json
+++ b/data/bestiary/creatures-aoa4.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Accursed Forge-spurned",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 32,
 			"level": 15,
@@ -198,7 +197,6 @@
 		},
 		{
 			"name": "Adult Magma Dragon",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 80,
 			"level": 13,
@@ -473,7 +471,6 @@
 		},
 		{
 			"name": "Ancient Magma Dragon",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 81,
 			"level": 18,
@@ -778,7 +775,6 @@
 		},
 		{
 			"name": "Carnivorous Crystal",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 76,
 			"level": 11,
@@ -962,7 +958,6 @@
 		},
 		{
 			"name": "Corrupt Guard",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 27,
 			"level": 12,
@@ -1103,7 +1098,6 @@
 		},
 		{
 			"name": "Dalos",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 77,
 			"level": 13,
@@ -1323,7 +1317,6 @@
 		},
 		{
 			"name": "Deculi",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 78,
 			"level": 12,
@@ -1492,7 +1485,6 @@
 		},
 		{
 			"name": "Devourer",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 79,
 			"level": 11,
@@ -1658,7 +1650,6 @@
 		},
 		{
 			"name": "Dragonscarred Dead",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 82,
 			"level": 13,
@@ -1844,7 +1835,6 @@
 		},
 		{
 			"name": "Duergar Slave Lord",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 50,
 			"level": 13,
@@ -2043,7 +2033,6 @@
 		},
 		{
 			"name": "Falrok",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 46,
 			"level": 14,
@@ -2302,7 +2291,6 @@
 		},
 		{
 			"name": "Forge-spurned",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 83,
 			"level": 5,
@@ -2490,7 +2478,6 @@
 		},
 		{
 			"name": "Gashadokuro",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 84,
 			"level": 13,
@@ -2677,7 +2664,6 @@
 		},
 		{
 			"name": "Ilssrah Embermead",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 89,
 			"level": 15,
@@ -3018,7 +3004,6 @@
 		},
 		{
 			"name": "Kelda Halrig",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 87,
 			"level": 8,
@@ -3137,7 +3122,6 @@
 		},
 		{
 			"name": "King Harral",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 42,
 			"level": 14,
@@ -3446,7 +3430,6 @@
 		},
 		{
 			"name": "Kralgurn",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 31,
 			"level": 14,
@@ -3615,7 +3598,6 @@
 		},
 		{
 			"name": "Lazurite-infused Stone Golem",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 45,
 			"level": 12,
@@ -3766,7 +3748,6 @@
 		},
 		{
 			"name": "Saggorak Poltergeist",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 43,
 			"level": 12,
@@ -3985,7 +3966,6 @@
 		},
 		{
 			"name": "Soulbound Ruin",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 85,
 			"level": 15,
@@ -4145,7 +4125,6 @@
 		},
 		{
 			"name": "Talamira",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 8,
 			"level": 13,
@@ -4588,7 +4567,6 @@
 		},
 		{
 			"name": "Veshumirix",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 91,
 			"level": 16,
@@ -4874,7 +4852,6 @@
 		},
 		{
 			"name": "Xevalorg",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 14,
 			"level": 13,
@@ -5095,7 +5072,6 @@
 		},
 		{
 			"name": "Young Magma Dragon",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 80,
 			"level": 9,
@@ -5348,7 +5324,6 @@
 		},
 		{
 			"name": "Zuferian",
-			"isNpc": false,
 			"source": "AoA4",
 			"page": 37,
 			"level": 15,

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aluum Enforcer",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 82,
 			"level": 10,
@@ -145,7 +144,6 @@
 		},
 		{
 			"name": "Calikang",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 84,
 			"level": 12,
@@ -345,7 +343,6 @@
 		},
 		{
 			"name": "Cornugon",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 87,
 			"level": 16,
@@ -647,7 +644,6 @@
 		},
 		{
 			"name": "Crucidaemon",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 85,
 			"level": 15,
@@ -882,7 +878,6 @@
 		},
 		{
 			"name": "Duneshaker Solifugid",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 89,
 			"level": 18,
@@ -1028,7 +1023,6 @@
 		},
 		{
 			"name": "Giant Solifugid",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 89,
 			"level": 1,
@@ -1146,7 +1140,6 @@
 		},
 		{
 			"name": "Immortal Ichor",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 88,
 			"level": 15,
@@ -1400,7 +1393,6 @@
 		},
 		{
 			"name": "Ishti",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 47,
 			"level": 18,
@@ -1608,7 +1600,6 @@
 		},
 		{
 			"name": "Nalfeshnee",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 86,
 			"level": 14,
@@ -1863,7 +1854,6 @@
 		},
 		{
 			"name": "Scarlet Triad Boss",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 57,
 			"level": 17,
@@ -2015,7 +2005,6 @@
 		},
 		{
 			"name": "Scarlet Triad Enforcer",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 41,
 			"level": 15,
@@ -2177,7 +2166,6 @@
 		},
 		{
 			"name": "Scarlet Triad Mage",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 57,
 			"level": 15,
@@ -2393,7 +2381,6 @@
 		},
 		{
 			"name": "Bshez \"Sand Claws\" Shak",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 34,
 			"level": 17,
@@ -2572,7 +2559,6 @@
 		},
 		{
 			"name": "Spiritbound Aluum",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 83,
 			"level": 16,
@@ -2755,7 +2741,6 @@
 		},
 		{
 			"name": "Teyam Ishtori",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 61,
 			"level": 19,
@@ -3059,7 +3044,6 @@
 		},
 		{
 			"name": "Uri Zandivar",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 93,
 			"level": 19,
@@ -3292,7 +3276,6 @@
 		},
 		{
 			"name": "Witchwyrd",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 90,
 			"level": 6,
@@ -3538,7 +3521,6 @@
 		},
 		{
 			"name": "Xotanispawn",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 91,
 			"level": 17,
@@ -3722,7 +3704,6 @@
 		},
 		{
 			"name": "Zephyr Guard",
-			"isNpc": false,
 			"source": "AoA5",
 			"page": 51,
 			"level": 14,

--- a/data/bestiary/creatures-aoa6.json
+++ b/data/bestiary/creatures-aoa6.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aiudara Wraith",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 78,
 			"level": 18,
@@ -160,7 +159,6 @@
 		},
 		{
 			"name": "Animated Dragonstorm",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 10,
 			"level": 18,
@@ -306,7 +304,6 @@
 		},
 		{
 			"name": "Candlaron's Echo",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 56,
 			"level": 21,
@@ -615,7 +612,6 @@
 		},
 		{
 			"name": "Dragonshard Guardian",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 79,
 			"level": 22,
@@ -793,7 +789,6 @@
 		},
 		{
 			"name": "Dragonstorm Fire Giant",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 14,
 			"level": 18,
@@ -984,7 +979,6 @@
 		},
 		{
 			"name": "Elder Wyrmwraith",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 85,
 			"level": 23,
@@ -1300,7 +1294,6 @@
 		},
 		{
 			"name": "Emaliza Zandivar",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 87,
 			"level": 20,
@@ -1669,7 +1662,6 @@
 		},
 		{
 			"name": "Hermean Mutant",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 40,
 			"level": 19,
@@ -1774,7 +1766,6 @@
 		},
 		{
 			"name": "Ilgreth",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 57,
 			"level": 20,
@@ -2120,7 +2111,6 @@
 		},
 		{
 			"name": "Ingnovim Tluss",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 39,
 			"level": 19,
@@ -2301,7 +2291,6 @@
 		},
 		{
 			"name": "Ingnovim's Assistant",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 40,
 			"level": 17,
@@ -2409,7 +2398,6 @@
 		},
 		{
 			"name": "Inizra Arumelo",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 89,
 			"level": 20,
@@ -2573,7 +2561,6 @@
 		},
 		{
 			"name": "Lesser Manifestation Of Dahak",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 16,
 			"level": 22,
@@ -2911,7 +2898,6 @@
 		},
 		{
 			"name": "Manifestation Of Dahak",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 63,
 			"level": 24,
@@ -3398,7 +3384,6 @@
 		},
 		{
 			"name": "Mengkare",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 90,
 			"level": 23,
@@ -3880,7 +3865,6 @@
 		},
 		{
 			"name": "Promise Guard",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 29,
 			"level": 17,
@@ -4056,7 +4040,6 @@
 		},
 		{
 			"name": "Rinnarv Bontimar",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 24,
 			"level": 20,
@@ -4548,7 +4531,6 @@
 		},
 		{
 			"name": "Tarrasque",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 80,
 			"level": 25,
@@ -4855,7 +4837,6 @@
 		},
 		{
 			"name": "Tzitzimitl",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 82,
 			"level": 19,
@@ -5150,7 +5131,6 @@
 		},
 		{
 			"name": "Vazgorlu",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 83,
 			"level": 20,
@@ -5377,7 +5357,6 @@
 		},
 		{
 			"name": "Wyrmwraith",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 84,
 			"level": 17,
@@ -5703,7 +5682,6 @@
 		},
 		{
 			"name": "Xotani",
-			"isNpc": false,
 			"source": "AoA6",
 			"page": 81,
 			"level": 20,

--- a/data/bestiary/creatures-aoe1.json
+++ b/data/bestiary/creatures-aoe1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Almiraj",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 16,
 			"level": 1,
@@ -113,7 +112,6 @@
 		},
 		{
 			"name": "Antaro Boldblade",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 8,
 			"level": -1,
@@ -228,7 +226,6 @@
 		},
 		{
 			"name": "Battle Leader Rekarek",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 27,
 			"level": 2,
@@ -353,7 +350,6 @@
 		},
 		{
 			"name": "Binumir",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 82,
 			"level": 3,
@@ -493,7 +489,6 @@
 		},
 		{
 			"name": "Bolar Of Stonemoor",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 8,
 			"level": -1,
@@ -601,7 +596,6 @@
 		},
 		{
 			"name": "Cobbleswarm",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 83,
 			"level": 2,
@@ -730,7 +724,6 @@
 		},
 		{
 			"name": "Eunice",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 12,
 			"level": 0,
@@ -816,7 +809,6 @@
 		},
 		{
 			"name": "Gref",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 34,
 			"level": 2,
@@ -965,7 +957,6 @@
 		},
 		{
 			"name": "Grick",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 35,
 			"level": 3,
@@ -1101,7 +1092,6 @@
 		},
 		{
 			"name": "Grospek Lavarsus",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 87,
 			"level": 7,
@@ -1231,7 +1221,6 @@
 		},
 		{
 			"name": "Hendrid Pratchett",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 89,
 			"level": 6,
@@ -1414,7 +1403,6 @@
 		},
 		{
 			"name": "Kekker",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 34,
 			"level": 2,
@@ -1563,7 +1551,6 @@
 		},
 		{
 			"name": "Kemeneles",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 53,
 			"level": 2,
@@ -1710,7 +1697,6 @@
 		},
 		{
 			"name": "Lyrma Swampwalker",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 54,
 			"level": 2,
@@ -1811,7 +1797,6 @@
 		},
 		{
 			"name": "Miriel Grayleaf",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 7,
 			"level": -1,
@@ -1928,7 +1913,6 @@
 		},
 		{
 			"name": "Pickled Punk",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 59,
 			"level": 1,
@@ -2045,7 +2029,6 @@
 		},
 		{
 			"name": "Ralso",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 91,
 			"level": 4,
@@ -2193,7 +2176,6 @@
 		},
 		{
 			"name": "Shredskin",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 60,
 			"level": 2,
@@ -2328,7 +2310,6 @@
 		},
 		{
 			"name": "Siege Shard",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 84,
 			"level": 3,
@@ -2497,7 +2478,6 @@
 		},
 		{
 			"name": "Skebs",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 8,
 			"level": -1,
@@ -2641,7 +2621,6 @@
 		},
 		{
 			"name": "Vargouille",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 35,
 			"level": 2,
@@ -2806,7 +2785,6 @@
 		},
 		{
 			"name": "Zrukbat",
-			"isNpc": false,
 			"source": "AoE1",
 			"page": 85,
 			"level": 2,

--- a/data/bestiary/creatures-aoe2.json
+++ b/data/bestiary/creatures-aoe2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Bone Skipper Swarm",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 80,
 			"level": 6,
@@ -131,7 +130,6 @@
 		},
 		{
 			"name": "Copper Hand Illusionist",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 23,
 			"level": 5,
@@ -311,7 +309,6 @@
 		},
 		{
 			"name": "Copper Hand Rogue",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 16,
 			"level": 4,
@@ -442,7 +439,6 @@
 		},
 		{
 			"name": "Dreadsong Dancer",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 81,
 			"level": 8,
@@ -664,7 +660,6 @@
 		},
 		{
 			"name": "Excorion",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 82,
 			"level": 7,
@@ -832,7 +827,6 @@
 		},
 		{
 			"name": "Fayati Alummur",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 26,
 			"level": 8,
@@ -1030,7 +1024,6 @@
 		},
 		{
 			"name": "Frefferth",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 35,
 			"level": 9,
@@ -1240,7 +1233,6 @@
 		},
 		{
 			"name": "Giant Bone Skipper",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 80,
 			"level": 7,
@@ -1383,7 +1375,6 @@
 		},
 		{
 			"name": "Kolo Harvan",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 17,
 			"level": 2,
@@ -1513,7 +1504,6 @@
 		},
 		{
 			"name": "Najra Lizard",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 83,
 			"level": 4,
@@ -1670,7 +1660,6 @@
 		},
 		{
 			"name": "Ofalth Zombie",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 47,
 			"level": 7,
@@ -1822,7 +1811,6 @@
 		},
 		{
 			"name": "Shristi Melipdra",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 91,
 			"level": 7,
@@ -1994,7 +1982,6 @@
 		},
 		{
 			"name": "Skinsaw Murderer",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 50,
 			"level": 6,
@@ -2143,7 +2130,6 @@
 		},
 		{
 			"name": "Skinsaw Seamer",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 51,
 			"level": 8,
@@ -2314,7 +2300,6 @@
 		},
 		{
 			"name": "Skinstitch",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 84,
 			"level": 5,
@@ -2454,7 +2439,6 @@
 		},
 		{
 			"name": "Tenome",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 85,
 			"level": 4,
@@ -2606,7 +2590,6 @@
 		},
 		{
 			"name": "Teraphant",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 86,
 			"level": 9,
@@ -2793,7 +2776,6 @@
 		},
 		{
 			"name": "Vaultbreaker Ooze",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 87,
 			"level": 6,
@@ -2943,7 +2925,6 @@
 		},
 		{
 			"name": "Wrent Dicaspiron",
-			"isNpc": false,
 			"source": "AoE2",
 			"page": 89,
 			"level": 10,

--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Avarek",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 80,
 			"level": 8,
@@ -255,7 +254,6 @@
 		},
 		{
 			"name": "Barnacle Ghoul",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 83,
 			"level": 9,
@@ -482,7 +480,6 @@
 		},
 		{
 			"name": "Bloody Berleth",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 21,
 			"level": 11,
@@ -653,7 +650,6 @@
 		},
 		{
 			"name": "Bregdi",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 81,
 			"level": 9,
@@ -820,7 +816,6 @@
 		},
 		{
 			"name": "Casino Bouncer",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 24,
 			"level": 8,
@@ -970,7 +965,6 @@
 		},
 		{
 			"name": "Diobel Sweeper Tough",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 8,
 			"level": 7,
@@ -1114,7 +1108,6 @@
 		},
 		{
 			"name": "Eberark",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 82,
 			"level": 10,
@@ -1288,7 +1281,6 @@
 		},
 		{
 			"name": "Franca Laurentz",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 87,
 			"level": 13,
@@ -1468,7 +1460,6 @@
 		},
 		{
 			"name": "Gage Carlyle",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 89,
 			"level": 11,
@@ -1607,7 +1598,6 @@
 		},
 		{
 			"name": "Iroran Skeleton",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 52,
 			"level": 11,
@@ -1755,7 +1745,6 @@
 		},
 		{
 			"name": "Maurrisa Jonne",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 91,
 			"level": 10,
@@ -1900,7 +1889,6 @@
 		},
 		{
 			"name": "Ravenile Rager",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 84,
 			"level": 14,
@@ -2075,7 +2063,6 @@
 		},
 		{
 			"name": "Scathka",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 43,
 			"level": 12,
@@ -2344,7 +2331,6 @@
 		},
 		{
 			"name": "Shikwashim Mercenary",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 52,
 			"level": 9,
@@ -2538,7 +2524,6 @@
 		},
 		{
 			"name": "Svartalfar Killer",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 85,
 			"level": 8,
@@ -2749,7 +2734,6 @@
 		},
 		{
 			"name": "Tonla And Yvelle",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 17,
 			"level": 9,
@@ -2909,7 +2893,6 @@
 		},
 		{
 			"name": "Washboard Dog Tough",
-			"isNpc": false,
 			"source": "AoE3",
 			"page": 8,
 			"level": 7,

--- a/data/bestiary/creatures-aoe4.json
+++ b/data/bestiary/creatures-aoe4.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Amateur Chemist",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 12,
 			"level": 5,
@@ -153,7 +152,6 @@
 		},
 		{
 			"name": "Blackfingers Acolyte",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 13,
 			"level": 6,
@@ -366,7 +364,6 @@
 		},
 		{
 			"name": "Clockwork Assassin",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 82,
 			"level": 13,
@@ -572,7 +569,6 @@
 		},
 		{
 			"name": "Gloaming Will-o'-wisp",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 59,
 			"level": 13,
@@ -717,7 +713,6 @@
 		},
 		{
 			"name": "Grabble Forden",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 45,
 			"level": 13,
@@ -1003,7 +998,6 @@
 		},
 		{
 			"name": "Japu Thalenger",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 14,
 			"level": 10,
@@ -1172,7 +1166,6 @@
 		},
 		{
 			"name": "Jonis Flakfatter",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 87,
 			"level": 15,
@@ -1488,7 +1481,6 @@
 		},
 		{
 			"name": "Jorogumo",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 83,
 			"level": 13,
@@ -1781,7 +1773,6 @@
 		},
 		{
 			"name": "Kalyn Pounch",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 14,
 			"level": 12,
@@ -2038,7 +2029,6 @@
 		},
 		{
 			"name": "Morgrat And Fillick",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 29,
 			"level": 9,
@@ -2306,7 +2296,6 @@
 		},
 		{
 			"name": "Norgorberite Poisoner",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 6,
 			"level": 11,
@@ -2493,7 +2482,6 @@
 		},
 		{
 			"name": "Poison Eater",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 23,
 			"level": 8,
@@ -2657,7 +2645,6 @@
 		},
 		{
 			"name": "Shatterling",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 84,
 			"level": 14,
@@ -2853,7 +2840,6 @@
 		},
 		{
 			"name": "Sleepless Sun Veteran",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 37,
 			"level": 6,
@@ -3024,7 +3010,6 @@
 		},
 		{
 			"name": "The Rabbit Prince",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 89,
 			"level": 17,
@@ -3274,7 +3259,6 @@
 		},
 		{
 			"name": "The Stabbing Beast",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 85,
 			"level": 15,
@@ -3573,7 +3557,6 @@
 		},
 		{
 			"name": "Velberi Jallist",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 22,
 			"level": 14,
@@ -3815,7 +3798,6 @@
 		},
 		{
 			"name": "Wynsal Starborn",
-			"isNpc": false,
 			"source": "AoE4",
 			"page": 91,
 			"level": 17,

--- a/data/bestiary/creatures-aoe5.json
+++ b/data/bestiary/creatures-aoe5.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Black Whale Guard",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 35,
 			"level": 12,
@@ -144,7 +143,6 @@
 		},
 		{
 			"name": "Bloody Barber Goon",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 21,
 			"level": 12,
@@ -309,7 +307,6 @@
 		},
 		{
 			"name": "Calennia",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 32,
 			"level": 16,
@@ -493,7 +490,6 @@
 		},
 		{
 			"name": "Child Of Venom",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 16,
 			"level": 13,
@@ -648,7 +644,6 @@
 		},
 		{
 			"name": "Clockwork Amalgam",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 81,
 			"level": 20,
@@ -853,7 +848,6 @@
 		},
 		{
 			"name": "Clockwork Assassin",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 50,
 			"level": 13,
@@ -1056,7 +1050,6 @@
 		},
 		{
 			"name": "Garrote Master Assassin",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 14,
 			"level": 16,
@@ -1263,7 +1256,6 @@
 		},
 		{
 			"name": "Graem And Grinlowe",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 40,
 			"level": 16,
@@ -1414,7 +1406,6 @@
 		},
 		{
 			"name": "Grimwold",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 7,
 			"level": 14,
@@ -1546,7 +1537,6 @@
 		},
 		{
 			"name": "Ixusoth",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 50,
 			"level": 15,
@@ -1808,7 +1798,6 @@
 		},
 		{
 			"name": "Kapral",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 7,
 			"level": 14,
@@ -2029,7 +2018,6 @@
 		},
 		{
 			"name": "Lord Guirden",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 37,
 			"level": 19,
@@ -2171,7 +2159,6 @@
 		},
 		{
 			"name": "Lusca",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 83,
 			"level": 17,
@@ -2435,7 +2422,6 @@
 		},
 		{
 			"name": "Minchgorm",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 84,
 			"level": 18,
@@ -2639,7 +2625,6 @@
 		},
 		{
 			"name": "Miogimo",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 89,
 			"level": 17,
@@ -2924,7 +2909,6 @@
 		},
 		{
 			"name": "Mother Venom",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 19,
 			"level": 17,
@@ -3242,7 +3226,6 @@
 		},
 		{
 			"name": "Myrna Rath",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 39,
 			"level": 16,
@@ -3555,7 +3538,6 @@
 		},
 		{
 			"name": "Myrucarx",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 85,
 			"level": 18,
@@ -3772,7 +3754,6 @@
 		},
 		{
 			"name": "Obrousian",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 86,
 			"level": 14,
@@ -3950,7 +3931,6 @@
 		},
 		{
 			"name": "Reginald Vancaskerkin",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 91,
 			"level": 18,
@@ -4208,7 +4188,6 @@
 		},
 		{
 			"name": "Starwatch Commando",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 26,
 			"level": 11,
@@ -4355,7 +4334,6 @@
 		},
 		{
 			"name": "Tiderunner Aquamancer",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 41,
 			"level": 13,
@@ -4598,7 +4576,6 @@
 		},
 		{
 			"name": "Twisted Jack",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 22,
 			"level": 17,
@@ -4757,7 +4734,6 @@
 		},
 		{
 			"name": "Elemental Vessel, Water",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 82,
 			"level": 16,
@@ -5003,7 +4979,6 @@
 		},
 		{
 			"name": "Zeal-damned Ghoul",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 9,
 			"level": 10,
@@ -5181,7 +5156,6 @@
 		},
 		{
 			"name": "Zealborn",
-			"isNpc": false,
 			"source": "AoE5",
 			"page": 87,
 			"level": 12,

--- a/data/bestiary/creatures-aoe6.json
+++ b/data/bestiary/creatures-aoe6.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Agent Of The Gray Queen",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 21,
 			"level": 19,
@@ -300,7 +299,6 @@
 		},
 		{
 			"name": "Agradaemon",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 79,
 			"level": 19,
@@ -556,7 +554,6 @@
 		},
 		{
 			"name": "Alchemical Horror",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 55,
 			"level": 21,
@@ -707,7 +704,6 @@
 		},
 		{
 			"name": "Avsheros The Betrayer",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 42,
 			"level": 23,
@@ -986,7 +982,6 @@
 		},
 		{
 			"name": "Baatamidar",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 76,
 			"level": 21,
@@ -1215,7 +1210,6 @@
 		},
 		{
 			"name": "Blune Bandersworth",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 87,
 			"level": 20,
@@ -1519,7 +1513,6 @@
 		},
 		{
 			"name": "Blune's Illusory Toady",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 13,
 			"level": 16,
@@ -1714,7 +1707,6 @@
 		},
 		{
 			"name": "Camarach",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 77,
 			"level": 17,
@@ -1969,7 +1961,6 @@
 		},
 		{
 			"name": "Chaos Gulgamodh",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 45,
 			"level": 21,
@@ -2150,7 +2141,6 @@
 		},
 		{
 			"name": "Daemonic Infector",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 56,
 			"level": 22,
@@ -2536,7 +2526,6 @@
 		},
 		{
 			"name": "Daemonic Rumormonger",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 53,
 			"level": 22,
@@ -2793,7 +2782,6 @@
 		},
 		{
 			"name": "Daemonic Skinner",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 51,
 			"level": 20,
@@ -3052,7 +3040,6 @@
 		},
 		{
 			"name": "Excorion Paragon",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 50,
 			"level": 18,
@@ -3230,7 +3217,6 @@
 		},
 		{
 			"name": "Ghaele Of Kharnas",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 32,
 			"level": 17,
@@ -3587,7 +3573,6 @@
 		},
 		{
 			"name": "Graveknight Of Kharnas",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 36,
 			"level": 17,
@@ -3772,7 +3757,6 @@
 		},
 		{
 			"name": "Hegessik",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 80,
 			"level": 15,
@@ -4153,7 +4137,6 @@
 		},
 		{
 			"name": "Hestriviniaas",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 15,
 			"level": 22,
@@ -4564,7 +4547,6 @@
 		},
 		{
 			"name": "Hundun Chaos Mage",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 17,
 			"level": 18,
@@ -4830,7 +4812,6 @@
 		},
 		{
 			"name": "Il'setsya Wyrmtouched",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 89,
 			"level": 18,
@@ -5242,7 +5223,6 @@
 		},
 		{
 			"name": "Izfiitar",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 81,
 			"level": 20,
@@ -5682,7 +5662,6 @@
 		},
 		{
 			"name": "Living Mural",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 31,
 			"level": 19,
@@ -5847,7 +5826,6 @@
 		},
 		{
 			"name": "Nenchuuj",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 85,
 			"level": 19,
@@ -6097,7 +6075,6 @@
 		},
 		{
 			"name": "Olansa Terimor",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 91,
 			"level": 23,
@@ -6420,7 +6397,6 @@
 		},
 		{
 			"name": "Overdrive Imentesh",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 9,
 			"level": 17,
@@ -6786,7 +6762,6 @@
 		},
 		{
 			"name": "Penqual",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 84,
 			"level": 15,
@@ -6997,7 +6972,6 @@
 		},
 		{
 			"name": "Rhevanna",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 83,
 			"level": 22,
@@ -7301,7 +7275,6 @@
 		},
 		{
 			"name": "Slithering Rift",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 27,
 			"level": 18,
@@ -7457,7 +7430,6 @@
 		},
 		{
 			"name": "Sordesdaemon",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 78,
 			"level": 15,
@@ -7697,7 +7669,6 @@
 		},
 		{
 			"name": "Ulressia The Blessed",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 39,
 			"level": 19,
@@ -8004,7 +7975,6 @@
 		},
 		{
 			"name": "Veksciralenix",
-			"isNpc": false,
 			"source": "AoE6",
 			"page": 7,
 			"level": 20,

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aller Rosk",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 43,
 			"level": 5,
@@ -172,7 +171,6 @@
 		},
 		{
 			"name": "Augrael",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 35,
 			"level": 3,
@@ -383,7 +381,6 @@
 		},
 		{
 			"name": "Bloodsiphon",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 23,
 			"level": 4,
@@ -519,7 +516,6 @@
 		},
 		{
 			"name": "Boss Skrawng",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 11,
 			"level": 1,
@@ -742,7 +738,6 @@
 		},
 		{
 			"name": "Canker Cultist",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 41,
 			"level": 3,
@@ -1000,7 +995,6 @@
 		},
 		{
 			"name": "Chandriu Invisar",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 50,
 			"level": 6,
@@ -1143,7 +1137,6 @@
 		},
 		{
 			"name": "Corpselight",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 82,
 			"level": 2,
@@ -1325,7 +1318,6 @@
 		},
 		{
 			"name": "Flickerwisp",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 83,
 			"level": 2,
@@ -1479,7 +1471,6 @@
 		},
 		{
 			"name": "Jarelle Kaldrian",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 40,
 			"level": 5,
@@ -1640,7 +1631,6 @@
 		},
 		{
 			"name": "Jaul Mezmin",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 59,
 			"level": 6,
@@ -1872,7 +1862,6 @@
 		},
 		{
 			"name": "Jaul's Wolf",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 60,
 			"level": 4,
@@ -1972,7 +1961,6 @@
 		},
 		{
 			"name": "Morlock Cultist",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 85,
 			"level": 4,
@@ -2179,7 +2167,6 @@
 		},
 		{
 			"name": "Morlock Engineer",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 84,
 			"level": 3,
@@ -2355,7 +2342,6 @@
 		},
 		{
 			"name": "Morlock Scavenger",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 84,
 			"level": 1,
@@ -2510,7 +2496,6 @@
 		},
 		{
 			"name": "Nhakazarin",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 48,
 			"level": 5,
@@ -2803,7 +2788,6 @@
 		},
 		{
 			"name": "Otari Ilvashti",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 89,
 			"level": 9,
@@ -2998,7 +2982,6 @@
 		},
 		{
 			"name": "Scalathrax",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 86,
 			"level": 4,
@@ -3160,7 +3143,6 @@
 		},
 		{
 			"name": "Voidglutton",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 87,
 			"level": 8,
@@ -3373,7 +3355,6 @@
 		},
 		{
 			"name": "Volluk Azrinae",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 54,
 			"level": 7,
@@ -3636,7 +3617,6 @@
 		},
 		{
 			"name": "Wrin Sivinxi",
-			"isNpc": false,
 			"source": "AV1",
 			"page": 90,
 			"level": 5,

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Carman Rajani",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 87,
 			"level": 6,
@@ -172,7 +171,6 @@
 		},
 		{
 			"name": "Chafkhem",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 19,
 			"level": 8,
@@ -502,7 +500,6 @@
 		},
 		{
 			"name": "Dreshkan",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 78,
 			"level": 4,
@@ -669,7 +666,6 @@
 		},
 		{
 			"name": "Gibtanius",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 81,
 			"level": 8,
@@ -826,7 +822,6 @@
 		},
 		{
 			"name": "Gibtas Bounder",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 80,
 			"level": 5,
@@ -963,7 +958,6 @@
 		},
 		{
 			"name": "Gibtas Spawn Swarm",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 80,
 			"level": 6,
@@ -1089,7 +1083,6 @@
 		},
 		{
 			"name": "Gulzash",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 35,
 			"level": 4,
@@ -1270,7 +1263,6 @@
 		},
 		{
 			"name": "Jafaki",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 88,
 			"level": 8,
@@ -1592,7 +1584,6 @@
 		},
 		{
 			"name": "Kragala",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 35,
 			"level": 4,
@@ -1833,7 +1824,6 @@
 		},
 		{
 			"name": "Mulventok",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 79,
 			"level": 7,
@@ -2028,7 +2018,6 @@
 		},
 		{
 			"name": "Murschen",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 39,
 			"level": 8,
@@ -2197,7 +2186,6 @@
 		},
 		{
 			"name": "Nox",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 36,
 			"level": 4,
@@ -2385,7 +2373,6 @@
 		},
 		{
 			"name": "Ryta",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 36,
 			"level": 4,
@@ -2585,7 +2572,6 @@
 		},
 		{
 			"name": "Sacuishu",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 57,
 			"level": 9,
@@ -2827,7 +2813,6 @@
 		},
 		{
 			"name": "Seugathi Reality Warper",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 83,
 			"level": 9,
@@ -3144,7 +3129,6 @@
 		},
 		{
 			"name": "Seugathi Servant",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 82,
 			"level": 6,
@@ -3389,7 +3373,6 @@
 		},
 		{
 			"name": "Shanrigol Behemoth",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 85,
 			"level": 9,
@@ -3576,7 +3559,6 @@
 		},
 		{
 			"name": "Shanrigol Heap",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 84,
 			"level": 4,
@@ -3728,7 +3710,6 @@
 		},
 		{
 			"name": "Urevian",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 90,
 			"level": 9,
@@ -4024,7 +4005,6 @@
 		},
 		{
 			"name": "Vischari",
-			"isNpc": false,
 			"source": "AV2",
 			"page": 34,
 			"level": 7,

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -387,7 +387,6 @@
 		},
 		{
 			"name": "Bhazrade And Klathor",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 33,
 			"level": 9,
@@ -683,7 +682,6 @@
 		},
 		{
 			"name": "Bright Walker",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 78,
 			"level": 9,
@@ -894,7 +892,6 @@
 		},
 		{
 			"name": "Caligni Defender",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 35,
 			"level": 8,
@@ -1092,7 +1089,6 @@
 		},
 		{
 			"name": "Deepwater Dhuthorex",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 80,
 			"level": 9,
@@ -1266,7 +1262,6 @@
 		},
 		{
 			"name": "Dragon's Blood Puffball",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 79,
 			"level": 8,
@@ -1385,7 +1380,6 @@
 		},
 		{
 			"name": "Dread Dhuthorex",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 80,
 			"level": 11,
@@ -1612,7 +1606,6 @@
 		},
 		{
 			"name": "Dread Wisp",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 81,
 			"level": 9,
@@ -1794,7 +1787,6 @@
 		},
 		{
 			"name": "Drow Hunter",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 82,
 			"level": 7,
@@ -1989,7 +1981,6 @@
 		},
 		{
 			"name": "Drow Shootist",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 83,
 			"level": 8,
@@ -2225,7 +2216,6 @@
 		},
 		{
 			"name": "Drow Warden",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 82,
 			"level": 4,
@@ -2411,7 +2401,6 @@
 		},
 		{
 			"name": "Dulac",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 9,
 			"level": 9,
@@ -2637,7 +2626,6 @@
 		},
 		{
 			"name": "Elder Child Of Belcorra",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 14,
 			"level": 9,
@@ -2884,7 +2872,6 @@
 		},
 		{
 			"name": "Galudu",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 36,
 			"level": 11,
@@ -3200,7 +3187,6 @@
 		},
 		{
 			"name": "Khurfel",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 89,
 			"level": 10,
@@ -3448,7 +3434,6 @@
 		},
 		{
 			"name": "Lady's Whisper",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 49,
 			"level": 11,
@@ -3780,7 +3765,6 @@
 		},
 		{
 			"name": "Padli",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 7,
 			"level": 9,
@@ -3997,7 +3981,6 @@
 		},
 		{
 			"name": "Quara Orshendiel",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 91,
 			"level": 11,
@@ -4264,7 +4247,6 @@
 		},
 		{
 			"name": "Reaper Skull Puffball",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 79,
 			"level": 9,
@@ -4441,7 +4423,6 @@
 		},
 		{
 			"name": "Salaisa Malthulas",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 30,
 			"level": 11,
@@ -4636,7 +4617,6 @@
 		},
 		{
 			"name": "Urdefhan Blood Mage",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 85,
 			"level": 8,
@@ -4937,7 +4917,6 @@
 		},
 		{
 			"name": "Urdefhan Death Scout",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 84,
 			"level": 6,
@@ -5151,7 +5130,6 @@
 		},
 		{
 			"name": "Urdefhan Lasher",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 84,
 			"level": 7,
@@ -5359,7 +5337,6 @@
 		},
 		{
 			"name": "Voidbracken Chuul",
-			"isNpc": false,
 			"source": "AV3",
 			"page": 57,
 			"level": 9,

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aasimar Redeemer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 263,
 			"level": 5,
@@ -190,7 +189,6 @@
 		},
 		{
 			"name": "Adamantine Golem",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Nex"
@@ -383,7 +381,6 @@
 		},
 		{
 			"name": "Adult Black Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 105,
 			"level": 11,
@@ -633,7 +630,6 @@
 		},
 		{
 			"name": "Adult Blue Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 108,
 			"level": 13,
@@ -914,7 +910,6 @@
 		},
 		{
 			"name": "Adult Brass Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 118,
 			"level": 11,
@@ -1160,7 +1155,6 @@
 		},
 		{
 			"name": "Adult Bronze Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 120,
 			"level": 13,
@@ -1423,7 +1417,6 @@
 		},
 		{
 			"name": "Adult Copper Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 122,
 			"level": 12,
@@ -1665,7 +1658,6 @@
 		},
 		{
 			"name": "Adult Gold Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 124,
 			"level": 15,
@@ -1943,7 +1935,6 @@
 		},
 		{
 			"name": "Adult Green Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 110,
 			"level": 12,
@@ -2210,7 +2201,6 @@
 		},
 		{
 			"name": "Adult Red Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 112,
 			"level": 14,
@@ -2486,7 +2476,6 @@
 		},
 		{
 			"name": "Adult Silver Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 126,
 			"level": 14,
@@ -2737,7 +2726,6 @@
 		},
 		{
 			"name": "Adult White Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 114,
 			"level": 10,
@@ -3024,7 +3012,6 @@
 		},
 		{
 			"name": "Air Mephit",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -3161,7 +3148,6 @@
 		},
 		{
 			"name": "Alchemical Golem",
-			"isNpc": false,
 			"source": "B1",
 			"page": 185,
 			"foundIn": [
@@ -3338,7 +3324,6 @@
 		},
 		{
 			"name": "Alghollthu Master",
-			"isNpc": false,
 			"source": "B1",
 			"page": 14,
 			"level": 7,
@@ -3542,7 +3527,6 @@
 		},
 		{
 			"name": "Ancient Black Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 106,
 			"level": 16,
@@ -3798,7 +3782,6 @@
 		},
 		{
 			"name": "Ancient Blue Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 108,
 			"level": 18,
@@ -4123,7 +4106,6 @@
 		},
 		{
 			"name": "Ancient Brass Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 118,
 			"level": 16,
@@ -4363,7 +4345,6 @@
 		},
 		{
 			"name": "Ancient Bronze Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 120,
 			"level": 18,
@@ -4662,7 +4643,6 @@
 		},
 		{
 			"name": "Ancient Copper Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 122,
 			"level": 17,
@@ -4946,7 +4926,6 @@
 		},
 		{
 			"name": "Ancient Gold Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 125,
 			"level": 20,
@@ -5233,7 +5212,6 @@
 		},
 		{
 			"name": "Ancient Green Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 110,
 			"level": 17,
@@ -5533,7 +5511,6 @@
 		},
 		{
 			"name": "Ancient Red Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 112,
 			"level": 19,
@@ -5844,7 +5821,6 @@
 		},
 		{
 			"name": "Ancient Silver Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 127,
 			"level": 19,
@@ -6122,7 +6098,6 @@
 		},
 		{
 			"name": "Ancient White Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 115,
 			"level": 15,
@@ -6432,7 +6407,6 @@
 		},
 		{
 			"name": "Animated Armor",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Nex"
@@ -6558,7 +6532,6 @@
 		},
 		{
 			"name": "Animated Broom",
-			"isNpc": false,
 			"source": "B1",
 			"page": 20,
 			"foundIn": [
@@ -6681,7 +6654,6 @@
 		},
 		{
 			"name": "Animated Statue",
-			"isNpc": false,
 			"source": "B1",
 			"page": 21,
 			"foundIn": [
@@ -6794,7 +6766,6 @@
 		},
 		{
 			"name": "Ankhrav",
-			"isNpc": false,
 			"source": "B1",
 			"page": 22,
 			"level": 3,
@@ -6923,7 +6894,6 @@
 		},
 		{
 			"name": "Ankylosaurus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 97,
 			"level": 6,
@@ -7040,7 +7010,6 @@
 		},
 		{
 			"name": "Annis Hag",
-			"isNpc": false,
 			"source": "B1",
 			"page": 202,
 			"level": 6,
@@ -7206,7 +7175,6 @@
 		},
 		{
 			"name": "Arbiter",
-			"isNpc": false,
 			"source": "B1",
 			"page": 8,
 			"level": 1,
@@ -7389,7 +7357,6 @@
 		},
 		{
 			"name": "Arboreal Regent",
-			"isNpc": false,
 			"source": "B1",
 			"page": 25,
 			"level": 8,
@@ -7582,7 +7549,6 @@
 		},
 		{
 			"name": "Arboreal Warden",
-			"isNpc": false,
 			"source": "B1",
 			"page": 24,
 			"level": 4,
@@ -7742,7 +7708,6 @@
 		},
 		{
 			"name": "Astradaemon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 73,
 			"level": 16,
@@ -8024,7 +7989,6 @@
 		},
 		{
 			"name": "Astral Deva",
-			"isNpc": false,
 			"source": "B1",
 			"page": 19,
 			"level": 14,
@@ -8272,7 +8236,6 @@
 		},
 		{
 			"name": "Awakened Tree",
-			"isNpc": false,
 			"source": "B1",
 			"page": 25,
 			"level": 6,
@@ -8393,7 +8356,6 @@
 		},
 		{
 			"name": "Axiomite",
-			"isNpc": false,
 			"source": "B1",
 			"page": 9,
 			"level": 8,
@@ -8608,7 +8570,6 @@
 		},
 		{
 			"name": "Azure Worm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 57,
 			"level": 15,
@@ -8824,7 +8785,6 @@
 		},
 		{
 			"name": "Balisse",
-			"isNpc": false,
 			"source": "B1",
 			"page": 18,
 			"level": 8,
@@ -9083,7 +9043,6 @@
 		},
 		{
 			"name": "Ball Python",
-			"isNpc": false,
 			"source": "B1",
 			"page": 302,
 			"level": 1,
@@ -9212,7 +9171,6 @@
 		},
 		{
 			"name": "Balor",
-			"isNpc": false,
 			"source": "B1",
 			"page": 83,
 			"level": 20,
@@ -9538,7 +9496,6 @@
 		},
 		{
 			"name": "Banshee",
-			"isNpc": false,
 			"source": "B1",
 			"page": 34,
 			"level": 17,
@@ -9722,7 +9679,6 @@
 		},
 		{
 			"name": "Baomal",
-			"isNpc": false,
 			"source": "B1",
 			"page": 35,
 			"level": 20,
@@ -9918,7 +9874,6 @@
 		},
 		{
 			"name": "Barbazu",
-			"isNpc": false,
 			"source": "B1",
 			"page": 88,
 			"level": 5,
@@ -10181,7 +10136,6 @@
 		},
 		{
 			"name": "Barghest",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -10393,7 +10347,6 @@
 		},
 		{
 			"name": "Basilisk",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -10514,7 +10467,6 @@
 		},
 		{
 			"name": "Black Pudding",
-			"isNpc": false,
 			"source": "B1",
 			"page": 255,
 			"foundIn": [
@@ -10670,7 +10622,6 @@
 		},
 		{
 			"name": "Bloodseeker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 42,
 			"level": -1,
@@ -10771,7 +10722,6 @@
 		},
 		{
 			"name": "Boar",
-			"isNpc": false,
 			"source": "B1",
 			"page": 43,
 			"level": 2,
@@ -10878,7 +10828,6 @@
 		},
 		{
 			"name": "Boggard Scout",
-			"isNpc": false,
 			"source": "B1",
 			"page": 44,
 			"level": 1,
@@ -11030,7 +10979,6 @@
 		},
 		{
 			"name": "Boggard Swampseer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 45,
 			"level": 3,
@@ -11255,7 +11203,6 @@
 		},
 		{
 			"name": "Boggard Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 44,
 			"level": 2,
@@ -11414,7 +11361,6 @@
 		},
 		{
 			"name": "Brain Collector",
-			"isNpc": false,
 			"source": "B1",
 			"page": 46,
 			"level": 8,
@@ -11682,7 +11628,6 @@
 		},
 		{
 			"name": "Brine Shark",
-			"isNpc": false,
 			"source": "B1",
 			"page": 152,
 			"foundIn": [
@@ -11797,7 +11742,6 @@
 		},
 		{
 			"name": "Brontosaurus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 100,
 			"level": 10,
@@ -11918,7 +11862,6 @@
 		},
 		{
 			"name": "Bugbear Thug",
-			"isNpc": false,
 			"source": "B1",
 			"page": 47,
 			"level": 2,
@@ -12061,7 +12004,6 @@
 		},
 		{
 			"name": "Bugbear Tormentor",
-			"isNpc": false,
 			"source": "B1",
 			"page": 47,
 			"level": 3,
@@ -12213,7 +12155,6 @@
 		},
 		{
 			"name": "Bulette",
-			"isNpc": false,
 			"source": "B1",
 			"page": 48,
 			"level": 8,
@@ -12332,7 +12273,6 @@
 		},
 		{
 			"name": "Bunyip",
-			"isNpc": false,
 			"source": "B1",
 			"page": 49,
 			"level": 3,
@@ -12504,7 +12444,6 @@
 		},
 		{
 			"name": "Cacodaemon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 70,
 			"level": 1,
@@ -12733,7 +12672,6 @@
 		},
 		{
 			"name": "Caligni Creeper",
-			"isNpc": false,
 			"source": "B1",
 			"page": 50,
 			"level": 2,
@@ -12902,7 +12840,6 @@
 		},
 		{
 			"name": "Caligni Dancer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 50,
 			"level": 1,
@@ -13103,7 +13040,6 @@
 		},
 		{
 			"name": "Caligni Stalker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 51,
 			"level": 4,
@@ -13290,7 +13226,6 @@
 		},
 		{
 			"name": "Cassisian",
-			"isNpc": false,
 			"source": "B1",
 			"page": 16,
 			"level": 1,
@@ -13501,7 +13436,6 @@
 		},
 		{
 			"name": "Catfolk Pouncer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 54,
 			"foundIn": [
@@ -13664,7 +13598,6 @@
 		},
 		{
 			"name": "Cauthooj",
-			"isNpc": false,
 			"source": "B1",
 			"page": 55,
 			"level": 12,
@@ -13827,7 +13760,6 @@
 		},
 		{
 			"name": "Cave Bear",
-			"isNpc": false,
 			"source": "B1",
 			"page": 40,
 			"level": 6,
@@ -13939,7 +13871,6 @@
 		},
 		{
 			"name": "Centaur",
-			"isNpc": false,
 			"source": "B1",
 			"page": 60,
 			"level": 3,
@@ -14100,7 +14031,6 @@
 		},
 		{
 			"name": "Centipede Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 61,
 			"level": 3,
@@ -14221,7 +14151,6 @@
 		},
 		{
 			"name": "Ceustodaemon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 71,
 			"level": 6,
@@ -14429,7 +14358,6 @@
 		},
 		{
 			"name": "Changeling Exile",
-			"isNpc": false,
 			"source": "B1",
 			"page": 62,
 			"level": 3,
@@ -14606,7 +14534,6 @@
 		},
 		{
 			"name": "Chimera",
-			"isNpc": false,
 			"source": "B1",
 			"page": 63,
 			"level": 8,
@@ -14793,7 +14720,6 @@
 		},
 		{
 			"name": "Choral",
-			"isNpc": false,
 			"source": "B1",
 			"page": 17,
 			"level": 6,
@@ -15053,7 +14979,6 @@
 		},
 		{
 			"name": "Chuul",
-			"isNpc": false,
 			"source": "B1",
 			"page": 64,
 			"level": 7,
@@ -15225,7 +15150,6 @@
 		},
 		{
 			"name": "Cinder Rat",
-			"isNpc": false,
 			"source": "B1",
 			"page": 148,
 			"foundIn": [
@@ -15351,7 +15275,6 @@
 		},
 		{
 			"name": "Clay Golem",
-			"isNpc": false,
 			"source": "B1",
 			"page": 186,
 			"foundIn": [
@@ -15532,7 +15455,6 @@
 		},
 		{
 			"name": "Cloaker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 65,
 			"level": 5,
@@ -15678,7 +15600,6 @@
 		},
 		{
 			"name": "Cloud Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 173,
 			"level": 11,
@@ -15903,7 +15824,6 @@
 		},
 		{
 			"name": "Cockatrice",
-			"isNpc": false,
 			"source": "B1",
 			"page": 66,
 			"level": 3,
@@ -15996,7 +15916,6 @@
 		},
 		{
 			"name": "Crag Linnorm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 224,
 			"level": 14,
@@ -16250,7 +16169,6 @@
 		},
 		{
 			"name": "Crimson Worm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 59,
 			"level": 18,
@@ -16494,7 +16412,6 @@
 		},
 		{
 			"name": "Crocodile",
-			"isNpc": false,
 			"source": "B1",
 			"page": 67,
 			"level": 2,
@@ -16628,7 +16545,6 @@
 		},
 		{
 			"name": "Cyclops",
-			"isNpc": false,
 			"source": "B1",
 			"page": 68,
 			"level": 5,
@@ -16788,7 +16704,6 @@
 		},
 		{
 			"name": "Daeodon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 43,
 			"level": 4,
@@ -16895,7 +16810,6 @@
 		},
 		{
 			"name": "Dandasuka",
-			"isNpc": false,
 			"source": "B1",
 			"page": 274,
 			"foundIn": [
@@ -17123,7 +17037,6 @@
 		},
 		{
 			"name": "Dark Naga",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray"
@@ -17378,7 +17291,6 @@
 		},
 		{
 			"name": "Deadly Mantis",
-			"isNpc": false,
 			"source": "B1",
 			"page": 233,
 			"level": 11,
@@ -17513,7 +17425,6 @@
 		},
 		{
 			"name": "Deep Gnome Rockwarden",
-			"isNpc": false,
 			"source": "B1",
 			"page": 75,
 			"level": 5,
@@ -17704,7 +17615,6 @@
 		},
 		{
 			"name": "Deep Gnome Scout",
-			"isNpc": false,
 			"source": "B1",
 			"page": 74,
 			"level": 1,
@@ -17839,7 +17749,6 @@
 		},
 		{
 			"name": "Deep Gnome Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 75,
 			"level": 2,
@@ -17983,7 +17892,6 @@
 		},
 		{
 			"name": "Deinonychus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 97,
 			"level": 2,
@@ -18098,7 +18006,6 @@
 		},
 		{
 			"name": "Deinosuchus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 67,
 			"level": 9,
@@ -18229,7 +18136,6 @@
 		},
 		{
 			"name": "Demilich",
-			"isNpc": false,
 			"source": "B1",
 			"page": 222,
 			"level": 15,
@@ -18530,7 +18436,6 @@
 		},
 		{
 			"name": "Dero Magister",
-			"isNpc": false,
 			"source": "B1",
 			"page": 85,
 			"level": 5,
@@ -18788,7 +18693,6 @@
 		},
 		{
 			"name": "Dero Stalker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 84,
 			"level": 2,
@@ -18970,7 +18874,6 @@
 		},
 		{
 			"name": "Dero Strangler",
-			"isNpc": false,
 			"source": "B1",
 			"page": 84,
 			"level": 3,
@@ -19160,7 +19063,6 @@
 		},
 		{
 			"name": "Desert Drake",
-			"isNpc": false,
 			"source": "B1",
 			"page": 135,
 			"level": 8,
@@ -19335,7 +19237,6 @@
 		},
 		{
 			"name": "Dezullon",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray"
@@ -19718,7 +19619,6 @@
 		},
 		{
 			"name": "Dire Wolf",
-			"isNpc": false,
 			"source": "B1",
 			"page": 334,
 			"level": 3,
@@ -19845,7 +19745,6 @@
 		},
 		{
 			"name": "Djinni",
-			"isNpc": false,
 			"source": "B1",
 			"page": 163,
 			"foundIn": [
@@ -20110,7 +20009,6 @@
 		},
 		{
 			"name": "Doppelganger",
-			"isNpc": false,
 			"source": "B1",
 			"page": 103,
 			"level": 3,
@@ -20257,7 +20155,6 @@
 		},
 		{
 			"name": "Dragon Turtle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 128,
 			"level": 9,
@@ -20398,7 +20295,6 @@
 		},
 		{
 			"name": "Drakauthix",
-			"isNpc": false,
 			"source": "B1",
 			"page": 129,
 			"level": 9,
@@ -20544,7 +20440,6 @@
 		},
 		{
 			"name": "Drider",
-			"isNpc": false,
 			"source": "B1",
 			"page": 159,
 			"level": 6,
@@ -20826,7 +20721,6 @@
 		},
 		{
 			"name": "Drow Fighter",
-			"isNpc": false,
 			"source": "B1",
 			"page": 136,
 			"foundIn": [
@@ -21043,7 +20937,6 @@
 		},
 		{
 			"name": "Drow Priestess",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Nex"
@@ -21310,7 +21203,6 @@
 		},
 		{
 			"name": "Drow Rogue",
-			"isNpc": false,
 			"source": "B1",
 			"page": 137,
 			"foundIn": [
@@ -21513,7 +21405,6 @@
 		},
 		{
 			"name": "Dryad",
-			"isNpc": false,
 			"source": "B1",
 			"page": 246,
 			"level": 3,
@@ -21729,7 +21620,6 @@
 		},
 		{
 			"name": "Dryad Queen",
-			"isNpc": false,
 			"source": "B1",
 			"page": 249,
 			"level": 13,
@@ -22165,7 +22055,6 @@
 		},
 		{
 			"name": "Duergar Bombardier",
-			"isNpc": false,
 			"source": "B1",
 			"page": 139,
 			"level": 1,
@@ -22358,7 +22247,6 @@
 		},
 		{
 			"name": "Duergar Sharpshooter",
-			"isNpc": false,
 			"source": "B1",
 			"page": 138,
 			"level": 0,
@@ -22506,7 +22394,6 @@
 		},
 		{
 			"name": "Duergar Taskmaster",
-			"isNpc": false,
 			"source": "B1",
 			"page": 139,
 			"level": 2,
@@ -22704,7 +22591,6 @@
 		},
 		{
 			"name": "Dullahan",
-			"isNpc": false,
 			"source": "B1",
 			"page": 140,
 			"level": 7,
@@ -22917,7 +22803,6 @@
 		},
 		{
 			"name": "Duskwalker Ghost Hunter",
-			"isNpc": false,
 			"source": "B1",
 			"page": 262,
 			"level": 4,
@@ -23090,7 +22975,6 @@
 		},
 		{
 			"name": "Eagle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 141,
 			"level": -1,
@@ -23189,7 +23073,6 @@
 		},
 		{
 			"name": "Earth Mephit",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -23330,7 +23213,6 @@
 		},
 		{
 			"name": "Efreeti",
-			"isNpc": false,
 			"source": "B1",
 			"page": 164,
 			"level": 9,
@@ -23566,7 +23448,6 @@
 		},
 		{
 			"name": "Elananx",
-			"isNpc": false,
 			"source": "B1",
 			"page": 143,
 			"level": 6,
@@ -23721,7 +23602,6 @@
 		},
 		{
 			"name": "Electric Eel",
-			"isNpc": false,
 			"source": "B1",
 			"page": 142,
 			"level": 1,
@@ -23833,7 +23713,6 @@
 		},
 		{
 			"name": "Elemental Avalanche",
-			"isNpc": false,
 			"source": "B1",
 			"page": 147,
 			"level": 11,
@@ -24006,7 +23885,6 @@
 		},
 		{
 			"name": "Elemental Hurricane",
-			"isNpc": false,
 			"source": "B1",
 			"page": 145,
 			"level": 11,
@@ -24178,7 +24056,6 @@
 		},
 		{
 			"name": "Elemental Inferno",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -24354,7 +24231,6 @@
 		},
 		{
 			"name": "Elemental Tsunami",
-			"isNpc": false,
 			"source": "B1",
 			"page": 153,
 			"foundIn": [
@@ -24506,7 +24382,6 @@
 		},
 		{
 			"name": "Elephant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 154,
 			"foundIn": [
@@ -24640,7 +24515,6 @@
 		},
 		{
 			"name": "Erinys",
-			"isNpc": false,
 			"source": "B1",
 			"page": 89,
 			"level": 8,
@@ -24887,7 +24761,6 @@
 		},
 		{
 			"name": "Ether Spider",
-			"isNpc": false,
 			"source": "B1",
 			"page": 155,
 			"level": 5,
@@ -25046,7 +24919,6 @@
 		},
 		{
 			"name": "Ettin",
-			"isNpc": false,
 			"source": "B1",
 			"page": 156,
 			"level": 6,
@@ -25181,7 +25053,6 @@
 		},
 		{
 			"name": "Faceless Stalker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 13,
 			"level": 4,
@@ -25366,7 +25237,6 @@
 		},
 		{
 			"name": "Faerie Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 157,
 			"level": 2,
@@ -25546,7 +25416,6 @@
 		},
 		{
 			"name": "Fire Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 172,
 			"level": 10,
@@ -25734,7 +25603,6 @@
 		},
 		{
 			"name": "Fire Mephit",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -25885,7 +25753,6 @@
 		},
 		{
 			"name": "Firewyrm",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -26051,7 +25918,6 @@
 		},
 		{
 			"name": "Flame Drake",
-			"isNpc": false,
 			"source": "B1",
 			"page": 131,
 			"level": 5,
@@ -26234,7 +26100,6 @@
 		},
 		{
 			"name": "Flash Beetle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 41,
 			"level": -1,
@@ -26340,7 +26205,6 @@
 		},
 		{
 			"name": "Flesh Golem",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Nex"
@@ -26498,7 +26362,6 @@
 		},
 		{
 			"name": "Frost Drake",
-			"isNpc": false,
 			"source": "B1",
 			"page": 134,
 			"level": 7,
@@ -26687,7 +26550,6 @@
 		},
 		{
 			"name": "Frost Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 171,
 			"level": 9,
@@ -26881,7 +26743,6 @@
 		},
 		{
 			"name": "Fungus Leshy",
-			"isNpc": false,
 			"source": "B1",
 			"page": 219,
 			"level": 2,
@@ -27056,7 +26917,6 @@
 		},
 		{
 			"name": "Gancanagh",
-			"isNpc": false,
 			"source": "B1",
 			"page": 31,
 			"level": 4,
@@ -27272,7 +27132,6 @@
 		},
 		{
 			"name": "Gargoyle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 161,
 			"level": 4,
@@ -27407,7 +27266,6 @@
 		},
 		{
 			"name": "Gelatinous Cube",
-			"isNpc": false,
 			"source": "B1",
 			"page": 254,
 			"foundIn": [
@@ -27547,7 +27405,6 @@
 		},
 		{
 			"name": "Gelugon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 91,
 			"level": 13,
@@ -27818,7 +27675,6 @@
 		},
 		{
 			"name": "Ghaele",
-			"isNpc": false,
 			"source": "B1",
 			"page": 33,
 			"level": 13,
@@ -28165,7 +28021,6 @@
 		},
 		{
 			"name": "Ghast",
-			"isNpc": false,
 			"source": "B1",
 			"page": 169,
 			"foundIn": [
@@ -28383,7 +28238,6 @@
 		},
 		{
 			"name": "Ghost Commoner",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes",
@@ -28556,7 +28410,6 @@
 					"LOIL|323"
 				]
 			},
-			"isNpc": false,
 			"source": "B1",
 			"page": 167,
 			"level": 10,
@@ -28811,7 +28664,6 @@
 		},
 		{
 			"name": "Ghoul",
-			"isNpc": false,
 			"foundIn": [
 				"Geb"
 			],
@@ -29010,7 +28862,6 @@
 		},
 		{
 			"name": "Giant Anaconda",
-			"isNpc": false,
 			"source": "B1",
 			"page": 303,
 			"level": 8,
@@ -29183,7 +29034,6 @@
 		},
 		{
 			"name": "Giant Animated Statue",
-			"isNpc": false,
 			"source": "B1",
 			"page": 21,
 			"level": 7,
@@ -29333,7 +29183,6 @@
 		},
 		{
 			"name": "Giant Bat",
-			"isNpc": false,
 			"source": "B1",
 			"page": 39,
 			"level": 2,
@@ -29448,7 +29297,6 @@
 		},
 		{
 			"name": "Giant Centipede",
-			"isNpc": false,
 			"source": "B1",
 			"page": 61,
 			"level": -1,
@@ -29561,7 +29409,6 @@
 		},
 		{
 			"name": "Giant Eagle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 141,
 			"level": 3,
@@ -29683,7 +29530,6 @@
 		},
 		{
 			"name": "Giant Flytrap",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Impossible Lands"
@@ -29842,7 +29688,6 @@
 		},
 		{
 			"name": "Giant Frilled Lizard",
-			"isNpc": false,
 			"source": "B1",
 			"page": 229,
 			"level": 5,
@@ -29959,7 +29804,6 @@
 		},
 		{
 			"name": "Giant Gecko",
-			"isNpc": false,
 			"source": "B1",
 			"page": 228,
 			"level": 1,
@@ -30046,7 +29890,6 @@
 		},
 		{
 			"name": "Giant Mantis",
-			"isNpc": false,
 			"source": "B1",
 			"page": 233,
 			"level": 3,
@@ -30160,7 +30003,6 @@
 		},
 		{
 			"name": "Giant Monitor Lizard",
-			"isNpc": false,
 			"source": "B1",
 			"page": 229,
 			"level": 2,
@@ -30294,7 +30136,6 @@
 		},
 		{
 			"name": "Giant Moray Eel",
-			"isNpc": false,
 			"source": "B1",
 			"page": 142,
 			"level": 5,
@@ -30435,7 +30276,6 @@
 		},
 		{
 			"name": "Giant Octopus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 250,
 			"level": 8,
@@ -30617,7 +30457,6 @@
 		},
 		{
 			"name": "Giant Rat",
-			"isNpc": false,
 			"source": "B1",
 			"page": 276,
 			"level": -1,
@@ -30746,7 +30585,6 @@
 		},
 		{
 			"name": "Giant Scorpion",
-			"isNpc": false,
 			"source": "B1",
 			"page": 285,
 			"level": 3,
@@ -30904,7 +30742,6 @@
 		},
 		{
 			"name": "Giant Stag Beetle",
-			"isNpc": false,
 			"source": "B1",
 			"page": 41,
 			"level": 4,
@@ -31003,7 +30840,6 @@
 		},
 		{
 			"name": "Giant Tarantula",
-			"isNpc": false,
 			"source": "B1",
 			"page": 307,
 			"level": 6,
@@ -31142,7 +30978,6 @@
 		},
 		{
 			"name": "Giant Viper",
-			"isNpc": false,
 			"source": "B1",
 			"page": 303,
 			"level": 2,
@@ -31281,7 +31116,6 @@
 		},
 		{
 			"name": "Giant Wasp",
-			"isNpc": false,
 			"source": "B1",
 			"page": 324,
 			"level": 3,
@@ -31428,7 +31262,6 @@
 		},
 		{
 			"name": "Gibbering Mouther",
-			"isNpc": false,
 			"source": "B1",
 			"page": 176,
 			"level": 5,
@@ -31607,7 +31440,6 @@
 		},
 		{
 			"name": "Gimmerling",
-			"isNpc": false,
 			"source": "B1",
 			"page": 177,
 			"level": 12,
@@ -32249,7 +32081,6 @@
 		},
 		{
 			"name": "Glabrezu",
-			"isNpc": false,
 			"source": "B1",
 			"page": 79,
 			"level": 13,
@@ -32542,7 +32373,6 @@
 		},
 		{
 			"name": "Gnoll Cultist",
-			"isNpc": false,
 			"source": "B1",
 			"page": 179,
 			"level": 3,
@@ -32668,7 +32498,6 @@
 		},
 		{
 			"name": "Gnoll Hunter",
-			"isNpc": false,
 			"source": "B1",
 			"page": 178,
 			"level": 2,
@@ -32803,7 +32632,6 @@
 		},
 		{
 			"name": "Gnoll Sergeant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 179,
 			"level": 4,
@@ -32967,7 +32795,6 @@
 		},
 		{
 			"name": "Goblin Commando",
-			"isNpc": false,
 			"source": "B1",
 			"page": 180,
 			"level": 1,
@@ -33093,7 +32920,6 @@
 		},
 		{
 			"name": "Goblin Dog",
-			"isNpc": false,
 			"source": "B1",
 			"page": 182,
 			"level": 1,
@@ -33250,7 +33076,6 @@
 		},
 		{
 			"name": "Goblin Pyro",
-			"isNpc": false,
 			"source": "B1",
 			"page": 181,
 			"foundIn": [
@@ -33401,7 +33226,6 @@
 		},
 		{
 			"name": "Goblin War Chanter",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -33597,7 +33421,6 @@
 		},
 		{
 			"name": "Goblin Warrior",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes"
@@ -33729,7 +33552,6 @@
 		},
 		{
 			"name": "Gogiteth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 183,
 			"level": 12,
@@ -33887,7 +33709,6 @@
 		},
 		{
 			"name": "Goliath Spider",
-			"isNpc": false,
 			"source": "B1",
 			"page": 307,
 			"level": 11,
@@ -34055,7 +33876,6 @@
 		},
 		{
 			"name": "Gorilla",
-			"isNpc": false,
 			"source": "B1",
 			"page": 23,
 			"level": 3,
@@ -34180,7 +34000,6 @@
 		},
 		{
 			"name": "Gourd Leshy",
-			"isNpc": false,
 			"source": "B1",
 			"page": 218,
 			"level": 1,
@@ -34354,7 +34173,6 @@
 		},
 		{
 			"name": "Great Cyclops",
-			"isNpc": false,
 			"source": "B1",
 			"page": 69,
 			"level": 12,
@@ -34555,7 +34373,6 @@
 		},
 		{
 			"name": "Great White Shark",
-			"isNpc": false,
 			"source": "B1",
 			"page": 291,
 			"level": 4,
@@ -34678,7 +34495,6 @@
 		},
 		{
 			"name": "Greater Barghest",
-			"isNpc": false,
 			"source": "B1",
 			"page": 37,
 			"level": 7,
@@ -34915,7 +34731,6 @@
 		},
 		{
 			"name": "Greater Nightmare",
-			"isNpc": false,
 			"source": "B1",
 			"page": 244,
 			"level": 11,
@@ -35090,7 +34905,6 @@
 		},
 		{
 			"name": "Greater Shadow",
-			"isNpc": false,
 			"source": "B1",
 			"page": 289,
 			"level": 7,
@@ -35248,7 +35062,6 @@
 		},
 		{
 			"name": "Green Hag",
-			"isNpc": false,
 			"source": "B1",
 			"page": 201,
 			"level": 4,
@@ -35497,7 +35310,6 @@
 		},
 		{
 			"name": "Griffon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 194,
 			"level": 4,
@@ -35631,7 +35443,6 @@
 		},
 		{
 			"name": "Grig",
-			"isNpc": false,
 			"source": "B1",
 			"page": 308,
 			"level": 1,
@@ -35805,7 +35616,6 @@
 		},
 		{
 			"name": "Grikkitog",
-			"isNpc": false,
 			"source": "B1",
 			"page": 195,
 			"level": 14,
@@ -35961,7 +35771,6 @@
 		},
 		{
 			"name": "Grim Reaper",
-			"isNpc": false,
 			"source": "B1",
 			"page": 196,
 			"level": 21,
@@ -36228,7 +36037,6 @@
 		},
 		{
 			"name": "Grizzly Bear",
-			"isNpc": false,
 			"source": "B1",
 			"page": 40,
 			"level": 3,
@@ -36339,7 +36147,6 @@
 		},
 		{
 			"name": "Grothlut",
-			"isNpc": false,
 			"source": "B1",
 			"page": 158,
 			"foundIn": [
@@ -36468,7 +36275,6 @@
 		},
 		{
 			"name": "Guard Dog",
-			"isNpc": false,
 			"source": "B1",
 			"page": 102,
 			"level": -1,
@@ -36560,7 +36366,6 @@
 		},
 		{
 			"name": "Guardian Naga",
-			"isNpc": false,
 			"source": "B1",
 			"page": 243,
 			"foundIn": [
@@ -36824,7 +36629,6 @@
 		},
 		{
 			"name": "Gug",
-			"isNpc": false,
 			"source": "B1",
 			"page": 198,
 			"level": 10,
@@ -36972,7 +36776,6 @@
 		},
 		{
 			"name": "Guthallath",
-			"isNpc": false,
 			"source": "B1",
 			"page": 199,
 			"level": 19,
@@ -37182,7 +36985,6 @@
 		},
 		{
 			"name": "Harpy",
-			"isNpc": false,
 			"source": "B1",
 			"page": 204,
 			"level": 5,
@@ -37325,7 +37127,6 @@
 		},
 		{
 			"name": "Hell Hound",
-			"isNpc": false,
 			"source": "B1",
 			"page": 205,
 			"level": 3,
@@ -37449,7 +37250,6 @@
 		},
 		{
 			"name": "Hill Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 170,
 			"foundIn": [
@@ -37611,7 +37411,6 @@
 		},
 		{
 			"name": "Hive Mother",
-			"isNpc": false,
 			"source": "B1",
 			"page": 22,
 			"level": 8,
@@ -37762,7 +37561,6 @@
 		},
 		{
 			"name": "Hobgoblin Archer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 207,
 			"level": 4,
@@ -37902,7 +37700,6 @@
 		},
 		{
 			"name": "Hobgoblin General",
-			"isNpc": false,
 			"source": "B1",
 			"page": 207,
 			"level": 6,
@@ -38039,7 +37836,6 @@
 		},
 		{
 			"name": "Hobgoblin Soldier",
-			"isNpc": false,
 			"source": "B1",
 			"page": 206,
 			"level": 1,
@@ -38174,7 +37970,6 @@
 		},
 		{
 			"name": "Homunculus",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Nex"
@@ -38305,7 +38100,6 @@
 		},
 		{
 			"name": "Horned Archon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 27,
 			"level": 4,
@@ -38530,7 +38324,6 @@
 		},
 		{
 			"name": "Hunting Spider",
-			"isNpc": false,
 			"source": "B1",
 			"page": 306,
 			"level": 1,
@@ -38696,7 +38489,6 @@
 		},
 		{
 			"name": "Hyaenodon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 211,
 			"level": 3,
@@ -38805,7 +38597,6 @@
 		},
 		{
 			"name": "Hydra",
-			"isNpc": false,
 			"source": "B1",
 			"page": 210,
 			"level": 6,
@@ -38963,7 +38754,6 @@
 		},
 		{
 			"name": "Hyena",
-			"isNpc": false,
 			"source": "B1",
 			"page": 211,
 			"level": 1,
@@ -39066,7 +38856,6 @@
 		},
 		{
 			"name": "Ice Linnorm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 225,
 			"level": 17,
@@ -39326,7 +39115,6 @@
 		},
 		{
 			"name": "Imp",
-			"isNpc": false,
 			"source": "B1",
 			"page": 87,
 			"level": 1,
@@ -39578,7 +39366,6 @@
 		},
 		{
 			"name": "Invisible Stalker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 144,
 			"foundIn": [
@@ -39706,7 +39493,6 @@
 		},
 		{
 			"name": "Iron Golem",
-			"isNpc": false,
 			"source": "B1",
 			"page": 188,
 			"level": 13,
@@ -39895,7 +39681,6 @@
 		},
 		{
 			"name": "Janni",
-			"isNpc": false,
 			"source": "B1",
 			"page": 162,
 			"foundIn": [
@@ -40113,7 +39898,6 @@
 		},
 		{
 			"name": "Jinkin",
-			"isNpc": false,
 			"source": "B1",
 			"page": 193,
 			"level": 1,
@@ -40255,7 +40039,6 @@
 		},
 		{
 			"name": "Jungle Drake",
-			"isNpc": false,
 			"source": "B1",
 			"page": 132,
 			"level": 6,
@@ -40460,7 +40243,6 @@
 		},
 		{
 			"name": "Keketar",
-			"isNpc": false,
 			"source": "B1",
 			"page": 269,
 			"level": 17,
@@ -40857,7 +40639,6 @@
 		},
 		{
 			"name": "Kobold Dragon Mage",
-			"isNpc": false,
 			"source": "B1",
 			"page": 213,
 			"level": 2,
@@ -41059,7 +40840,6 @@
 		},
 		{
 			"name": "Kobold Scout",
-			"isNpc": false,
 			"source": "B1",
 			"page": 213,
 			"level": 1,
@@ -41196,7 +40976,6 @@
 		},
 		{
 			"name": "Kobold Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 212,
 			"level": -1,
@@ -41329,7 +41108,6 @@
 		},
 		{
 			"name": "Kolyarut",
-			"isNpc": false,
 			"source": "B1",
 			"page": 10,
 			"level": 12,
@@ -41534,7 +41312,6 @@
 		},
 		{
 			"name": "Kraken",
-			"isNpc": false,
 			"source": "B1",
 			"page": 214,
 			"level": 18,
@@ -41792,7 +41569,6 @@
 		},
 		{
 			"name": "Krooth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 215,
 			"level": 8,
@@ -41959,7 +41735,6 @@
 		},
 		{
 			"name": "Lamia",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Impossible Lands"
@@ -42176,7 +41951,6 @@
 		},
 		{
 			"name": "Lamia Matriarch",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -42474,7 +42248,6 @@
 		},
 		{
 			"name": "Lantern Archon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 26,
 			"level": 1,
@@ -42666,7 +42439,6 @@
 		},
 		{
 			"name": "Leaf Leshy",
-			"isNpc": false,
 			"source": "B1",
 			"page": 218,
 			"level": 0,
@@ -42864,7 +42636,6 @@
 		},
 		{
 			"name": "Legion Archon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 28,
 			"level": 7,
@@ -43090,7 +42861,6 @@
 		},
 		{
 			"name": "Lemure",
-			"isNpc": false,
 			"source": "B1",
 			"page": 86,
 			"level": 0,
@@ -43195,7 +42965,6 @@
 		},
 		{
 			"name": "Leopard",
-			"isNpc": false,
 			"source": "B1",
 			"page": 52,
 			"foundIn": [
@@ -43337,7 +43106,6 @@
 		},
 		{
 			"name": "Lesser Death",
-			"isNpc": false,
 			"source": "B1",
 			"page": 197,
 			"level": 16,
@@ -43556,7 +43324,6 @@
 		},
 		{
 			"name": "Leukodaemon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 72,
 			"level": 9,
@@ -43858,7 +43625,6 @@
 		},
 		{
 			"name": "Lich",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Geb"
@@ -44178,7 +43944,6 @@
 		},
 		{
 			"name": "Lillend",
-			"isNpc": false,
 			"source": "B1",
 			"page": 32,
 			"level": 7,
@@ -44431,7 +44196,6 @@
 		},
 		{
 			"name": "Lion",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes"
@@ -44564,7 +44328,6 @@
 		},
 		{
 			"name": "Living Landslide",
-			"isNpc": false,
 			"source": "B1",
 			"page": 146,
 			"foundIn": [
@@ -44700,7 +44463,6 @@
 		},
 		{
 			"name": "Living Waterfall",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -44843,7 +44605,6 @@
 		},
 		{
 			"name": "Living Whirlwind",
-			"isNpc": false,
 			"source": "B1",
 			"page": 144,
 			"foundIn": [
@@ -44966,7 +44727,6 @@
 		},
 		{
 			"name": "Living Wildfire",
-			"isNpc": false,
 			"source": "B1",
 			"page": 148,
 			"foundIn": [
@@ -45108,7 +44868,6 @@
 		},
 		{
 			"name": "Lizardfolk Defender",
-			"isNpc": false,
 			"source": "B1",
 			"page": 230,
 			"level": 1,
@@ -45270,7 +45029,6 @@
 		},
 		{
 			"name": "Lizardfolk Scout",
-			"isNpc": false,
 			"source": "B1",
 			"page": 231,
 			"level": 1,
@@ -45450,7 +45208,6 @@
 		},
 		{
 			"name": "Lizardfolk Stargazer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 231,
 			"level": 2,
@@ -45618,7 +45375,6 @@
 		},
 		{
 			"name": "Lyrakien",
-			"isNpc": false,
 			"source": "B1",
 			"page": 30,
 			"level": 1,
@@ -45810,7 +45566,6 @@
 		},
 		{
 			"name": "Mammoth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 154,
 			"level": 10,
@@ -45953,7 +45708,6 @@
 		},
 		{
 			"name": "Manticore",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -46089,7 +45843,6 @@
 		},
 		{
 			"name": "Marid",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray"
@@ -46383,7 +46136,6 @@
 		},
 		{
 			"name": "Marilith",
-			"isNpc": false,
 			"source": "B1",
 			"page": 81,
 			"level": 17,
@@ -46677,7 +46429,6 @@
 		},
 		{
 			"name": "Medusa",
-			"isNpc": false,
 			"source": "B1",
 			"page": 234,
 			"level": 7,
@@ -46873,7 +46624,6 @@
 		},
 		{
 			"name": "Megalodon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 291,
 			"level": 9,
@@ -47027,7 +46777,6 @@
 		},
 		{
 			"name": "Megaprimatus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 23,
 			"level": 8,
@@ -47160,7 +46909,6 @@
 		},
 		{
 			"name": "Merfolk Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 235,
 			"level": 1,
@@ -47270,7 +47018,6 @@
 		},
 		{
 			"name": "Merfolk Wavecaller",
-			"isNpc": false,
 			"source": "B1",
 			"page": 235,
 			"level": 2,
@@ -47443,7 +47190,6 @@
 		},
 		{
 			"name": "Mimic",
-			"isNpc": false,
 			"source": "B1",
 			"page": 236,
 			"level": 4,
@@ -47563,7 +47309,6 @@
 		},
 		{
 			"name": "Minotaur",
-			"isNpc": false,
 			"source": "B1",
 			"page": 237,
 			"level": 4,
@@ -47701,7 +47446,6 @@
 		},
 		{
 			"name": "Mitflit",
-			"isNpc": false,
 			"source": "B1",
 			"page": 192,
 			"level": -1,
@@ -47894,7 +47638,6 @@
 		},
 		{
 			"name": "Morrigna",
-			"isNpc": false,
 			"source": "B1",
 			"page": 271,
 			"level": 15,
@@ -48274,7 +48017,6 @@
 		},
 		{
 			"name": "Mu Spore",
-			"isNpc": false,
 			"source": "B1",
 			"page": 238,
 			"level": 21,
@@ -48509,7 +48251,6 @@
 		},
 		{
 			"name": "Mukradi",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -48756,7 +48497,6 @@
 		},
 		{
 			"name": "Mummy Guardian",
-			"isNpc": false,
 			"foundIn": [
 				"Geb"
 			],
@@ -48911,7 +48651,6 @@
 		},
 		{
 			"name": "Mummy Pharaoh",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Geb"
@@ -49157,7 +48896,6 @@
 		},
 		{
 			"name": "Naiad",
-			"isNpc": false,
 			"source": "B1",
 			"page": 246,
 			"level": 1,
@@ -49344,7 +49082,6 @@
 		},
 		{
 			"name": "Naiad Queen",
-			"isNpc": false,
 			"source": "B1",
 			"page": 248,
 			"level": 7,
@@ -49672,7 +49409,6 @@
 		},
 		{
 			"name": "Naunet",
-			"isNpc": false,
 			"source": "B1",
 			"page": 267,
 			"level": 7,
@@ -49988,7 +49724,6 @@
 		},
 		{
 			"name": "Nessian Warhound",
-			"isNpc": false,
 			"source": "B1",
 			"page": 205,
 			"level": 9,
@@ -50124,7 +49859,6 @@
 		},
 		{
 			"name": "Night Hag",
-			"isNpc": false,
 			"source": "B1",
 			"page": 202,
 			"level": 9,
@@ -50432,7 +50166,6 @@
 		},
 		{
 			"name": "Nightmare",
-			"isNpc": false,
 			"source": "B1",
 			"page": 244,
 			"level": 6,
@@ -50589,7 +50322,6 @@
 		},
 		{
 			"name": "Nilith",
-			"isNpc": false,
 			"source": "B1",
 			"page": 245,
 			"level": 10,
@@ -50795,7 +50527,6 @@
 		},
 		{
 			"name": "Nosoi",
-			"isNpc": false,
 			"source": "B1",
 			"page": 270,
 			"level": 1,
@@ -51010,7 +50741,6 @@
 		},
 		{
 			"name": "Ochre Jelly",
-			"isNpc": false,
 			"source": "B1",
 			"page": 255,
 			"foundIn": [
@@ -51148,7 +50878,6 @@
 		},
 		{
 			"name": "Ofalth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 251,
 			"level": 10,
@@ -51301,7 +51030,6 @@
 		},
 		{
 			"name": "Ogre Boss",
-			"isNpc": false,
 			"source": "B1",
 			"page": 253,
 			"foundIn": [
@@ -51456,7 +51184,6 @@
 		},
 		{
 			"name": "Ogre Glutton",
-			"isNpc": false,
 			"source": "B1",
 			"page": 253,
 			"foundIn": [
@@ -51602,7 +51329,6 @@
 		},
 		{
 			"name": "Ogre Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 252,
 			"level": 3,
@@ -51701,7 +51427,6 @@
 		},
 		{
 			"name": "Orc Brute",
-			"isNpc": false,
 			"source": "B1",
 			"page": 256,
 			"level": 0,
@@ -51828,7 +51553,6 @@
 		},
 		{
 			"name": "Orc Warchief",
-			"isNpc": false,
 			"source": "B1",
 			"page": 257,
 			"level": 2,
@@ -51988,7 +51712,6 @@
 		},
 		{
 			"name": "Orc Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 257,
 			"level": 1,
@@ -52142,7 +51865,6 @@
 		},
 		{
 			"name": "Otyugh",
-			"isNpc": false,
 			"source": "B1",
 			"page": 258,
 			"level": 4,
@@ -52321,7 +52043,6 @@
 		},
 		{
 			"name": "Owlbear",
-			"isNpc": false,
 			"source": "B1",
 			"page": 259,
 			"level": 4,
@@ -52480,7 +52201,6 @@
 		},
 		{
 			"name": "Pegasus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 260,
 			"level": 3,
@@ -52615,7 +52335,6 @@
 		},
 		{
 			"name": "Phistophilus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 90,
 			"level": 10,
@@ -52910,7 +52629,6 @@
 		},
 		{
 			"name": "Phoenix",
-			"isNpc": false,
 			"source": "B1",
 			"page": 261,
 			"level": 15,
@@ -53186,7 +52904,6 @@
 		},
 		{
 			"name": "Pit Fiend",
-			"isNpc": false,
 			"source": "B1",
 			"page": 92,
 			"level": 20,
@@ -53594,7 +53311,6 @@
 		},
 		{
 			"name": "Pixie",
-			"isNpc": false,
 			"source": "B1",
 			"page": 309,
 			"level": 4,
@@ -53795,7 +53511,6 @@
 		},
 		{
 			"name": "Plague Zombie",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes",
@@ -53949,7 +53664,6 @@
 		},
 		{
 			"name": "Pleroma",
-			"isNpc": false,
 			"source": "B1",
 			"page": 10,
 			"level": 20,
@@ -54257,7 +53971,6 @@
 		},
 		{
 			"name": "Poltergeist",
-			"isNpc": false,
 			"source": "B1",
 			"page": 264,
 			"level": 5,
@@ -54482,7 +54195,6 @@
 		},
 		{
 			"name": "Poracha",
-			"isNpc": false,
 			"source": "B1",
 			"page": 265,
 			"level": 4,
@@ -54630,7 +54342,6 @@
 		},
 		{
 			"name": "Pteranodon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 272,
 			"level": 2,
@@ -54722,7 +54433,6 @@
 		},
 		{
 			"name": "Pugwampi",
-			"isNpc": false,
 			"source": "B1",
 			"page": 193,
 			"level": 0,
@@ -54884,7 +54594,6 @@
 		},
 		{
 			"name": "Purple Worm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 56,
 			"level": 13,
@@ -55109,7 +54818,6 @@
 		},
 		{
 			"name": "Quasit",
-			"isNpc": false,
 			"source": "B1",
 			"page": 76,
 			"level": 1,
@@ -55369,7 +55077,6 @@
 		},
 		{
 			"name": "Quatoid",
-			"isNpc": false,
 			"source": "B1",
 			"page": 153,
 			"foundIn": [
@@ -55542,7 +55249,6 @@
 		},
 		{
 			"name": "Quelaunt",
-			"isNpc": false,
 			"source": "B1",
 			"page": 273,
 			"level": 15,
@@ -55747,7 +55453,6 @@
 		},
 		{
 			"name": "Quetzalcoatlus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 272,
 			"level": 7,
@@ -55851,7 +55556,6 @@
 		},
 		{
 			"name": "Raja Rakshasa",
-			"isNpc": false,
 			"source": "B1",
 			"page": 275,
 			"foundIn": [
@@ -56162,7 +55866,6 @@
 		},
 		{
 			"name": "Rat Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 276,
 			"level": 1,
@@ -56288,7 +55991,6 @@
 		},
 		{
 			"name": "Ratfolk Grenadier",
-			"isNpc": false,
 			"source": "B1",
 			"page": 277,
 			"level": 4,
@@ -56461,7 +56163,6 @@
 		},
 		{
 			"name": "Redcap",
-			"isNpc": false,
 			"source": "B1",
 			"page": 278,
 			"level": 5,
@@ -56657,7 +56358,6 @@
 		},
 		{
 			"name": "Reefclaw",
-			"isNpc": false,
 			"source": "B1",
 			"page": 279,
 			"level": 1,
@@ -56796,7 +56496,6 @@
 		},
 		{
 			"name": "Remorhaz",
-			"isNpc": false,
 			"source": "B1",
 			"page": 280,
 			"level": 7,
@@ -56973,7 +56672,6 @@
 		},
 		{
 			"name": "Riding Dog",
-			"isNpc": false,
 			"source": "B1",
 			"page": 102,
 			"level": 1,
@@ -57068,7 +56766,6 @@
 		},
 		{
 			"name": "Riding Horse",
-			"isNpc": false,
 			"source": "B1",
 			"page": 209,
 			"level": 1,
@@ -57174,7 +56871,6 @@
 		},
 		{
 			"name": "Riding Pony",
-			"isNpc": false,
 			"source": "B1",
 			"page": 209,
 			"level": 0,
@@ -57279,7 +56975,6 @@
 		},
 		{
 			"name": "River Drake",
-			"isNpc": false,
 			"source": "B1",
 			"page": 131,
 			"level": 3,
@@ -57452,7 +57147,6 @@
 		},
 		{
 			"name": "Roc",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -57604,7 +57298,6 @@
 		},
 		{
 			"name": "Roper",
-			"isNpc": false,
 			"source": "B1",
 			"page": 282,
 			"level": 10,
@@ -57769,7 +57462,6 @@
 		},
 		{
 			"name": "Rune Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 175,
 			"level": 16,
@@ -58097,7 +57789,6 @@
 		},
 		{
 			"name": "Rust Monster",
-			"isNpc": false,
 			"source": "B1",
 			"page": 283,
 			"level": 3,
@@ -58248,7 +57939,6 @@
 		},
 		{
 			"name": "Salamander",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -58426,7 +58116,6 @@
 		},
 		{
 			"name": "Satyr",
-			"isNpc": false,
 			"source": "B1",
 			"page": 284,
 			"level": 4,
@@ -58645,7 +58334,6 @@
 		},
 		{
 			"name": "Scorpion Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 285,
 			"level": 4,
@@ -58750,7 +58438,6 @@
 		},
 		{
 			"name": "Sea Devil Baron",
-			"isNpc": false,
 			"source": "B1",
 			"page": 287,
 			"level": 6,
@@ -58935,7 +58622,6 @@
 		},
 		{
 			"name": "Sea Devil Brute",
-			"isNpc": false,
 			"source": "B1",
 			"page": 287,
 			"level": 4,
@@ -59103,7 +58789,6 @@
 		},
 		{
 			"name": "Sea Devil Scout",
-			"isNpc": false,
 			"source": "B1",
 			"page": 286,
 			"level": 2,
@@ -59260,7 +58945,6 @@
 		},
 		{
 			"name": "Sea Hag",
-			"isNpc": false,
 			"source": "B1",
 			"page": 200,
 			"level": 3,
@@ -59407,7 +59091,6 @@
 		},
 		{
 			"name": "Sea Serpent",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -59627,7 +59310,6 @@
 		},
 		{
 			"name": "Sewer Ooze",
-			"isNpc": false,
 			"source": "B1",
 			"page": 254,
 			"foundIn": [
@@ -59745,7 +59427,6 @@
 		},
 		{
 			"name": "Shadow",
-			"isNpc": false,
 			"source": "B1",
 			"page": 289,
 			"level": 4,
@@ -59886,7 +59567,6 @@
 		},
 		{
 			"name": "Shaitan",
-			"isNpc": false,
 			"source": "B1",
 			"page": 164,
 			"foundIn": [
@@ -60105,7 +59785,6 @@
 		},
 		{
 			"name": "Shambler",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -60252,7 +59931,6 @@
 		},
 		{
 			"name": "Shemhazian",
-			"isNpc": false,
 			"source": "B1",
 			"page": 80,
 			"level": 16,
@@ -60552,7 +60230,6 @@
 		},
 		{
 			"name": "Shield Archon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 29,
 			"level": 10,
@@ -60774,7 +60451,6 @@
 		},
 		{
 			"name": "Shining Child",
-			"isNpc": false,
 			"source": "B1",
 			"page": 292,
 			"level": 12,
@@ -61003,7 +60679,6 @@
 		},
 		{
 			"name": "Shoggoth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 293,
 			"level": 18,
@@ -61178,7 +60853,6 @@
 		},
 		{
 			"name": "Shuln",
-			"isNpc": false,
 			"source": "B1",
 			"page": 294,
 			"level": 12,
@@ -61324,7 +60998,6 @@
 		},
 		{
 			"name": "Sinspawn",
-			"isNpc": false,
 			"source": "B1",
 			"page": 297,
 			"level": 2,
@@ -61491,7 +61164,6 @@
 		},
 		{
 			"name": "Skeletal Champion",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -61677,7 +61349,6 @@
 		},
 		{
 			"name": "Skeletal Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 299,
 			"foundIn": [
@@ -61838,7 +61509,6 @@
 		},
 		{
 			"name": "Skeletal Horse",
-			"isNpc": false,
 			"source": "B1",
 			"page": 299,
 			"foundIn": [
@@ -61975,7 +61645,6 @@
 		},
 		{
 			"name": "Skeletal Hulk",
-			"isNpc": false,
 			"source": "B1",
 			"page": 299,
 			"foundIn": [
@@ -62095,7 +61764,6 @@
 		},
 		{
 			"name": "Skeleton Guard",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -62246,7 +61914,6 @@
 		},
 		{
 			"name": "Skulltaker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 300,
 			"level": 18,
@@ -62506,7 +62173,6 @@
 		},
 		{
 			"name": "Skum",
-			"isNpc": false,
 			"source": "B1",
 			"page": 12,
 			"level": 2,
@@ -62625,7 +62291,6 @@
 		},
 		{
 			"name": "Slurk",
-			"isNpc": false,
 			"source": "B1",
 			"page": 301,
 			"level": 2,
@@ -62742,7 +62407,6 @@
 		},
 		{
 			"name": "Smilodon",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -62886,7 +62550,6 @@
 		},
 		{
 			"name": "Snapping Flytrap",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Impossible Lands"
@@ -63044,7 +62707,6 @@
 		},
 		{
 			"name": "Sod Hound",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -63162,7 +62824,6 @@
 		},
 		{
 			"name": "Soulbound Doll",
-			"isNpc": false,
 			"source": "B1",
 			"page": 304,
 			"foundIn": [
@@ -63318,7 +62979,6 @@
 		},
 		{
 			"name": "Sphinx",
-			"isNpc": false,
 			"source": "B1",
 			"page": 305,
 			"foundIn": [
@@ -63533,7 +63193,6 @@
 		},
 		{
 			"name": "Spider Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 306,
 			"level": 0,
@@ -63660,7 +63319,6 @@
 		},
 		{
 			"name": "Sprite",
-			"isNpc": false,
 			"source": "B1",
 			"page": 308,
 			"level": -1,
@@ -63810,7 +63468,6 @@
 		},
 		{
 			"name": "Stegosaurus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 98,
 			"level": 7,
@@ -63931,7 +63588,6 @@
 		},
 		{
 			"name": "Stone Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 170,
 			"level": 8,
@@ -64092,7 +63748,6 @@
 		},
 		{
 			"name": "Stone Golem",
-			"isNpc": false,
 			"source": "B1",
 			"page": 187,
 			"foundIn": [
@@ -64261,7 +63916,6 @@
 		},
 		{
 			"name": "Stone Mauler",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -64421,7 +64075,6 @@
 		},
 		{
 			"name": "Storm Giant",
-			"isNpc": false,
 			"source": "B1",
 			"page": 174,
 			"level": 13,
@@ -64641,7 +64294,6 @@
 		},
 		{
 			"name": "Storm Lord",
-			"isNpc": false,
 			"source": "B1",
 			"page": 145,
 			"foundIn": [
@@ -64785,7 +64437,6 @@
 		},
 		{
 			"name": "Succubus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 77,
 			"level": 7,
@@ -65082,7 +64733,6 @@
 		},
 		{
 			"name": "Tarn Linnorm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 226,
 			"level": 20,
@@ -65363,7 +65013,6 @@
 		},
 		{
 			"name": "Tengu Sneak",
-			"isNpc": false,
 			"source": "B1",
 			"page": 310,
 			"level": 2,
@@ -65515,7 +65164,6 @@
 		},
 		{
 			"name": "Terotricus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 311,
 			"level": 19,
@@ -65746,7 +65394,6 @@
 		},
 		{
 			"name": "Tidal Master",
-			"isNpc": false,
 			"source": "B1",
 			"page": 153,
 			"foundIn": [
@@ -65888,7 +65535,6 @@
 		},
 		{
 			"name": "Tiefling Adept",
-			"isNpc": false,
 			"source": "B1",
 			"page": 262,
 			"level": 3,
@@ -66124,7 +65770,6 @@
 		},
 		{
 			"name": "Tiger",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -66260,7 +65905,6 @@
 		},
 		{
 			"name": "Tor Linnorm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 227,
 			"level": 21,
@@ -66536,7 +66180,6 @@
 		},
 		{
 			"name": "Treerazer",
-			"isNpc": false,
 			"source": "B1",
 			"page": 312,
 			"level": 25,
@@ -66891,7 +66534,6 @@
 		},
 		{
 			"name": "Triceratops",
-			"isNpc": false,
 			"source": "B1",
 			"page": 99,
 			"level": 8,
@@ -67030,7 +66672,6 @@
 		},
 		{
 			"name": "Troll",
-			"isNpc": false,
 			"source": "B1",
 			"page": 314,
 			"level": 5,
@@ -67164,7 +66805,6 @@
 		},
 		{
 			"name": "Troll King",
-			"isNpc": false,
 			"source": "B1",
 			"page": 315,
 			"level": 10,
@@ -67361,7 +67001,6 @@
 		},
 		{
 			"name": "Tyrannosaurus",
-			"isNpc": false,
 			"source": "B1",
 			"page": 101,
 			"level": 10,
@@ -67539,7 +67178,6 @@
 		},
 		{
 			"name": "Unicorn",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Impossible Lands"
@@ -67737,7 +67375,6 @@
 		},
 		{
 			"name": "Uthul",
-			"isNpc": false,
 			"source": "B1",
 			"page": 317,
 			"level": 14,
@@ -67904,7 +67541,6 @@
 		},
 		{
 			"name": "Vampire Bat Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 39,
 			"level": 1,
@@ -68013,7 +67649,6 @@
 		},
 		{
 			"name": "Vampire Count",
-			"isNpc": false,
 			"source": "B1",
 			"page": 320,
 			"foundIn": [
@@ -68263,7 +67898,6 @@
 		},
 		{
 			"name": "Vampire Mastermind",
-			"isNpc": false,
 			"source": "B1",
 			"page": 321,
 			"level": 9,
@@ -68626,7 +68260,6 @@
 		},
 		{
 			"name": "Vampire Spawn Rogue",
-			"isNpc": false,
 			"source": "B1",
 			"page": 320,
 			"foundIn": [
@@ -68775,7 +68408,6 @@
 		},
 		{
 			"name": "Veiled Master",
-			"isNpc": false,
 			"source": "B1",
 			"page": 15,
 			"level": 14,
@@ -69140,7 +68772,6 @@
 		},
 		{
 			"name": "Velociraptor",
-			"isNpc": false,
 			"source": "B1",
 			"page": 96,
 			"level": 1,
@@ -69257,7 +68888,6 @@
 		},
 		{
 			"name": "Viper",
-			"isNpc": false,
 			"source": "B1",
 			"page": 302,
 			"level": -1,
@@ -69384,7 +69014,6 @@
 		},
 		{
 			"name": "Voidworm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 266,
 			"level": 1,
@@ -69640,7 +69269,6 @@
 		},
 		{
 			"name": "Vrock",
-			"isNpc": false,
 			"source": "B1",
 			"page": 78,
 			"level": 9,
@@ -69910,7 +69538,6 @@
 		},
 		{
 			"name": "War Horse",
-			"isNpc": false,
 			"source": "B1",
 			"page": 209,
 			"level": 2,
@@ -70015,7 +69642,6 @@
 		},
 		{
 			"name": "War Pony",
-			"isNpc": false,
 			"source": "B1",
 			"page": 209,
 			"level": 1,
@@ -70120,7 +69746,6 @@
 		},
 		{
 			"name": "Warg",
-			"isNpc": false,
 			"source": "B1",
 			"page": 322,
 			"level": 2,
@@ -70257,7 +69882,6 @@
 		},
 		{
 			"name": "Warsworn",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Alkenstar",
@@ -70477,7 +70101,6 @@
 		},
 		{
 			"name": "Wasp Swarm",
-			"isNpc": false,
 			"source": "B1",
 			"page": 324,
 			"level": 4,
@@ -70587,7 +70210,6 @@
 		},
 		{
 			"name": "Water Mephit",
-			"isNpc": false,
 			"source": "B1",
 			"foundIn": [
 				"Jalmeray",
@@ -70722,7 +70344,6 @@
 		},
 		{
 			"name": "Web Lurker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 325,
 			"level": 3,
@@ -70894,7 +70515,6 @@
 		},
 		{
 			"name": "Wemmuth",
-			"isNpc": false,
 			"source": "B1",
 			"page": 326,
 			"level": 15,
@@ -71056,7 +70676,6 @@
 		},
 		{
 			"name": "Wendigo",
-			"isNpc": false,
 			"source": "B1",
 			"page": 327,
 			"level": 17,
@@ -71326,7 +70945,6 @@
 		},
 		{
 			"name": "Werebear",
-			"isNpc": false,
 			"source": "B1",
 			"page": 331,
 			"level": 4,
@@ -71572,7 +71190,6 @@
 		},
 		{
 			"name": "Wererat",
-			"isNpc": false,
 			"source": "B1",
 			"page": 329,
 			"level": 2,
@@ -71811,7 +71428,6 @@
 		},
 		{
 			"name": "Werewolf",
-			"isNpc": false,
 			"source": "B1",
 			"page": 330,
 			"level": 3,
@@ -72035,7 +71651,6 @@
 		},
 		{
 			"name": "Wight",
-			"isNpc": false,
 			"source": "B1",
 			"page": 332,
 			"level": 3,
@@ -72167,7 +71782,6 @@
 		},
 		{
 			"name": "Will-o'-wisp",
-			"isNpc": false,
 			"source": "B1",
 			"page": 333,
 			"level": 6,
@@ -72308,7 +71922,6 @@
 		},
 		{
 			"name": "Winter Wolf",
-			"isNpc": false,
 			"source": "B1",
 			"page": 322,
 			"level": 5,
@@ -72471,7 +72084,6 @@
 		},
 		{
 			"name": "Wolf",
-			"isNpc": false,
 			"source": "B1",
 			"page": 334,
 			"level": 1,
@@ -72567,7 +72179,6 @@
 		},
 		{
 			"name": "Wraith",
-			"isNpc": false,
 			"source": "B1",
 			"page": 335,
 			"foundIn": [
@@ -72744,7 +72355,6 @@
 		},
 		{
 			"name": "Wyvern",
-			"isNpc": false,
 			"source": "B1",
 			"page": 133,
 			"level": 6,
@@ -72941,7 +72551,6 @@
 		},
 		{
 			"name": "Xorn",
-			"isNpc": false,
 			"source": "B1",
 			"page": 146,
 			"foundIn": [
@@ -73099,7 +72708,6 @@
 		},
 		{
 			"name": "Xulgath Leader",
-			"isNpc": false,
 			"source": "B1",
 			"page": 337,
 			"level": 3,
@@ -73254,7 +72862,6 @@
 		},
 		{
 			"name": "Xulgath Skulker",
-			"isNpc": false,
 			"source": "B1",
 			"page": 337,
 			"level": 2,
@@ -73422,7 +73029,6 @@
 		},
 		{
 			"name": "Xulgath Warrior",
-			"isNpc": false,
 			"source": "B1",
 			"page": 336,
 			"level": 1,
@@ -73564,7 +73170,6 @@
 		},
 		{
 			"name": "Yeti",
-			"isNpc": false,
 			"source": "B1",
 			"page": 338,
 			"level": 5,
@@ -73723,7 +73328,6 @@
 		},
 		{
 			"name": "Young Black Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 105,
 			"level": 7,
@@ -73929,7 +73533,6 @@
 		},
 		{
 			"name": "Young Blue Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 107,
 			"level": 9,
@@ -74188,7 +73791,6 @@
 		},
 		{
 			"name": "Young Brass Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 117,
 			"level": 7,
@@ -74409,7 +74011,6 @@
 		},
 		{
 			"name": "Young Bronze Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 119,
 			"level": 9,
@@ -74651,7 +74252,6 @@
 		},
 		{
 			"name": "Young Copper Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 121,
 			"level": 8,
@@ -74878,7 +74478,6 @@
 		},
 		{
 			"name": "Young Gold Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 124,
 			"level": 11,
@@ -75131,7 +74730,6 @@
 		},
 		{
 			"name": "Young Green Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 109,
 			"level": 8,
@@ -75383,7 +74981,6 @@
 		},
 		{
 			"name": "Young Red Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 112,
 			"level": 10,
@@ -75632,7 +75229,6 @@
 		},
 		{
 			"name": "Young Silver Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 126,
 			"level": 10,
@@ -75877,7 +75473,6 @@
 		},
 		{
 			"name": "Young White Dragon",
-			"isNpc": false,
 			"source": "B1",
 			"page": 113,
 			"level": 6,
@@ -76121,7 +75716,6 @@
 		},
 		{
 			"name": "Zaramuun",
-			"isNpc": false,
 			"source": "B1",
 			"page": 339,
 			"level": 16,
@@ -76369,7 +75963,6 @@
 		},
 		{
 			"name": "Zephyr Hawk",
-			"isNpc": false,
 			"source": "B1",
 			"page": 144,
 			"foundIn": [
@@ -76474,7 +76067,6 @@
 		},
 		{
 			"name": "Zombie Brute",
-			"isNpc": false,
 			"source": "B1",
 			"page": 341,
 			"foundIn": [
@@ -76589,7 +76181,6 @@
 		},
 		{
 			"name": "Zombie Hulk",
-			"isNpc": false,
 			"source": "B1",
 			"page": 341,
 			"foundIn": [
@@ -76737,7 +76328,6 @@
 		},
 		{
 			"name": "Zombie Shambler",
-			"isNpc": false,
 			"source": "B1",
 			"page": 340,
 			"level": -1,

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -7,7 +7,6 @@
 	"creature": [
 		{
 			"name": "Aapoph Serpentfolk",
-			"isNpc": false,
 			"source": "B2",
 			"page": 238,
 			"level": 3,
@@ -189,7 +188,6 @@
 		},
 		{
 			"name": "Adult Brine Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 87,
 			"level": 12,
@@ -452,7 +450,6 @@
 		},
 		{
 			"name": "Adult Cloud Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 90,
 			"level": 14,
@@ -735,7 +732,6 @@
 		},
 		{
 			"name": "Adult Crystal Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 92,
 			"level": 11,
@@ -1002,7 +998,6 @@
 		},
 		{
 			"name": "Adult Magma Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 94,
 			"level": 13,
@@ -1276,7 +1271,6 @@
 		},
 		{
 			"name": "Adult Umbral Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Impossible Lands"
@@ -1572,7 +1566,6 @@
 		},
 		{
 			"name": "Ahuizotl",
-			"isNpc": false,
 			"source": "B2",
 			"page": 12,
 			"level": 6,
@@ -1717,7 +1710,6 @@
 		},
 		{
 			"name": "Akata",
-			"isNpc": false,
 			"source": "B2",
 			"page": 13,
 			"level": 1,
@@ -1895,7 +1887,6 @@
 		},
 		{
 			"name": "Akizendri",
-			"isNpc": false,
 			"source": "B2",
 			"page": 204,
 			"level": 3,
@@ -2199,7 +2190,6 @@
 		},
 		{
 			"name": "Amoeba Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 192,
 			"foundIn": [
@@ -2312,7 +2302,6 @@
 		},
 		{
 			"name": "Anancus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 116,
 			"level": 8,
@@ -2430,7 +2419,6 @@
 		},
 		{
 			"name": "Ancient Brine Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 88,
 			"level": 17,
@@ -2725,7 +2713,6 @@
 		},
 		{
 			"name": "Ancient Cloud Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 90,
 			"level": 19,
@@ -3034,7 +3021,6 @@
 		},
 		{
 			"name": "Ancient Crystal Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 92,
 			"level": 16,
@@ -3354,7 +3340,6 @@
 		},
 		{
 			"name": "Ancient Magma Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 95,
 			"level": 18,
@@ -3651,7 +3636,6 @@
 		},
 		{
 			"name": "Ancient Umbral Dragon",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -3962,7 +3946,6 @@
 		},
 		{
 			"name": "Animate Dream",
-			"isNpc": false,
 			"source": "B2",
 			"page": 18,
 			"level": 8,
@@ -4144,7 +4127,6 @@
 		},
 		{
 			"name": "Ankou",
-			"isNpc": false,
 			"source": "B2",
 			"page": 19,
 			"level": 14,
@@ -4347,7 +4329,6 @@
 		},
 		{
 			"name": "Aolaz",
-			"isNpc": false,
 			"source": "B2",
 			"page": 21,
 			"level": 18,
@@ -4543,7 +4524,6 @@
 		},
 		{
 			"name": "Army Ant Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 20,
 			"level": 5,
@@ -4658,7 +4638,6 @@
 		},
 		{
 			"name": "Assassin Vine",
-			"isNpc": false,
 			"source": "B2",
 			"page": 26,
 			"level": 3,
@@ -4794,7 +4773,6 @@
 		},
 		{
 			"name": "Athach",
-			"isNpc": false,
 			"source": "B2",
 			"page": 27,
 			"level": 12,
@@ -4992,7 +4970,6 @@
 		},
 		{
 			"name": "Attic Whisperer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 28,
 			"level": 4,
@@ -5174,7 +5151,6 @@
 		},
 		{
 			"name": "Augnagar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 216,
 			"level": 14,
@@ -5416,7 +5392,6 @@
 		},
 		{
 			"name": "Augur",
-			"isNpc": false,
 			"source": "B2",
 			"page": 280,
 			"level": 1,
@@ -5640,7 +5615,6 @@
 		},
 		{
 			"name": "Aurumvorax",
-			"isNpc": false,
 			"source": "B2",
 			"page": 29,
 			"level": 9,
@@ -5786,7 +5760,6 @@
 		},
 		{
 			"name": "Azuretzi",
-			"isNpc": false,
 			"source": "B2",
 			"page": 206,
 			"level": 5,
@@ -6103,7 +6076,6 @@
 		},
 		{
 			"name": "Babau",
-			"isNpc": false,
 			"source": "B2",
 			"page": 64,
 			"level": 6,
@@ -6342,7 +6314,6 @@
 		},
 		{
 			"name": "Badger",
-			"isNpc": false,
 			"source": "B2",
 			"page": 32,
 			"level": 0,
@@ -6447,7 +6418,6 @@
 		},
 		{
 			"name": "Baobhan Sith",
-			"isNpc": false,
 			"source": "B2",
 			"page": 33,
 			"level": 6,
@@ -6620,7 +6590,6 @@
 		},
 		{
 			"name": "Basidirond",
-			"isNpc": false,
 			"source": "B2",
 			"page": 34,
 			"foundIn": [
@@ -6780,7 +6749,6 @@
 		},
 		{
 			"name": "Bastion Archon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 25,
 			"level": 20,
@@ -7048,7 +7016,6 @@
 		},
 		{
 			"name": "Bebilith",
-			"isNpc": false,
 			"source": "B2",
 			"page": 37,
 			"level": 10,
@@ -7266,7 +7233,6 @@
 		},
 		{
 			"name": "Behemoth Hippopotamus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 144,
 			"level": 10,
@@ -7444,7 +7410,6 @@
 		},
 		{
 			"name": "Behir",
-			"isNpc": false,
 			"source": "B2",
 			"page": 38,
 			"foundIn": [
@@ -7630,7 +7595,6 @@
 		},
 		{
 			"name": "Belker",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray",
@@ -7788,7 +7752,6 @@
 		},
 		{
 			"name": "Black Bear",
-			"isNpc": false,
 			"source": "B2",
 			"page": 36,
 			"level": 2,
@@ -7890,7 +7853,6 @@
 		},
 		{
 			"name": "Black Scorpion",
-			"isNpc": false,
 			"source": "B2",
 			"page": 234,
 			"level": 15,
@@ -8039,7 +8001,6 @@
 		},
 		{
 			"name": "Blindheim",
-			"isNpc": false,
 			"source": "B2",
 			"page": 39,
 			"level": 2,
@@ -8157,7 +8118,6 @@
 		},
 		{
 			"name": "Blink Dog",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Nex"
@@ -8287,7 +8247,6 @@
 		},
 		{
 			"name": "Blizzardborn",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray",
@@ -8427,7 +8386,6 @@
 		},
 		{
 			"name": "Blodeuwedd",
-			"isNpc": false,
 			"source": "B2",
 			"page": 41,
 			"level": 6,
@@ -8673,7 +8631,6 @@
 		},
 		{
 			"name": "Blue-ringed Octopus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 187,
 			"level": 0,
@@ -8818,7 +8775,6 @@
 		},
 		{
 			"name": "Bodak",
-			"isNpc": false,
 			"source": "B2",
 			"page": 42,
 			"level": 8,
@@ -8993,7 +8949,6 @@
 		},
 		{
 			"name": "Bog Mummy",
-			"isNpc": false,
 			"source": "B2",
 			"page": 177,
 			"level": 5,
@@ -9162,7 +9117,6 @@
 		},
 		{
 			"name": "Bog Strider",
-			"isNpc": false,
 			"source": "B2",
 			"page": 43,
 			"level": 2,
@@ -9316,7 +9270,6 @@
 		},
 		{
 			"name": "Bone Prophet",
-			"isNpc": false,
 			"source": "B2",
 			"page": 239,
 			"level": 8,
@@ -9618,7 +9571,6 @@
 		},
 		{
 			"name": "Bottlenose Dolphin",
-			"isNpc": false,
 			"source": "B2",
 			"page": 84,
 			"level": 0,
@@ -9727,7 +9679,6 @@
 		},
 		{
 			"name": "Bralani",
-			"isNpc": false,
 			"source": "B2",
 			"page": 30,
 			"level": 6,
@@ -9950,7 +9901,6 @@
 		},
 		{
 			"name": "Brood Leech Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 156,
 			"level": 4,
@@ -10069,7 +10019,6 @@
 		},
 		{
 			"name": "Brownie",
-			"isNpc": false,
 			"source": "B2",
 			"page": 44,
 			"level": 1,
@@ -10243,7 +10192,6 @@
 		},
 		{
 			"name": "Bythos",
-			"isNpc": false,
 			"source": "B2",
 			"page": 11,
 			"level": 16,
@@ -10524,7 +10472,6 @@
 		},
 		{
 			"name": "Cairn Linnorm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 166,
 			"level": 18,
@@ -10768,7 +10715,6 @@
 		},
 		{
 			"name": "Cairn Wight",
-			"isNpc": false,
 			"source": "B2",
 			"page": 292,
 			"level": 4,
@@ -10952,7 +10898,6 @@
 		},
 		{
 			"name": "Calathgar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 45,
 			"level": 4,
@@ -11099,7 +11044,6 @@
 		},
 		{
 			"name": "Caligni Slayer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 46,
 			"level": 3,
@@ -11331,7 +11275,6 @@
 		},
 		{
 			"name": "Carbuncle",
-			"isNpc": false,
 			"source": "B2",
 			"page": 47,
 			"level": 1,
@@ -11507,7 +11450,6 @@
 		},
 		{
 			"name": "Carnivorous Blob",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Alkenstar",
@@ -11673,7 +11615,6 @@
 		},
 		{
 			"name": "Carrion Golem",
-			"isNpc": false,
 			"source": "B2",
 			"page": 128,
 			"foundIn": [
@@ -11849,7 +11790,6 @@
 		},
 		{
 			"name": "Catoblepas",
-			"isNpc": false,
 			"source": "B2",
 			"page": 48,
 			"level": 12,
@@ -12025,7 +11965,6 @@
 		},
 		{
 			"name": "Catrina",
-			"isNpc": false,
 			"source": "B2",
 			"page": 209,
 			"level": 5,
@@ -12281,7 +12220,6 @@
 		},
 		{
 			"name": "Cave Fisher",
-			"isNpc": false,
 			"source": "B2",
 			"page": 49,
 			"level": 2,
@@ -12387,7 +12325,6 @@
 		},
 		{
 			"name": "Cave Scorpion",
-			"isNpc": false,
 			"source": "B2",
 			"page": 234,
 			"level": 1,
@@ -12518,7 +12455,6 @@
 		},
 		{
 			"name": "Cavern Troll",
-			"isNpc": false,
 			"source": "B2",
 			"page": 265,
 			"level": 6,
@@ -12702,7 +12638,6 @@
 		},
 		{
 			"name": "Chernobue",
-			"isNpc": false,
 			"source": "B2",
 			"page": 214,
 			"level": 12,
@@ -12989,7 +12924,6 @@
 		},
 		{
 			"name": "Choker",
-			"isNpc": false,
 			"source": "B2",
 			"page": 51,
 			"level": 2,
@@ -13116,7 +13050,6 @@
 		},
 		{
 			"name": "Chupacabra",
-			"isNpc": false,
 			"source": "B2",
 			"page": 52,
 			"level": 3,
@@ -13238,7 +13171,6 @@
 		},
 		{
 			"name": "Cockroach Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 53,
 			"level": 2,
@@ -13342,7 +13274,6 @@
 		},
 		{
 			"name": "Coil Spy",
-			"isNpc": false,
 			"source": "B2",
 			"page": 238,
 			"level": 4,
@@ -13580,7 +13511,6 @@
 		},
 		{
 			"name": "Compsognathus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 80,
 			"level": -1,
@@ -13691,7 +13621,6 @@
 		},
 		{
 			"name": "Cornugon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 77,
 			"level": 16,
@@ -13984,7 +13913,6 @@
 		},
 		{
 			"name": "Crawling Hand",
-			"isNpc": false,
 			"source": "B2",
 			"page": 56,
 			"level": -1,
@@ -14097,7 +14025,6 @@
 		},
 		{
 			"name": "Culdewen",
-			"isNpc": false,
 			"source": "B2",
 			"page": 57,
 			"level": 7,
@@ -14293,7 +14220,6 @@
 		},
 		{
 			"name": "Cythnigot",
-			"isNpc": false,
 			"source": "B2",
 			"page": 212,
 			"level": 1,
@@ -14508,7 +14434,6 @@
 		},
 		{
 			"name": "D'ziriak",
-			"isNpc": false,
 			"source": "B2",
 			"page": 104,
 			"level": 3,
@@ -14688,7 +14613,6 @@
 		},
 		{
 			"name": "Denizen Of Leng",
-			"isNpc": false,
 			"source": "B2",
 			"page": 70,
 			"level": 8,
@@ -14942,7 +14866,6 @@
 		},
 		{
 			"name": "Derghodaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 60,
 			"level": 12,
@@ -15173,7 +15096,6 @@
 		},
 		{
 			"name": "Destrachan",
-			"isNpc": false,
 			"source": "B2",
 			"page": 71,
 			"level": 8,
@@ -15343,7 +15265,6 @@
 		},
 		{
 			"name": "Devourer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 78,
 			"level": 11,
@@ -15501,7 +15422,6 @@
 		},
 		{
 			"name": "Dig-widget",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes"
@@ -15656,7 +15576,6 @@
 		},
 		{
 			"name": "Doprillu",
-			"isNpc": false,
 			"source": "B2",
 			"page": 85,
 			"level": 14,
@@ -15839,7 +15758,6 @@
 		},
 		{
 			"name": "Dracolisk",
-			"isNpc": false,
 			"source": "B2",
 			"page": 35,
 			"level": 9,
@@ -16065,7 +15983,6 @@
 		},
 		{
 			"name": "Drainberry Bush",
-			"isNpc": false,
 			"source": "B2",
 			"page": 99,
 			"level": 7,
@@ -16223,7 +16140,6 @@
 		},
 		{
 			"name": "Draugr",
-			"isNpc": false,
 			"source": "B2",
 			"page": 102,
 			"level": 2,
@@ -16383,7 +16299,6 @@
 		},
 		{
 			"name": "Dread Wraith",
-			"isNpc": false,
 			"source": "B2",
 			"page": 298,
 			"level": 9,
@@ -16558,7 +16473,6 @@
 		},
 		{
 			"name": "Dream Spider",
-			"isNpc": false,
 			"source": "B2",
 			"page": 249,
 			"level": 0,
@@ -16693,7 +16607,6 @@
 		},
 		{
 			"name": "Duneshaker Solifugid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 246,
 			"level": 18,
@@ -16839,7 +16752,6 @@
 		},
 		{
 			"name": "Dust Mephit",
-			"isNpc": false,
 			"source": "B2",
 			"page": 112,
 			"level": 1,
@@ -16979,7 +16891,6 @@
 		},
 		{
 			"name": "Dweomercat",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Alkenstar",
@@ -17232,7 +17143,6 @@
 		},
 		{
 			"name": "Earthen Destrier",
-			"isNpc": false,
 			"source": "B2",
 			"page": 108,
 			"foundIn": [
@@ -17381,7 +17291,6 @@
 		},
 		{
 			"name": "Elasmosaurus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 105,
 			"level": 7,
@@ -17534,7 +17443,6 @@
 		},
 		{
 			"name": "Ember Fox",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray",
@@ -17657,7 +17565,6 @@
 		},
 		{
 			"name": "Emperor Cobra",
-			"isNpc": false,
 			"source": "B2",
 			"page": 245,
 			"level": 5,
@@ -17802,7 +17709,6 @@
 		},
 		{
 			"name": "Eremite",
-			"isNpc": false,
 			"source": "B2",
 			"page": 285,
 			"level": 20,
@@ -18118,7 +18024,6 @@
 		},
 		{
 			"name": "Esobok",
-			"isNpc": false,
 			"source": "B2",
 			"page": 208,
 			"level": 3,
@@ -18310,7 +18215,6 @@
 		},
 		{
 			"name": "Evangelist",
-			"isNpc": false,
 			"source": "B2",
 			"page": 282,
 			"level": 6,
@@ -18496,7 +18400,6 @@
 		},
 		{
 			"name": "Fen Mosquito Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 175,
 			"level": 3,
@@ -18620,7 +18523,6 @@
 		},
 		{
 			"name": "Fetchling Scout",
-			"isNpc": false,
 			"source": "B2",
 			"page": 117,
 			"level": 1,
@@ -18793,7 +18695,6 @@
 		},
 		{
 			"name": "Filth Fire",
-			"isNpc": false,
 			"source": "B2",
 			"page": 110,
 			"foundIn": [
@@ -18937,7 +18838,6 @@
 		},
 		{
 			"name": "Fire Jellyfish Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 152,
 			"level": 6,
@@ -19062,7 +18962,6 @@
 		},
 		{
 			"name": "Fire Yai",
-			"isNpc": false,
 			"source": "B2",
 			"page": 190,
 			"level": 14,
@@ -19340,7 +19239,6 @@
 		},
 		{
 			"name": "Fjord Linnorm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 165,
 			"level": 16,
@@ -19569,7 +19467,6 @@
 		},
 		{
 			"name": "Flytrap Leshy",
-			"isNpc": false,
 			"source": "B2",
 			"page": 161,
 			"level": 4,
@@ -19807,7 +19704,6 @@
 		},
 		{
 			"name": "Froghemoth",
-			"isNpc": false,
 			"source": "B2",
 			"page": 122,
 			"level": 13,
@@ -20018,7 +19914,6 @@
 		},
 		{
 			"name": "Frost Troll",
-			"isNpc": false,
 			"source": "B2",
 			"page": 264,
 			"level": 4,
@@ -20201,7 +20096,6 @@
 		},
 		{
 			"name": "Frost Worm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 123,
 			"level": 12,
@@ -20369,7 +20263,6 @@
 		},
 		{
 			"name": "Ghonhatine",
-			"isNpc": false,
 			"source": "B2",
 			"page": 119,
 			"level": 10,
@@ -20573,7 +20466,6 @@
 		},
 		{
 			"name": "Giant Amoeba",
-			"isNpc": false,
 			"source": "B2",
 			"page": 192,
 			"level": 1,
@@ -20706,7 +20598,6 @@
 		},
 		{
 			"name": "Giant Ant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 20,
 			"level": 2,
@@ -20844,7 +20735,6 @@
 		},
 		{
 			"name": "Giant Badger",
-			"isNpc": false,
 			"source": "B2",
 			"page": 32,
 			"level": 2,
@@ -20968,7 +20858,6 @@
 		},
 		{
 			"name": "Giant Chameleon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 168,
 			"level": 3,
@@ -21050,7 +20939,6 @@
 		},
 		{
 			"name": "Giant Cockroach",
-			"isNpc": false,
 			"source": "B2",
 			"page": 53,
 			"level": 1,
@@ -21147,7 +21035,6 @@
 		},
 		{
 			"name": "Giant Crab",
-			"isNpc": false,
 			"source": "B2",
 			"page": 55,
 			"level": 2,
@@ -21270,7 +21157,6 @@
 		},
 		{
 			"name": "Giant Crawling Hand",
-			"isNpc": false,
 			"source": "B2",
 			"page": 56,
 			"level": 5,
@@ -21402,7 +21288,6 @@
 		},
 		{
 			"name": "Giant Dragonfly",
-			"isNpc": false,
 			"source": "B2",
 			"page": 98,
 			"level": 4,
@@ -21518,7 +21403,6 @@
 		},
 		{
 			"name": "Giant Dragonfly Nymph",
-			"isNpc": false,
 			"source": "B2",
 			"page": 98,
 			"level": 3,
@@ -21615,7 +21499,6 @@
 		},
 		{
 			"name": "Giant Fly",
-			"isNpc": false,
 			"foundIn": [
 				"Geb"
 			],
@@ -21761,7 +21644,6 @@
 		},
 		{
 			"name": "Giant Frog",
-			"isNpc": false,
 			"source": "B2",
 			"page": 121,
 			"level": 1,
@@ -21870,7 +21752,6 @@
 		},
 		{
 			"name": "Giant Hippocampus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 142,
 			"level": 8,
@@ -21981,7 +21862,6 @@
 		},
 		{
 			"name": "Giant Jellyfish",
-			"isNpc": false,
 			"source": "B2",
 			"page": 152,
 			"level": 7,
@@ -22116,7 +21996,6 @@
 		},
 		{
 			"name": "Giant Leech",
-			"isNpc": false,
 			"source": "B2",
 			"page": 156,
 			"level": 2,
@@ -22209,7 +22088,6 @@
 		},
 		{
 			"name": "Giant Maggot",
-			"isNpc": false,
 			"source": "B2",
 			"page": 120,
 			"level": 0,
@@ -22312,7 +22190,6 @@
 		},
 		{
 			"name": "Giant Mosquito",
-			"isNpc": false,
 			"source": "B2",
 			"page": 175,
 			"level": 6,
@@ -22444,7 +22321,6 @@
 		},
 		{
 			"name": "Giant Slug",
-			"isNpc": false,
 			"source": "B2",
 			"page": 244,
 			"level": 8,
@@ -22599,7 +22475,6 @@
 		},
 		{
 			"name": "Giant Snapping Turtle",
-			"isNpc": false,
 			"source": "B2",
 			"page": 269,
 			"level": 9,
@@ -22726,7 +22601,6 @@
 		},
 		{
 			"name": "Giant Solifugid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 246,
 			"level": 1,
@@ -22845,7 +22719,6 @@
 		},
 		{
 			"name": "Giant Squid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 254,
 			"level": 9,
@@ -22992,7 +22865,6 @@
 		},
 		{
 			"name": "Giant Tick",
-			"isNpc": false,
 			"source": "B2",
 			"page": 260,
 			"level": 1,
@@ -23114,7 +22986,6 @@
 		},
 		{
 			"name": "Giant Toad",
-			"isNpc": false,
 			"source": "B2",
 			"page": 261,
 			"level": 2,
@@ -23262,7 +23133,6 @@
 		},
 		{
 			"name": "Giant Whiptail Centipede",
-			"isNpc": false,
 			"source": "B2",
 			"page": 50,
 			"level": 3,
@@ -23415,7 +23285,6 @@
 		},
 		{
 			"name": "Giant Wolverine",
-			"isNpc": false,
 			"source": "B2",
 			"page": 295,
 			"level": 4,
@@ -23557,7 +23426,6 @@
 		},
 		{
 			"name": "Glass Golem",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Nex"
@@ -23725,7 +23593,6 @@
 		},
 		{
 			"name": "Gorgon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 132,
 			"level": 8,
@@ -23861,7 +23728,6 @@
 		},
 		{
 			"name": "Gosreg",
-			"isNpc": false,
 			"source": "B2",
 			"page": 133,
 			"level": 11,
@@ -24114,7 +23980,6 @@
 		},
 		{
 			"name": "Granite Glyptodont",
-			"isNpc": false,
 			"source": "B2",
 			"page": 109,
 			"level": 8,
@@ -24241,7 +24106,6 @@
 		},
 		{
 			"name": "Gray Ooze",
-			"isNpc": false,
 			"source": "B2",
 			"page": 194,
 			"foundIn": [
@@ -24386,7 +24250,6 @@
 		},
 		{
 			"name": "Grendel",
-			"isNpc": false,
 			"source": "B2",
 			"page": 136,
 			"level": 19,
@@ -24611,7 +24474,6 @@
 		},
 		{
 			"name": "Grimstalker",
-			"isNpc": false,
 			"source": "B2",
 			"page": 137,
 			"level": 5,
@@ -24795,7 +24657,6 @@
 		},
 		{
 			"name": "Grindylow",
-			"isNpc": false,
 			"source": "B2",
 			"page": 138,
 			"level": 0,
@@ -24959,7 +24820,6 @@
 		},
 		{
 			"name": "Grippli Scout",
-			"isNpc": false,
 			"source": "B2",
 			"page": 139,
 			"level": 1,
@@ -25097,7 +24957,6 @@
 		},
 		{
 			"name": "Grodair",
-			"isNpc": false,
 			"source": "B2",
 			"page": 140,
 			"level": 5,
@@ -25271,7 +25130,6 @@
 		},
 		{
 			"name": "Gylou",
-			"isNpc": false,
 			"source": "B2",
 			"page": 76,
 			"level": 14,
@@ -25527,7 +25385,6 @@
 		},
 		{
 			"name": "Hadrosaurid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 82,
 			"level": 4,
@@ -25626,7 +25483,6 @@
 		},
 		{
 			"name": "Hamatula",
-			"isNpc": false,
 			"source": "B2",
 			"page": 74,
 			"level": 11,
@@ -25877,7 +25733,6 @@
 		},
 		{
 			"name": "Hellcat",
-			"isNpc": false,
 			"source": "B2",
 			"page": 141,
 			"level": 7,
@@ -26077,7 +25932,6 @@
 		},
 		{
 			"name": "Hezrou",
-			"isNpc": false,
 			"source": "B2",
 			"page": 67,
 			"level": 11,
@@ -26274,7 +26128,6 @@
 		},
 		{
 			"name": "Hippocampus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 142,
 			"level": 1,
@@ -26385,7 +26238,6 @@
 		},
 		{
 			"name": "Hippogriff",
-			"isNpc": false,
 			"source": "B2",
 			"page": 143,
 			"level": 2,
@@ -26519,7 +26371,6 @@
 		},
 		{
 			"name": "Hippopotamus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 144,
 			"level": 5,
@@ -26664,7 +26515,6 @@
 		},
 		{
 			"name": "Hodag",
-			"isNpc": false,
 			"source": "B2",
 			"page": 145,
 			"level": 6,
@@ -26825,7 +26675,6 @@
 		},
 		{
 			"name": "Hound Archon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 22,
 			"level": 4,
@@ -27031,7 +26880,6 @@
 		},
 		{
 			"name": "Hound Of Tindalos",
-			"isNpc": false,
 			"source": "B2",
 			"page": 146,
 			"level": 7,
@@ -27239,7 +27087,6 @@
 		},
 		{
 			"name": "Ice Golem",
-			"isNpc": false,
 			"source": "B2",
 			"page": 129,
 			"foundIn": [
@@ -27402,7 +27249,6 @@
 		},
 		{
 			"name": "Ice Mephit",
-			"isNpc": false,
 			"source": "B2",
 			"page": 112,
 			"foundIn": [
@@ -27531,7 +27377,6 @@
 		},
 		{
 			"name": "Ice Yai",
-			"isNpc": false,
 			"source": "B2",
 			"page": 189,
 			"level": 13,
@@ -27798,7 +27643,6 @@
 		},
 		{
 			"name": "Icewyrm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 115,
 			"foundIn": [
@@ -27965,7 +27809,6 @@
 		},
 		{
 			"name": "Icicle Snake",
-			"isNpc": false,
 			"source": "B2",
 			"page": 114,
 			"foundIn": [
@@ -28077,7 +27920,6 @@
 		},
 		{
 			"name": "Ifrit Pyrochemist",
-			"isNpc": false,
 			"source": "B2",
 			"page": 200,
 			"foundIn": [
@@ -28220,7 +28062,6 @@
 		},
 		{
 			"name": "Iguanodon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 82,
 			"level": 6,
@@ -28325,7 +28166,6 @@
 		},
 		{
 			"name": "Imentesh",
-			"isNpc": false,
 			"source": "B2",
 			"page": 207,
 			"level": 10,
@@ -28676,7 +28516,6 @@
 		},
 		{
 			"name": "Intellect Devourer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 147,
 			"level": 8,
@@ -28890,7 +28729,6 @@
 		},
 		{
 			"name": "Interlocutor",
-			"isNpc": false,
 			"source": "B2",
 			"page": 284,
 			"level": 12,
@@ -29094,7 +28932,6 @@
 		},
 		{
 			"name": "Invidiak",
-			"isNpc": false,
 			"source": "B2",
 			"page": 65,
 			"level": 7,
@@ -29294,7 +29131,6 @@
 		},
 		{
 			"name": "Irlgaunt",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Nex"
@@ -29469,7 +29305,6 @@
 		},
 		{
 			"name": "Irnakurse",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Alkenstar",
@@ -29670,7 +29505,6 @@
 		},
 		{
 			"name": "Isqulug",
-			"isNpc": false,
 			"source": "B2",
 			"page": 149,
 			"level": 11,
@@ -29919,7 +29753,6 @@
 		},
 		{
 			"name": "Jabberwock",
-			"isNpc": false,
 			"source": "B2",
 			"page": 151,
 			"level": 23,
@@ -30199,7 +30032,6 @@
 		},
 		{
 			"name": "Jotund Troll",
-			"isNpc": false,
 			"source": "B2",
 			"page": 267,
 			"level": 15,
@@ -30448,7 +30280,6 @@
 		},
 		{
 			"name": "Jyoti",
-			"isNpc": false,
 			"source": "B2",
 			"page": 153,
 			"level": 9,
@@ -30680,7 +30511,6 @@
 		},
 		{
 			"name": "Kelpie",
-			"isNpc": false,
 			"source": "B2",
 			"page": 154,
 			"level": 4,
@@ -30823,7 +30653,6 @@
 		},
 		{
 			"name": "Korred",
-			"isNpc": false,
 			"source": "B2",
 			"page": 155,
 			"level": 4,
@@ -31061,7 +30890,6 @@
 		},
 		{
 			"name": "Leng Spider",
-			"isNpc": false,
 			"source": "B2",
 			"page": 157,
 			"level": 13,
@@ -31360,7 +31188,6 @@
 		},
 		{
 			"name": "Leprechaun",
-			"isNpc": false,
 			"source": "B2",
 			"page": 158,
 			"level": 2,
@@ -31539,7 +31366,6 @@
 		},
 		{
 			"name": "Lerritan",
-			"isNpc": false,
 			"source": "B2",
 			"page": 159,
 			"level": 21,
@@ -31797,7 +31623,6 @@
 		},
 		{
 			"name": "Leucrotta",
-			"isNpc": false,
 			"source": "B2",
 			"page": 162,
 			"level": 5,
@@ -31949,7 +31774,6 @@
 		},
 		{
 			"name": "Leydroth",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -32195,7 +32019,6 @@
 		},
 		{
 			"name": "Living Boulder",
-			"isNpc": false,
 			"source": "B2",
 			"page": 108,
 			"foundIn": [
@@ -32306,7 +32129,6 @@
 		},
 		{
 			"name": "Living Thunderclap",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -32439,7 +32261,6 @@
 		},
 		{
 			"name": "Lunar Naga",
-			"isNpc": false,
 			"source": "B2",
 			"page": 178,
 			"foundIn": [
@@ -32685,7 +32506,6 @@
 		},
 		{
 			"name": "Lurker In Light",
-			"isNpc": false,
 			"source": "B2",
 			"page": 169,
 			"level": 5,
@@ -32900,7 +32720,6 @@
 		},
 		{
 			"name": "Magma Scorpion",
-			"isNpc": false,
 			"source": "B2",
 			"page": 111,
 			"foundIn": [
@@ -33071,7 +32890,6 @@
 		},
 		{
 			"name": "Mandragora",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Nex"
@@ -33289,7 +33107,6 @@
 		},
 		{
 			"name": "Manta Ray",
-			"isNpc": false,
 			"source": "B2",
 			"page": 226,
 			"level": 1,
@@ -33389,7 +33206,6 @@
 		},
 		{
 			"name": "Marrmora",
-			"isNpc": false,
 			"source": "B2",
 			"page": 171,
 			"level": 15,
@@ -33631,7 +33447,6 @@
 		},
 		{
 			"name": "Marsh Giant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 125,
 			"level": 8,
@@ -33837,7 +33652,6 @@
 		},
 		{
 			"name": "Marut",
-			"isNpc": false,
 			"source": "B2",
 			"page": 10,
 			"level": 15,
@@ -34076,7 +33890,6 @@
 		},
 		{
 			"name": "Mastodon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 116,
 			"level": 9,
@@ -34212,7 +34025,6 @@
 		},
 		{
 			"name": "Megalania",
-			"isNpc": false,
 			"source": "B2",
 			"page": 168,
 			"level": 7,
@@ -34324,7 +34136,6 @@
 		},
 		{
 			"name": "Meladaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 59,
 			"level": 11,
@@ -34586,7 +34397,6 @@
 		},
 		{
 			"name": "Melody On The Wind",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -34769,7 +34579,6 @@
 		},
 		{
 			"name": "Mist Stalker",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray",
@@ -34922,7 +34731,6 @@
 		},
 		{
 			"name": "Mohrg",
-			"isNpc": false,
 			"source": "B2",
 			"page": 172,
 			"level": 8,
@@ -35070,7 +34878,6 @@
 		},
 		{
 			"name": "Monadic Deva",
-			"isNpc": false,
 			"source": "B2",
 			"page": 15,
 			"level": 12,
@@ -35330,7 +35137,6 @@
 		},
 		{
 			"name": "Moonflower",
-			"isNpc": false,
 			"source": "B2",
 			"page": 173,
 			"level": 8,
@@ -35502,7 +35308,6 @@
 		},
 		{
 			"name": "Morlock",
-			"isNpc": false,
 			"source": "B2",
 			"page": 174,
 			"level": 2,
@@ -35670,7 +35475,6 @@
 		},
 		{
 			"name": "Movanic Deva",
-			"isNpc": false,
 			"source": "B2",
 			"page": 14,
 			"level": 10,
@@ -35901,7 +35705,6 @@
 		},
 		{
 			"name": "Mudwretch",
-			"isNpc": false,
 			"source": "B2",
 			"page": 176,
 			"level": 2,
@@ -36087,7 +35890,6 @@
 		},
 		{
 			"name": "Nabasu",
-			"isNpc": false,
 			"source": "B2",
 			"page": 66,
 			"level": 8,
@@ -36299,7 +36101,6 @@
 		},
 		{
 			"name": "Nalfeshnee",
-			"isNpc": false,
 			"source": "B2",
 			"page": 68,
 			"level": 14,
@@ -36529,7 +36330,6 @@
 		},
 		{
 			"name": "Necrophidius",
-			"isNpc": false,
 			"source": "B2",
 			"page": 180,
 			"level": 3,
@@ -36668,7 +36468,6 @@
 		},
 		{
 			"name": "Neothelid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 181,
 			"level": 15,
@@ -36973,7 +36772,6 @@
 		},
 		{
 			"name": "Nereid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 182,
 			"level": 10,
@@ -37172,7 +36970,6 @@
 		},
 		{
 			"name": "Nixie",
-			"isNpc": false,
 			"source": "B2",
 			"page": 183,
 			"level": 1,
@@ -37289,7 +37086,6 @@
 		},
 		{
 			"name": "Norn",
-			"isNpc": false,
 			"source": "B2",
 			"page": 184,
 			"level": 20,
@@ -37594,7 +37390,6 @@
 		},
 		{
 			"name": "Nuckelavee",
-			"isNpc": false,
 			"source": "B2",
 			"page": 186,
 			"level": 9,
@@ -37854,7 +37649,6 @@
 		},
 		{
 			"name": "Nuglub",
-			"isNpc": false,
 			"source": "B2",
 			"page": 135,
 			"level": 2,
@@ -37991,7 +37785,6 @@
 		},
 		{
 			"name": "Nyogoth",
-			"isNpc": false,
 			"source": "B2",
 			"page": 214,
 			"level": 10,
@@ -38229,7 +38022,6 @@
 		},
 		{
 			"name": "Ogre Spider",
-			"isNpc": false,
 			"source": "B2",
 			"page": 249,
 			"level": 5,
@@ -38373,7 +38165,6 @@
 		},
 		{
 			"name": "Olethrodaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 63,
 			"level": 20,
@@ -38634,7 +38425,6 @@
 		},
 		{
 			"name": "Onidoshi",
-			"isNpc": false,
 			"source": "B2",
 			"page": 188,
 			"level": 8,
@@ -38858,7 +38648,6 @@
 		},
 		{
 			"name": "Ooze Mephit",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray",
@@ -38994,7 +38783,6 @@
 		},
 		{
 			"name": "Orca",
-			"isNpc": false,
 			"source": "B2",
 			"page": 84,
 			"level": 5,
@@ -39114,7 +38902,6 @@
 		},
 		{
 			"name": "Oread Guard",
-			"isNpc": false,
 			"source": "B2",
 			"page": 201,
 			"foundIn": [
@@ -39271,7 +39058,6 @@
 		},
 		{
 			"name": "Ostiarius",
-			"isNpc": false,
 			"source": "B2",
 			"page": 281,
 			"level": 5,
@@ -39522,7 +39308,6 @@
 		},
 		{
 			"name": "Osyluth",
-			"isNpc": false,
 			"source": "B2",
 			"page": 74,
 			"level": 9,
@@ -39793,7 +39578,6 @@
 		},
 		{
 			"name": "Pachycephalosaurus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 81,
 			"level": 3,
@@ -39912,7 +39696,6 @@
 		},
 		{
 			"name": "Peluda",
-			"isNpc": false,
 			"source": "B2",
 			"page": 196,
 			"level": 10,
@@ -40106,7 +39889,6 @@
 		},
 		{
 			"name": "Peryton",
-			"isNpc": false,
 			"source": "B2",
 			"page": 197,
 			"level": 4,
@@ -40665,7 +40447,6 @@
 		},
 		{
 			"name": "Petitioner",
-			"isNpc": false,
 			"source": "B2",
 			"page": 198,
 			"level": 1,
@@ -40768,7 +40549,6 @@
 		},
 		{
 			"name": "Piscodaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 58,
 			"level": 10,
@@ -41037,7 +40817,6 @@
 		},
 		{
 			"name": "Planetar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 16,
 			"level": 16,
@@ -41331,7 +41110,6 @@
 		},
 		{
 			"name": "Polar Bear",
-			"isNpc": false,
 			"source": "B2",
 			"page": 36,
 			"level": 5,
@@ -41445,7 +41223,6 @@
 		},
 		{
 			"name": "Purrodaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 62,
 			"level": 18,
@@ -41710,7 +41487,6 @@
 		},
 		{
 			"name": "Quetz Couatl",
-			"isNpc": false,
 			"source": "B2",
 			"page": 54,
 			"level": 10,
@@ -41972,7 +41748,6 @@
 		},
 		{
 			"name": "Quickling",
-			"isNpc": false,
 			"source": "B2",
 			"page": 218,
 			"level": 3,
@@ -42158,7 +41933,6 @@
 		},
 		{
 			"name": "Quoppopak",
-			"isNpc": false,
 			"source": "B2",
 			"page": 219,
 			"level": 11,
@@ -42336,7 +42110,6 @@
 		},
 		{
 			"name": "Radiant Warden",
-			"isNpc": false,
 			"source": "B2",
 			"page": 220,
 			"level": 17,
@@ -42560,7 +42333,6 @@
 		},
 		{
 			"name": "Raven",
-			"isNpc": false,
 			"source": "B2",
 			"page": 221,
 			"level": -1,
@@ -42647,7 +42419,6 @@
 		},
 		{
 			"name": "Raven Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 221,
 			"level": 3,
@@ -42739,7 +42510,6 @@
 		},
 		{
 			"name": "Ravener",
-			"isNpc": false,
 			"source": "B2",
 			"page": 224,
 			"level": 21,
@@ -43103,7 +42873,6 @@
 		},
 		{
 			"name": "Ravener Husk",
-			"isNpc": false,
 			"source": "B2",
 			"page": 224,
 			"level": 14,
@@ -43283,7 +43052,6 @@
 		},
 		{
 			"name": "Reef Octopus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 187,
 			"level": 1,
@@ -43445,7 +43213,6 @@
 		},
 		{
 			"name": "Revenant",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -43645,7 +43412,6 @@
 		},
 		{
 			"name": "Rhinoceros",
-			"isNpc": false,
 			"source": "B2",
 			"page": 228,
 			"level": 4,
@@ -43754,7 +43520,6 @@
 		},
 		{
 			"name": "Rusalka",
-			"isNpc": false,
 			"source": "B2",
 			"page": 229,
 			"level": 12,
@@ -44006,7 +43771,6 @@
 		},
 		{
 			"name": "Sacristan",
-			"isNpc": false,
 			"source": "B2",
 			"page": 283,
 			"level": 10,
@@ -44230,7 +43994,6 @@
 		},
 		{
 			"name": "Sand Sentry",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -44360,7 +44123,6 @@
 		},
 		{
 			"name": "Sandpoint Devil",
-			"isNpc": false,
 			"source": "B2",
 			"page": 230,
 			"level": 8,
@@ -44610,7 +44372,6 @@
 		},
 		{
 			"name": "Sard",
-			"isNpc": false,
 			"source": "B2",
 			"page": 231,
 			"level": 19,
@@ -44901,7 +44662,6 @@
 		},
 		{
 			"name": "Sarglagon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 73,
 			"level": 8,
@@ -45171,7 +44931,6 @@
 		},
 		{
 			"name": "Scarecrow",
-			"isNpc": false,
 			"source": "B2",
 			"page": 232,
 			"level": 4,
@@ -45333,7 +45092,6 @@
 		},
 		{
 			"name": "Sceaduinar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 233,
 			"level": 7,
@@ -45563,7 +45321,6 @@
 		},
 		{
 			"name": "Scythe Tree",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Alkenstar",
@@ -45717,7 +45474,6 @@
 		},
 		{
 			"name": "Sea Drake",
-			"isNpc": false,
 			"source": "B2",
 			"page": 101,
 			"level": 6,
@@ -45914,7 +45670,6 @@
 		},
 		{
 			"name": "Sea Snake",
-			"isNpc": false,
 			"source": "B2",
 			"page": 245,
 			"level": 0,
@@ -46049,7 +45804,6 @@
 		},
 		{
 			"name": "Shadow Drake",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Impossible Lands"
@@ -46235,7 +45989,6 @@
 		},
 		{
 			"name": "Shadow Giant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 127,
 			"level": 13,
@@ -46422,7 +46175,6 @@
 		},
 		{
 			"name": "Shoal Linnorm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 164,
 			"level": 15,
@@ -46668,7 +46420,6 @@
 		},
 		{
 			"name": "Shocker Lizard",
-			"isNpc": false,
 			"source": "B2",
 			"page": 240,
 			"level": 2,
@@ -46824,7 +46575,6 @@
 		},
 		{
 			"name": "Shoggti",
-			"isNpc": false,
 			"source": "B2",
 			"page": 213,
 			"level": 7,
@@ -47058,7 +46808,6 @@
 		},
 		{
 			"name": "Skaveling",
-			"isNpc": false,
 			"source": "B2",
 			"page": 241,
 			"level": 5,
@@ -47254,7 +47003,6 @@
 		},
 		{
 			"name": "Skrik Nettle",
-			"isNpc": false,
 			"source": "B2",
 			"page": 242,
 			"level": 6,
@@ -47409,7 +47157,6 @@
 		},
 		{
 			"name": "Skulk",
-			"isNpc": false,
 			"source": "B2",
 			"page": 243,
 			"level": 1,
@@ -47546,7 +47293,6 @@
 		},
 		{
 			"name": "Slime Mold",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes"
@@ -47682,7 +47428,6 @@
 		},
 		{
 			"name": "Snapping Turtle",
-			"isNpc": false,
 			"source": "B2",
 			"page": 269,
 			"level": -1,
@@ -47783,7 +47528,6 @@
 		},
 		{
 			"name": "Solar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 16,
 			"level": 23,
@@ -47986,7 +47730,6 @@
 		},
 		{
 			"name": "Soul Eater",
-			"isNpc": false,
 			"source": "B2",
 			"page": 247,
 			"level": 7,
@@ -48158,7 +47901,6 @@
 		},
 		{
 			"name": "Spark Bat",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -48254,7 +47996,6 @@
 		},
 		{
 			"name": "Spear Frog",
-			"isNpc": false,
 			"source": "B2",
 			"page": 121,
 			"level": 0,
@@ -48375,7 +48116,6 @@
 		},
 		{
 			"name": "Specter",
-			"isNpc": false,
 			"source": "B2",
 			"page": 248,
 			"level": 7,
@@ -48540,7 +48280,6 @@
 		},
 		{
 			"name": "Spinosaurus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 83,
 			"level": 11,
@@ -48702,7 +48441,6 @@
 		},
 		{
 			"name": "Spiral Centurion",
-			"isNpc": false,
 			"source": "B2",
 			"page": 250,
 			"foundIn": [
@@ -48860,7 +48598,6 @@
 		},
 		{
 			"name": "Spirit Naga",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Jalmeray"
@@ -49117,7 +48854,6 @@
 		},
 		{
 			"name": "Sportlebore Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 251,
 			"level": 7,
@@ -49244,7 +48980,6 @@
 		},
 		{
 			"name": "Spriggan Bully",
-			"isNpc": false,
 			"source": "B2",
 			"page": 252,
 			"level": 3,
@@ -49433,7 +49168,6 @@
 		},
 		{
 			"name": "Spriggan Warlord",
-			"isNpc": false,
 			"source": "B2",
 			"page": 253,
 			"level": 7,
@@ -49643,7 +49377,6 @@
 		},
 		{
 			"name": "Star Archon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 24,
 			"level": 19,
@@ -49921,7 +49654,6 @@
 		},
 		{
 			"name": "Steam Mephit",
-			"isNpc": false,
 			"source": "B2",
 			"page": 113,
 			"foundIn": [
@@ -50101,7 +49833,6 @@
 		},
 		{
 			"name": "Stingray",
-			"isNpc": false,
 			"source": "B2",
 			"page": 226,
 			"level": 0,
@@ -50219,7 +49950,6 @@
 		},
 		{
 			"name": "Striding Fire",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray",
 				"Nex"
@@ -50347,7 +50077,6 @@
 		},
 		{
 			"name": "Stygira",
-			"isNpc": false,
 			"source": "B2",
 			"page": 255,
 			"level": 7,
@@ -50567,7 +50296,6 @@
 		},
 		{
 			"name": "Suli Dune Dancer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 202,
 			"foundIn": [
@@ -50733,7 +50461,6 @@
 		},
 		{
 			"name": "Sunflower Leshy",
-			"isNpc": false,
 			"source": "B2",
 			"page": 160,
 			"level": 1,
@@ -50931,7 +50658,6 @@
 		},
 		{
 			"name": "Sylph Sneak",
-			"isNpc": false,
 			"source": "B2",
 			"page": 202,
 			"level": 1,
@@ -51089,7 +50815,6 @@
 		},
 		{
 			"name": "Taiga Giant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 126,
 			"level": 12,
@@ -51279,7 +51004,6 @@
 		},
 		{
 			"name": "Taiga Linnorm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 167,
 			"level": 19,
@@ -51530,7 +51254,6 @@
 		},
 		{
 			"name": "Tatzlwyrm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 256,
 			"level": 2,
@@ -51664,7 +51387,6 @@
 		},
 		{
 			"name": "Tendriculos",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -51865,7 +51587,6 @@
 		},
 		{
 			"name": "Thanadaemon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 61,
 			"level": 13,
@@ -52143,7 +51864,6 @@
 		},
 		{
 			"name": "Theletos",
-			"isNpc": false,
 			"source": "B2",
 			"page": 8,
 			"level": 7,
@@ -52333,7 +52053,6 @@
 		},
 		{
 			"name": "Thrasfyr",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Nex"
@@ -52457,7 +52176,6 @@
 		},
 		{
 			"name": "Thulgant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 217,
 			"level": 18,
@@ -52780,7 +52498,6 @@
 		},
 		{
 			"name": "Thunderbird",
-			"isNpc": false,
 			"source": "B2",
 			"page": 259,
 			"level": 11,
@@ -52974,7 +52691,6 @@
 		},
 		{
 			"name": "Tick Swarm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 260,
 			"level": 9,
@@ -53100,7 +52816,6 @@
 		},
 		{
 			"name": "Titan Centipede",
-			"isNpc": false,
 			"source": "B2",
 			"page": 50,
 			"level": 9,
@@ -53249,7 +52964,6 @@
 		},
 		{
 			"name": "Totenmaske",
-			"isNpc": false,
 			"source": "B2",
 			"page": 262,
 			"level": 7,
@@ -53388,7 +53102,6 @@
 		},
 		{
 			"name": "Triton",
-			"isNpc": false,
 			"source": "B2",
 			"page": 263,
 			"level": 2,
@@ -53526,7 +53239,6 @@
 		},
 		{
 			"name": "Trollhound",
-			"isNpc": false,
 			"source": "B2",
 			"page": 268,
 			"level": 3,
@@ -53663,7 +53375,6 @@
 		},
 		{
 			"name": "Trumpet Archon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 23,
 			"level": 14,
@@ -53928,7 +53639,6 @@
 		},
 		{
 			"name": "Twigjack",
-			"isNpc": false,
 			"source": "B2",
 			"page": 270,
 			"level": 3,
@@ -54061,7 +53771,6 @@
 		},
 		{
 			"name": "Two-headed Troll",
-			"isNpc": false,
 			"source": "B2",
 			"page": 266,
 			"level": 8,
@@ -54235,7 +53944,6 @@
 		},
 		{
 			"name": "Umonlee",
-			"isNpc": false,
 			"source": "B2",
 			"page": 271,
 			"level": 15,
@@ -54393,7 +54101,6 @@
 		},
 		{
 			"name": "Undine Hydromancer",
-			"isNpc": false,
 			"source": "B2",
 			"page": 203,
 			"foundIn": [
@@ -54572,7 +54279,6 @@
 		},
 		{
 			"name": "Urdefhan Tormentor",
-			"isNpc": false,
 			"source": "B2",
 			"page": 273,
 			"level": 5,
@@ -54705,7 +54411,6 @@
 		},
 		{
 			"name": "Urdefhan Warrior",
-			"isNpc": false,
 			"source": "B2",
 			"page": 272,
 			"level": 3,
@@ -54897,7 +54602,6 @@
 		},
 		{
 			"name": "Vampire Squid",
-			"isNpc": false,
 			"source": "B2",
 			"page": 254,
 			"level": 0,
@@ -55004,7 +54708,6 @@
 		},
 		{
 			"name": "Vampiric Mist",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Alkenstar",
@@ -55146,7 +54849,6 @@
 		},
 		{
 			"name": "Vanth",
-			"isNpc": false,
 			"source": "B2",
 			"page": 210,
 			"level": 7,
@@ -55412,7 +55114,6 @@
 		},
 		{
 			"name": "Vaspercham",
-			"isNpc": false,
 			"source": "B2",
 			"page": 279,
 			"level": 17,
@@ -55664,7 +55365,6 @@
 		},
 		{
 			"name": "Veranallia",
-			"isNpc": false,
 			"source": "B2",
 			"page": 31,
 			"level": 20,
@@ -55927,7 +55627,6 @@
 		},
 		{
 			"name": "Verdurous Ooze",
-			"isNpc": false,
 			"source": "B2",
 			"page": 194,
 			"foundIn": [
@@ -56109,7 +55808,6 @@
 		},
 		{
 			"name": "Vexgit",
-			"isNpc": false,
 			"source": "B2",
 			"page": 134,
 			"level": 1,
@@ -56217,7 +55915,6 @@
 		},
 		{
 			"name": "Violet Fungus",
-			"isNpc": false,
 			"source": "B2",
 			"page": 286,
 			"level": 3,
@@ -56337,7 +56034,6 @@
 		},
 		{
 			"name": "Viper Vine",
-			"isNpc": false,
 			"source": "B2",
 			"page": 287,
 			"level": 13,
@@ -56490,7 +56186,6 @@
 		},
 		{
 			"name": "Void Zombie",
-			"isNpc": false,
 			"source": "B2",
 			"page": 288,
 			"level": 1,
@@ -56617,7 +56312,6 @@
 		},
 		{
 			"name": "Vrolikai",
-			"isNpc": false,
 			"source": "B2",
 			"page": 69,
 			"level": 19,
@@ -56901,7 +56595,6 @@
 		},
 		{
 			"name": "Vrykolakas Ancient",
-			"isNpc": false,
 			"source": "B2",
 			"page": 277,
 			"level": 13,
@@ -57213,7 +56906,6 @@
 		},
 		{
 			"name": "Vrykolakas Master",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Geb"
@@ -57374,7 +57066,6 @@
 		},
 		{
 			"name": "Vrykolakas Spawn",
-			"isNpc": false,
 			"source": "B2",
 			"page": 276,
 			"foundIn": [
@@ -57548,7 +57239,6 @@
 		},
 		{
 			"name": "Water Orm",
-			"isNpc": false,
 			"source": "B2",
 			"page": 289,
 			"level": 10,
@@ -57701,7 +57391,6 @@
 		},
 		{
 			"name": "Water Yai",
-			"isNpc": false,
 			"source": "B2",
 			"page": 191,
 			"level": 17,
@@ -58005,7 +57694,6 @@
 		},
 		{
 			"name": "Wereboar",
-			"isNpc": false,
 			"source": "B2",
 			"page": 290,
 			"level": 2,
@@ -58229,7 +57917,6 @@
 		},
 		{
 			"name": "Weretiger",
-			"isNpc": false,
 			"source": "B2",
 			"page": 291,
 			"level": 4,
@@ -58439,7 +58126,6 @@
 		},
 		{
 			"name": "Witchfire",
-			"isNpc": false,
 			"source": "B2",
 			"page": 293,
 			"level": 9,
@@ -58704,7 +58390,6 @@
 		},
 		{
 			"name": "Witchwyrd",
-			"isNpc": false,
 			"source": "B2",
 			"page": 294,
 			"level": 6,
@@ -58947,7 +58632,6 @@
 		},
 		{
 			"name": "Wolverine",
-			"isNpc": false,
 			"source": "B2",
 			"page": 295,
 			"level": 2,
@@ -59082,7 +58766,6 @@
 		},
 		{
 			"name": "Wood Giant",
-			"isNpc": false,
 			"source": "B2",
 			"page": 124,
 			"level": 6,
@@ -59319,7 +59002,6 @@
 		},
 		{
 			"name": "Wood Golem",
-			"isNpc": false,
 			"source": "B2",
 			"page": 130,
 			"foundIn": [
@@ -59475,7 +59157,6 @@
 		},
 		{
 			"name": "Woolly Rhinoceros",
-			"isNpc": false,
 			"source": "B2",
 			"page": 228,
 			"level": 6,
@@ -59607,7 +59288,6 @@
 		},
 		{
 			"name": "Worm That Walks Cultist",
-			"isNpc": false,
 			"source": "B2",
 			"page": 297,
 			"level": 14,
@@ -59918,7 +59598,6 @@
 		},
 		{
 			"name": "Xill",
-			"isNpc": false,
 			"source": "B2",
 			"page": 299,
 			"level": 6,
@@ -60176,7 +59855,6 @@
 		},
 		{
 			"name": "Yamaraj",
-			"isNpc": false,
 			"source": "B2",
 			"page": 211,
 			"level": 20,
@@ -60522,7 +60200,6 @@
 		},
 		{
 			"name": "Yellow Musk Brute",
-			"isNpc": false,
 			"source": "B2",
 			"page": 301,
 			"level": 2,
@@ -60644,7 +60321,6 @@
 		},
 		{
 			"name": "Yellow Musk Creeper",
-			"isNpc": false,
 			"source": "B2",
 			"page": 300,
 			"level": 2,
@@ -60768,7 +60444,6 @@
 		},
 		{
 			"name": "Yellow Musk Thrall",
-			"isNpc": false,
 			"source": "B2",
 			"page": 301,
 			"level": -1,
@@ -60892,7 +60567,6 @@
 		},
 		{
 			"name": "Yeth Hound",
-			"isNpc": false,
 			"source": "B2",
 			"page": 302,
 			"level": 3,
@@ -61036,7 +60710,6 @@
 		},
 		{
 			"name": "Young Brine Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 87,
 			"level": 8,
@@ -61277,7 +60950,6 @@
 		},
 		{
 			"name": "Young Cloud Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 89,
 			"level": 10,
@@ -61539,7 +61211,6 @@
 		},
 		{
 			"name": "Young Crystal Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 91,
 			"level": 7,
@@ -61839,7 +61510,6 @@
 		},
 		{
 			"name": "Young Magma Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"page": 94,
 			"level": 9,
@@ -62091,7 +61761,6 @@
 		},
 		{
 			"name": "Young Umbral Dragon",
-			"isNpc": false,
 			"source": "B2",
 			"foundIn": [
 				"Impossible Lands"
@@ -62344,7 +62013,6 @@
 		},
 		{
 			"name": "Zebub",
-			"isNpc": false,
 			"source": "B2",
 			"page": 72,
 			"level": 3,
@@ -62566,7 +62234,6 @@
 		},
 		{
 			"name": "Zelekhut",
-			"isNpc": false,
 			"source": "B2",
 			"page": 9,
 			"level": 9,
@@ -62774,7 +62441,6 @@
 		},
 		{
 			"name": "Zomok",
-			"isNpc": false,
 			"source": "B2",
 			"page": 303,
 			"level": 16,
@@ -63037,7 +62703,6 @@
 		},
 		{
 			"name": "Zyss Serpentfolk",
-			"isNpc": false,
 			"source": "B2",
 			"page": 237,
 			"level": 2,

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Abandoned Zealot",
-			"isNpc": false,
 			"source": "B3",
 			"page": 8,
 			"level": 6,
@@ -214,7 +213,6 @@
 		},
 		{
 			"name": "Abrikandilu",
-			"isNpc": false,
 			"source": "B3",
 			"page": 61,
 			"level": 4,
@@ -385,7 +383,6 @@
 		},
 		{
 			"name": "Adachros",
-			"isNpc": false,
 			"source": "B3",
 			"page": 95,
 			"level": 13,
@@ -605,7 +602,6 @@
 		},
 		{
 			"name": "Adhukait",
-			"isNpc": false,
 			"source": "B3",
 			"page": 23,
 			"level": 7,
@@ -778,7 +774,6 @@
 		},
 		{
 			"name": "Adlet",
-			"isNpc": false,
 			"source": "B3",
 			"page": 9,
 			"level": 10,
@@ -968,7 +963,6 @@
 		},
 		{
 			"name": "Adult Forest Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 75,
 			"level": 14,
@@ -1276,7 +1270,6 @@
 		},
 		{
 			"name": "Adult Sea Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 78,
 			"level": 12,
@@ -1582,7 +1575,6 @@
 		},
 		{
 			"name": "Adult Sky Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 80,
 			"level": 13,
@@ -1855,7 +1847,6 @@
 		},
 		{
 			"name": "Adult Sovereign Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 82,
 			"level": 15,
@@ -2172,7 +2163,6 @@
 		},
 		{
 			"name": "Adult Underworld Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 84,
 			"level": 11,
@@ -2446,7 +2436,6 @@
 		},
 		{
 			"name": "Aghash",
-			"isNpc": false,
 			"source": "B3",
 			"page": 69,
 			"level": 4,
@@ -2670,7 +2659,6 @@
 		},
 		{
 			"name": "Air Wisp",
-			"isNpc": false,
 			"source": "B3",
 			"page": 90,
 			"level": 0,
@@ -2796,7 +2784,6 @@
 		},
 		{
 			"name": "Amalgamite",
-			"isNpc": false,
 			"source": "B3",
 			"page": 14,
 			"level": 13,
@@ -3006,7 +2993,6 @@
 		},
 		{
 			"name": "Amphisbaena",
-			"isNpc": false,
 			"source": "B3",
 			"page": 15,
 			"level": 4,
@@ -3151,7 +3137,6 @@
 		},
 		{
 			"name": "Ancient Forest Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 76,
 			"level": 19,
@@ -3488,7 +3473,6 @@
 		},
 		{
 			"name": "Ancient Sea Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 78,
 			"level": 17,
@@ -3820,7 +3804,6 @@
 		},
 		{
 			"name": "Ancient Sky Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 80,
 			"level": 18,
@@ -4115,7 +4098,6 @@
 		},
 		{
 			"name": "Ancient Sovereign Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 83,
 			"level": 20,
@@ -4447,7 +4429,6 @@
 		},
 		{
 			"name": "Ancient Underworld Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 85,
 			"level": 16,
@@ -4741,7 +4722,6 @@
 		},
 		{
 			"name": "Android Infiltrator",
-			"isNpc": false,
 			"source": "B3",
 			"page": 16,
 			"level": 2,
@@ -4902,7 +4882,6 @@
 		},
 		{
 			"name": "Angazhani",
-			"isNpc": false,
 			"source": "B3",
 			"page": 17,
 			"level": 8,
@@ -5089,7 +5068,6 @@
 		},
 		{
 			"name": "Angheuvore Flesh-gnawer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 174,
 			"level": 2,
@@ -5294,7 +5272,6 @@
 		},
 		{
 			"name": "Animated Colossus",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Nex"
@@ -5463,7 +5440,6 @@
 		},
 		{
 			"name": "Animated Furnace",
-			"isNpc": false,
 			"source": "B3",
 			"page": 18,
 			"foundIn": [
@@ -5603,7 +5579,6 @@
 		},
 		{
 			"name": "Animated Silverware Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Nex"
@@ -5749,7 +5724,6 @@
 		},
 		{
 			"name": "Animated Trebuchet",
-			"isNpc": false,
 			"source": "B3",
 			"page": 19,
 			"foundIn": [
@@ -5905,7 +5879,6 @@
 		},
 		{
 			"name": "Aphorite Sharpshooter",
-			"isNpc": false,
 			"source": "B3",
 			"page": 204,
 			"foundIn": [
@@ -6088,7 +6061,6 @@
 		},
 		{
 			"name": "Arboreal Archive",
-			"isNpc": false,
 			"source": "B3",
 			"page": 21,
 			"level": 12,
@@ -6295,7 +6267,6 @@
 		},
 		{
 			"name": "Arboreal Reaper",
-			"isNpc": false,
 			"source": "B3",
 			"page": 20,
 			"level": 7,
@@ -6463,7 +6434,6 @@
 		},
 		{
 			"name": "Arcane Living Rune",
-			"isNpc": false,
 			"source": "B3",
 			"page": 163,
 			"level": 13,
@@ -6656,7 +6626,6 @@
 		},
 		{
 			"name": "Azarketi Explorer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 26,
 			"level": 2,
@@ -6827,7 +6796,6 @@
 		},
 		{
 			"name": "Azer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 27,
 			"level": 2,
@@ -6995,7 +6963,6 @@
 		},
 		{
 			"name": "Bauble Beast",
-			"isNpc": false,
 			"source": "B3",
 			"page": 28,
 			"level": 6,
@@ -7156,7 +7123,6 @@
 		},
 		{
 			"name": "Baykok",
-			"isNpc": false,
 			"source": "B3",
 			"page": 29,
 			"level": 9,
@@ -7359,7 +7325,6 @@
 		},
 		{
 			"name": "Betobeto-san",
-			"isNpc": false,
 			"source": "B3",
 			"page": 31,
 			"level": 12,
@@ -7551,7 +7516,6 @@
 		},
 		{
 			"name": "Bison",
-			"isNpc": false,
 			"source": "B3",
 			"page": 32,
 			"level": 4,
@@ -7671,7 +7635,6 @@
 		},
 		{
 			"name": "Blood Hag",
-			"isNpc": false,
 			"source": "B3",
 			"page": 130,
 			"level": 8,
@@ -7888,7 +7851,6 @@
 		},
 		{
 			"name": "Blood Painter",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Nex"
@@ -8045,7 +8007,6 @@
 		},
 		{
 			"name": "Bone Ship",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Geb"
@@ -8300,7 +8261,6 @@
 		},
 		{
 			"name": "Bore Worm Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -8408,7 +8368,6 @@
 		},
 		{
 			"name": "Brainchild",
-			"isNpc": false,
 			"source": "B3",
 			"page": 38,
 			"level": 11,
@@ -8622,7 +8581,6 @@
 		},
 		{
 			"name": "Brimorak",
-			"isNpc": false,
 			"source": "B3",
 			"page": 62,
 			"level": 5,
@@ -8849,7 +8807,6 @@
 		},
 		{
 			"name": "Buso Farmer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 39,
 			"hasImages": true,
@@ -8982,7 +8939,6 @@
 		},
 		{
 			"name": "Cactus Leshy",
-			"isNpc": false,
 			"source": "B3",
 			"page": 160,
 			"foundIn": [
@@ -9165,7 +9121,6 @@
 		},
 		{
 			"name": "Caligni Caller",
-			"isNpc": false,
 			"source": "B3",
 			"page": 41,
 			"level": 6,
@@ -9354,7 +9309,6 @@
 		},
 		{
 			"name": "Caligni Vanguard",
-			"isNpc": false,
 			"source": "B3",
 			"page": 40,
 			"level": 5,
@@ -9533,7 +9487,6 @@
 		},
 		{
 			"name": "Calikang",
-			"isNpc": false,
 			"source": "B3",
 			"page": 42,
 			"level": 12,
@@ -9736,7 +9689,6 @@
 		},
 		{
 			"name": "Camel",
-			"isNpc": false,
 			"source": "B3",
 			"page": 43,
 			"level": 1,
@@ -9852,7 +9804,6 @@
 		},
 		{
 			"name": "Caulborn",
-			"isNpc": false,
 			"source": "B3",
 			"page": 94,
 			"level": 7,
@@ -10107,7 +10058,6 @@
 		},
 		{
 			"name": "Cave Giant",
-			"isNpc": false,
 			"source": "B3",
 			"page": 108,
 			"level": 6,
@@ -10261,7 +10211,6 @@
 		},
 		{
 			"name": "Cecaelia Trapper",
-			"isNpc": false,
 			"source": "B3",
 			"page": 45,
 			"level": 5,
@@ -10413,7 +10362,6 @@
 		},
 		{
 			"name": "Chouchin-obake",
-			"isNpc": false,
 			"source": "B3",
 			"page": 277,
 			"level": 6,
@@ -10564,7 +10512,6 @@
 		},
 		{
 			"name": "Chyzaedu",
-			"isNpc": false,
 			"source": "B3",
 			"page": 46,
 			"level": 10,
@@ -10844,7 +10791,6 @@
 		},
 		{
 			"name": "City Guard Squadron",
-			"isNpc": false,
 			"source": "B3",
 			"page": 47,
 			"level": 5,
@@ -10992,7 +10938,6 @@
 		},
 		{
 			"name": "Clacking Skull Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 244,
 			"level": 10,
@@ -11155,7 +11100,6 @@
 		},
 		{
 			"name": "Clockwork Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -11368,7 +11312,6 @@
 		},
 		{
 			"name": "Clockwork Mage",
-			"isNpc": false,
 			"foundIn": [
 				"Alkenstar",
 				"Mana Wastes",
@@ -11608,7 +11551,6 @@
 		},
 		{
 			"name": "Clockwork Soldier",
-			"isNpc": false,
 			"source": "B3",
 			"page": 49,
 			"level": 6,
@@ -11766,7 +11708,6 @@
 		},
 		{
 			"name": "Clockwork Spy",
-			"isNpc": false,
 			"source": "B3",
 			"page": 48,
 			"foundIn": [
@@ -11898,7 +11839,6 @@
 		},
 		{
 			"name": "Cobbleswarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 52,
 			"level": 2,
@@ -12029,7 +11969,6 @@
 		},
 		{
 			"name": "Common Eurypterid",
-			"isNpc": false,
 			"source": "B3",
 			"page": 97,
 			"level": -1,
@@ -12169,7 +12108,6 @@
 		},
 		{
 			"name": "Consonite Choir",
-			"isNpc": false,
 			"source": "B3",
 			"page": 53,
 			"level": 13,
@@ -12325,7 +12263,6 @@
 		},
 		{
 			"name": "Coral Capuchin",
-			"isNpc": false,
 			"source": "B3",
 			"page": 54,
 			"level": 1,
@@ -12442,7 +12379,6 @@
 		},
 		{
 			"name": "Corrupted Relic",
-			"isNpc": false,
 			"foundIn": [
 				"Impossible Lands"
 			],
@@ -12643,7 +12579,6 @@
 		},
 		{
 			"name": "Crossroads Guardian",
-			"isNpc": false,
 			"source": "B3",
 			"page": 59,
 			"level": 7,
@@ -12818,7 +12753,6 @@
 		},
 		{
 			"name": "Cunning Fox",
-			"isNpc": false,
 			"source": "B3",
 			"page": 252,
 			"hasImages": true,
@@ -13011,7 +12945,6 @@
 		},
 		{
 			"name": "Danava Titan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 270,
 			"level": 23,
@@ -13299,7 +13232,6 @@
 		},
 		{
 			"name": "Deimavigga",
-			"isNpc": false,
 			"source": "B3",
 			"page": 66,
 			"level": 17,
@@ -13566,7 +13498,6 @@
 		},
 		{
 			"name": "Desert Giant",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -13732,7 +13663,6 @@
 		},
 		{
 			"name": "Divine Warden Of Nethys",
-			"isNpc": false,
 			"source": "B3",
 			"page": 73,
 			"level": 5,
@@ -13912,7 +13842,6 @@
 		},
 		{
 			"name": "Domovoi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 136,
 			"level": 2,
@@ -14077,7 +14006,6 @@
 		},
 		{
 			"name": "Doru",
-			"isNpc": false,
 			"source": "B3",
 			"page": 68,
 			"level": 1,
@@ -14279,7 +14207,6 @@
 		},
 		{
 			"name": "Draconal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 13,
 			"level": 20,
@@ -14538,7 +14465,6 @@
 		},
 		{
 			"name": "Dramofir",
-			"isNpc": false,
 			"source": "B3",
 			"page": 86,
 			"level": 14,
@@ -14776,7 +14702,6 @@
 		},
 		{
 			"name": "Draxie",
-			"isNpc": false,
 			"source": "B3",
 			"page": 255,
 			"level": 3,
@@ -14954,7 +14879,6 @@
 		},
 		{
 			"name": "Dretch",
-			"isNpc": false,
 			"source": "B3",
 			"page": 60,
 			"level": 2,
@@ -15123,7 +15047,6 @@
 		},
 		{
 			"name": "Duende",
-			"isNpc": false,
 			"source": "B3",
 			"page": 87,
 			"level": 2,
@@ -15316,7 +15239,6 @@
 		},
 		{
 			"name": "Dvorovoi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 137,
 			"level": 3,
@@ -15479,7 +15401,6 @@
 		},
 		{
 			"name": "Dybbuk",
-			"isNpc": false,
 			"source": "B3",
 			"page": 88,
 			"level": 15,
@@ -15719,7 +15640,6 @@
 		},
 		{
 			"name": "Earth Wisp",
-			"isNpc": false,
 			"source": "B3",
 			"page": 91,
 			"level": 0,
@@ -15856,7 +15776,6 @@
 		},
 		{
 			"name": "Einherji",
-			"isNpc": false,
 			"source": "B3",
 			"page": 89,
 			"level": 10,
@@ -16070,7 +15989,6 @@
 		},
 		{
 			"name": "Elder Sphinx",
-			"isNpc": false,
 			"source": "B3",
 			"page": 250,
 			"level": 16,
@@ -16323,7 +16241,6 @@
 		},
 		{
 			"name": "Elder Wyrmwraith",
-			"isNpc": false,
 			"source": "B3",
 			"page": 297,
 			"level": 23,
@@ -16626,7 +16543,6 @@
 		},
 		{
 			"name": "Elysian Titan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 268,
 			"level": 21,
@@ -16901,7 +16817,6 @@
 		},
 		{
 			"name": "Empress Bore Worm",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -17035,7 +16950,6 @@
 		},
 		{
 			"name": "Esipil",
-			"isNpc": false,
 			"source": "B3",
 			"page": 218,
 			"level": 1,
@@ -17233,7 +17147,6 @@
 		},
 		{
 			"name": "Etioling Blightmage",
-			"isNpc": false,
 			"source": "B3",
 			"page": 177,
 			"level": 10,
@@ -17503,7 +17416,6 @@
 		},
 		{
 			"name": "Eunemvro",
-			"isNpc": false,
 			"source": "B3",
 			"page": 96,
 			"level": 5,
@@ -17712,7 +17624,6 @@
 		},
 		{
 			"name": "Fading Fox",
-			"isNpc": false,
 			"source": "B3",
 			"page": 102,
 			"level": 2,
@@ -17855,7 +17766,6 @@
 		},
 		{
 			"name": "Feathered Bear",
-			"isNpc": false,
 			"source": "B3",
 			"page": 253,
 			"level": 10,
@@ -18056,7 +17966,6 @@
 		},
 		{
 			"name": "Feral Skull Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 244,
 			"level": 12,
@@ -18227,7 +18136,6 @@
 		},
 		{
 			"name": "Festrog",
-			"isNpc": false,
 			"source": "B3",
 			"page": 98,
 			"level": 1,
@@ -18373,7 +18281,6 @@
 		},
 		{
 			"name": "Fire Wisp",
-			"isNpc": false,
 			"source": "B3",
 			"page": 91,
 			"level": 0,
@@ -18523,7 +18430,6 @@
 		},
 		{
 			"name": "Flaming Skull",
-			"isNpc": false,
 			"source": "B3",
 			"page": 30,
 			"level": 2,
@@ -18654,7 +18560,6 @@
 		},
 		{
 			"name": "Flumph",
-			"isNpc": false,
 			"source": "B3",
 			"page": 100,
 			"level": 1,
@@ -18771,7 +18676,6 @@
 		},
 		{
 			"name": "Fortune Eater",
-			"isNpc": false,
 			"source": "B3",
 			"page": 101,
 			"level": 7,
@@ -18972,7 +18876,6 @@
 		},
 		{
 			"name": "Fossil Golem",
-			"isNpc": false,
 			"source": "B3",
 			"page": 116,
 			"level": 12,
@@ -19115,7 +19018,6 @@
 		},
 		{
 			"name": "Fuath",
-			"isNpc": false,
 			"source": "B3",
 			"page": 121,
 			"level": 1,
@@ -19296,7 +19198,6 @@
 		},
 		{
 			"name": "Galvo",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Impossible Lands"
@@ -19474,7 +19375,6 @@
 		},
 		{
 			"name": "Ganzi Martial Artist",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -19647,7 +19547,6 @@
 		},
 		{
 			"name": "Garuda",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -19864,7 +19763,6 @@
 		},
 		{
 			"name": "Gathlain Wanderer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 105,
 			"level": 1,
@@ -20008,7 +19906,6 @@
 		},
 		{
 			"name": "Ghoran Manipulator",
-			"isNpc": false,
 			"source": "B3",
 			"page": 106,
 			"foundIn": [
@@ -20273,7 +20170,6 @@
 		},
 		{
 			"name": "Giant Flying Squirrel",
-			"isNpc": false,
 			"source": "B3",
 			"page": 257,
 			"level": 2,
@@ -20381,7 +20277,6 @@
 		},
 		{
 			"name": "Giant Hermit Crab",
-			"isNpc": false,
 			"source": "B3",
 			"page": 58,
 			"level": 5,
@@ -20526,7 +20421,6 @@
 		},
 		{
 			"name": "Giant Opossum",
-			"isNpc": false,
 			"source": "B3",
 			"page": 192,
 			"level": 2,
@@ -20677,7 +20571,6 @@
 		},
 		{
 			"name": "Giant Pangolin",
-			"isNpc": false,
 			"source": "B3",
 			"page": 199,
 			"level": 4,
@@ -20817,7 +20710,6 @@
 		},
 		{
 			"name": "Giant Porcupine",
-			"isNpc": false,
 			"source": "B3",
 			"page": 207,
 			"level": 2,
@@ -20933,7 +20825,6 @@
 		},
 		{
 			"name": "Giant Seahorse",
-			"isNpc": false,
 			"source": "B3",
 			"page": 227,
 			"level": 3,
@@ -21043,7 +20934,6 @@
 		},
 		{
 			"name": "Giant Skunk",
-			"isNpc": false,
 			"source": "B3",
 			"page": 246,
 			"level": 1,
@@ -21161,7 +21051,6 @@
 		},
 		{
 			"name": "Giant Vulture",
-			"isNpc": false,
 			"source": "B3",
 			"page": 289,
 			"level": 3,
@@ -21290,7 +21179,6 @@
 		},
 		{
 			"name": "Girtablilu Seer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 113,
 			"level": 12,
@@ -21584,7 +21472,6 @@
 		},
 		{
 			"name": "Girtablilu Sentry",
-			"isNpc": false,
 			"source": "B3",
 			"page": 112,
 			"level": 8,
@@ -21761,7 +21648,6 @@
 		},
 		{
 			"name": "Gliminal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 114,
 			"level": 9,
@@ -21990,7 +21876,6 @@
 		},
 		{
 			"name": "Globster",
-			"isNpc": false,
 			"source": "B3",
 			"page": 115,
 			"level": 5,
@@ -22116,7 +22001,6 @@
 		},
 		{
 			"name": "Green Man",
-			"isNpc": false,
 			"source": "B3",
 			"page": 118,
 			"level": 24,
@@ -22459,7 +22343,6 @@
 		},
 		{
 			"name": "Grimple",
-			"isNpc": false,
 			"source": "B3",
 			"page": 120,
 			"level": -1,
@@ -22625,7 +22508,6 @@
 		},
 		{
 			"name": "Grioth Cultist",
-			"isNpc": false,
 			"source": "B3",
 			"page": 123,
 			"level": 3,
@@ -22947,7 +22829,6 @@
 		},
 		{
 			"name": "Grioth Scout",
-			"isNpc": false,
 			"source": "B3",
 			"page": 122,
 			"level": 1,
@@ -23179,7 +23060,6 @@
 		},
 		{
 			"name": "Guecubu",
-			"isNpc": false,
 			"source": "B3",
 			"page": 126,
 			"level": 8,
@@ -23366,7 +23246,6 @@
 		},
 		{
 			"name": "Gurgist Mauler",
-			"isNpc": false,
 			"source": "B3",
 			"page": 175,
 			"level": 6,
@@ -23552,7 +23431,6 @@
 		},
 		{
 			"name": "Hadrinnex",
-			"isNpc": false,
 			"source": "B3",
 			"page": 127,
 			"level": 8,
@@ -23717,7 +23595,6 @@
 		},
 		{
 			"name": "Haniver",
-			"isNpc": false,
 			"source": "B3",
 			"page": 120,
 			"level": -1,
@@ -23859,7 +23736,6 @@
 		},
 		{
 			"name": "Harmona",
-			"isNpc": false,
 			"source": "B3",
 			"page": 132,
 			"level": 11,
@@ -24064,7 +23940,6 @@
 		},
 		{
 			"name": "Harpy Skeleton",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -24227,7 +24102,6 @@
 		},
 		{
 			"name": "Hatred Siktempora",
-			"isNpc": false,
 			"source": "B3",
 			"page": 235,
 			"level": 18,
@@ -24452,7 +24326,6 @@
 		},
 		{
 			"name": "Hekatonkheires Titan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 271,
 			"level": 24,
@@ -24711,7 +24584,6 @@
 		},
 		{
 			"name": "Hellbound Attorney",
-			"isNpc": false,
 			"source": "B3",
 			"page": 64,
 			"level": 4,
@@ -24877,7 +24749,6 @@
 		},
 		{
 			"name": "Hellknight Cavalry Brigade",
-			"isNpc": false,
 			"source": "B3",
 			"page": 44,
 			"level": 8,
@@ -25056,7 +24927,6 @@
 		},
 		{
 			"name": "Hellwasp Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 133,
 			"level": 8,
@@ -25233,7 +25103,6 @@
 		},
 		{
 			"name": "Herexen",
-			"isNpc": false,
 			"source": "B3",
 			"page": 134,
 			"level": 2,
@@ -25384,7 +25253,6 @@
 		},
 		{
 			"name": "Hermit Crab Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 58,
 			"level": 4,
@@ -25478,7 +25346,6 @@
 		},
 		{
 			"name": "Hesperid",
-			"isNpc": false,
 			"source": "B3",
 			"page": 189,
 			"level": 9,
@@ -25680,7 +25547,6 @@
 		},
 		{
 			"name": "Hesperid Queen",
-			"isNpc": false,
 			"source": "B3",
 			"page": 191,
 			"level": 19,
@@ -26092,7 +25958,6 @@
 		},
 		{
 			"name": "Hieracosphinx",
-			"isNpc": false,
 			"source": "B3",
 			"page": 250,
 			"level": 5,
@@ -26250,7 +26115,6 @@
 		},
 		{
 			"name": "House Drake",
-			"isNpc": false,
 			"source": "B3",
 			"page": 135,
 			"level": 1,
@@ -26425,7 +26289,6 @@
 		},
 		{
 			"name": "Huldra",
-			"isNpc": false,
 			"source": "B3",
 			"page": 138,
 			"level": 4,
@@ -26537,7 +26400,6 @@
 		},
 		{
 			"name": "Hyakume",
-			"isNpc": false,
 			"source": "B3",
 			"page": 139,
 			"level": 15,
@@ -26798,7 +26660,6 @@
 		},
 		{
 			"name": "Incutilis",
-			"isNpc": false,
 			"source": "B3",
 			"page": 140,
 			"level": 2,
@@ -26923,7 +26784,6 @@
 		},
 		{
 			"name": "Ioton",
-			"isNpc": false,
 			"source": "B3",
 			"page": 92,
 			"level": 0,
@@ -27081,7 +26941,6 @@
 		},
 		{
 			"name": "Ittan-momen",
-			"isNpc": false,
 			"source": "B3",
 			"page": 276,
 			"level": 2,
@@ -27228,7 +27087,6 @@
 		},
 		{
 			"name": "Japalisura",
-			"isNpc": false,
 			"source": "B3",
 			"page": 23,
 			"level": 12,
@@ -27485,7 +27343,6 @@
 		},
 		{
 			"name": "Jorogumo",
-			"isNpc": false,
 			"source": "B3",
 			"page": 141,
 			"level": 13,
@@ -27624,7 +27481,6 @@
 		},
 		{
 			"name": "Kangaroo",
-			"isNpc": false,
 			"source": "B3",
 			"page": 146,
 			"level": 0,
@@ -27737,7 +27593,6 @@
 		},
 		{
 			"name": "Kappa",
-			"isNpc": false,
 			"source": "B3",
 			"page": 147,
 			"level": 2,
@@ -27850,7 +27705,6 @@
 		},
 		{
 			"name": "Kasa-obake",
-			"isNpc": false,
 			"source": "B3",
 			"page": 277,
 			"level": 4,
@@ -27979,7 +27833,6 @@
 		},
 		{
 			"name": "Khravgodon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 192,
 			"level": 9,
@@ -28145,7 +27998,6 @@
 		},
 		{
 			"name": "Kimenhul",
-			"isNpc": false,
 			"source": "B3",
 			"page": 222,
 			"level": 20,
@@ -28457,7 +28309,6 @@
 		},
 		{
 			"name": "Kirin",
-			"isNpc": false,
 			"source": "B3",
 			"page": 148,
 			"level": 7,
@@ -28688,7 +28539,6 @@
 		},
 		{
 			"name": "Kishi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 149,
 			"level": 8,
@@ -28858,7 +28708,6 @@
 		},
 		{
 			"name": "Kitsune Trickster",
-			"isNpc": false,
 			"source": "B3",
 			"page": 150,
 			"level": 2,
@@ -29062,7 +28911,6 @@
 		},
 		{
 			"name": "Kodama",
-			"isNpc": false,
 			"source": "B3",
 			"page": 143,
 			"level": 5,
@@ -29265,7 +29113,6 @@
 		},
 		{
 			"name": "Kokogiak",
-			"isNpc": false,
 			"source": "B3",
 			"page": 151,
 			"level": 12,
@@ -29456,7 +29303,6 @@
 		},
 		{
 			"name": "Kongamato",
-			"isNpc": false,
 			"source": "B3",
 			"page": 152,
 			"level": 11,
@@ -29643,7 +29489,6 @@
 		},
 		{
 			"name": "Kovintus Geomancer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 153,
 			"level": 3,
@@ -29836,7 +29681,6 @@
 		},
 		{
 			"name": "Krampus",
-			"isNpc": false,
 			"source": "B3",
 			"page": 154,
 			"level": 21,
@@ -30147,7 +29991,6 @@
 		},
 		{
 			"name": "Kuchisake-onna",
-			"isNpc": false,
 			"source": "B3",
 			"page": 156,
 			"level": 14,
@@ -30304,7 +30147,6 @@
 		},
 		{
 			"name": "Kurobozu",
-			"isNpc": false,
 			"source": "B3",
 			"page": 157,
 			"level": 6,
@@ -30482,7 +30324,6 @@
 		},
 		{
 			"name": "Kushtaka",
-			"isNpc": false,
 			"source": "B3",
 			"page": 158,
 			"level": 4,
@@ -30701,7 +30542,6 @@
 		},
 		{
 			"name": "Lampad",
-			"isNpc": false,
 			"source": "B3",
 			"page": 188,
 			"level": 5,
@@ -30907,7 +30747,6 @@
 		},
 		{
 			"name": "Lampad Queen",
-			"isNpc": false,
 			"source": "B3",
 			"page": 189,
 			"level": 15,
@@ -31340,7 +31179,6 @@
 		},
 		{
 			"name": "Ledalusca",
-			"isNpc": false,
 			"source": "B3",
 			"page": 159,
 			"level": 2,
@@ -31522,7 +31360,6 @@
 		},
 		{
 			"name": "Leng Ghoul",
-			"isNpc": false,
 			"source": "B3",
 			"page": 107,
 			"level": 10,
@@ -31729,7 +31566,6 @@
 		},
 		{
 			"name": "Levaloch",
-			"isNpc": false,
 			"source": "B3",
 			"page": 65,
 			"level": 7,
@@ -31929,7 +31765,6 @@
 		},
 		{
 			"name": "Lifeleecher Brawler",
-			"isNpc": false,
 			"source": "B3",
 			"page": 176,
 			"level": 8,
@@ -32108,7 +31943,6 @@
 		},
 		{
 			"name": "Locathah Hunter",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -32274,7 +32108,6 @@
 		},
 		{
 			"name": "Love Siktempora",
-			"isNpc": false,
 			"source": "B3",
 			"page": 234,
 			"level": 16,
@@ -32532,7 +32365,6 @@
 		},
 		{
 			"name": "Lovelorn",
-			"isNpc": false,
 			"source": "B3",
 			"page": 165,
 			"level": 4,
@@ -32745,7 +32577,6 @@
 		},
 		{
 			"name": "Maftet Guardian",
-			"isNpc": false,
 			"source": "B3",
 			"page": 166,
 			"foundIn": [
@@ -32935,7 +32766,6 @@
 		},
 		{
 			"name": "Maharaja",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -33379,7 +33209,6 @@
 		},
 		{
 			"name": "Manticore Paaridar",
-			"isNpc": false,
 			"foundIn": [
 				"Jalmeray"
 			],
@@ -33578,7 +33407,6 @@
 		},
 		{
 			"name": "Megalictis",
-			"isNpc": false,
 			"source": "B3",
 			"page": 291,
 			"level": 3,
@@ -33702,7 +33530,6 @@
 		},
 		{
 			"name": "Megatherium",
-			"isNpc": false,
 			"source": "B3",
 			"page": 248,
 			"level": 5,
@@ -33833,7 +33660,6 @@
 		},
 		{
 			"name": "Melixie",
-			"isNpc": false,
 			"source": "B3",
 			"page": 255,
 			"level": 0,
@@ -33986,7 +33812,6 @@
 		},
 		{
 			"name": "Mezlan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 167,
 			"level": 14,
@@ -34170,7 +33995,6 @@
 		},
 		{
 			"name": "Mi-Go",
-			"isNpc": false,
 			"source": "B3",
 			"page": 168,
 			"level": 6,
@@ -34343,7 +34167,6 @@
 		},
 		{
 			"name": "Millindemalion",
-			"isNpc": false,
 			"source": "B3",
 			"page": 169,
 			"level": 13,
@@ -34522,7 +34345,6 @@
 		},
 		{
 			"name": "Misery Siktempora",
-			"isNpc": false,
 			"source": "B3",
 			"page": 232,
 			"level": 12,
@@ -34744,7 +34566,6 @@
 		},
 		{
 			"name": "Mithral Golem",
-			"isNpc": false,
 			"source": "B3",
 			"page": 117,
 			"foundIn": [
@@ -34919,7 +34740,6 @@
 		},
 		{
 			"name": "Mix Couatl",
-			"isNpc": false,
 			"source": "B3",
 			"page": 56,
 			"level": 8,
@@ -35186,7 +35006,6 @@
 		},
 		{
 			"name": "Mobogo",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -35431,7 +35250,6 @@
 		},
 		{
 			"name": "Mokele-mbembe",
-			"isNpc": false,
 			"source": "B3",
 			"page": 171,
 			"level": 9,
@@ -35581,7 +35399,6 @@
 		},
 		{
 			"name": "Monkey",
-			"isNpc": false,
 			"source": "B3",
 			"page": 172,
 			"level": -1,
@@ -35667,7 +35484,6 @@
 		},
 		{
 			"name": "Monkey Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 172,
 			"level": 2,
@@ -35785,7 +35601,6 @@
 		},
 		{
 			"name": "Moon Hag",
-			"isNpc": false,
 			"source": "B3",
 			"page": 131,
 			"level": 10,
@@ -35980,7 +35795,6 @@
 		},
 		{
 			"name": "Moose",
-			"isNpc": false,
 			"source": "B3",
 			"page": 173,
 			"level": 3,
@@ -36112,7 +35926,6 @@
 		},
 		{
 			"name": "Mothman",
-			"isNpc": false,
 			"source": "B3",
 			"page": 179,
 			"level": 7,
@@ -36332,7 +36145,6 @@
 		},
 		{
 			"name": "Munagola",
-			"isNpc": false,
 			"source": "B3",
 			"page": 66,
 			"level": 11,
@@ -36564,7 +36376,6 @@
 		},
 		{
 			"name": "Munavri Spellblade",
-			"isNpc": false,
 			"source": "B3",
 			"page": 180,
 			"level": 2,
@@ -36692,7 +36503,6 @@
 		},
 		{
 			"name": "Myceloid",
-			"isNpc": false,
 			"source": "B3",
 			"page": 181,
 			"level": 4,
@@ -36866,7 +36676,6 @@
 		},
 		{
 			"name": "Nagaji Soldier",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -37017,7 +36826,6 @@
 		},
 		{
 			"name": "Namorrodor",
-			"isNpc": false,
 			"source": "B3",
 			"page": 183,
 			"level": 5,
@@ -37189,7 +36997,6 @@
 		},
 		{
 			"name": "Narwhal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 184,
 			"level": 3,
@@ -37303,7 +37110,6 @@
 		},
 		{
 			"name": "Nemhaith",
-			"isNpc": false,
 			"source": "B3",
 			"page": 185,
 			"level": 15,
@@ -37541,7 +37347,6 @@
 		},
 		{
 			"name": "Nightgaunt",
-			"isNpc": false,
 			"source": "B3",
 			"page": 186,
 			"level": 4,
@@ -37712,7 +37517,6 @@
 		},
 		{
 			"name": "Nightmarchers",
-			"isNpc": false,
 			"source": "B3",
 			"page": 187,
 			"level": 14,
@@ -37923,7 +37727,6 @@
 		},
 		{
 			"name": "Nikaramsa",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -38212,7 +38015,6 @@
 		},
 		{
 			"name": "Nosferatu Malefactor",
-			"isNpc": false,
 			"source": "B3",
 			"page": 285,
 			"level": 10,
@@ -38445,7 +38247,6 @@
 		},
 		{
 			"name": "Nosferatu Overlord",
-			"isNpc": false,
 			"source": "B3",
 			"page": 285,
 			"level": 15,
@@ -38666,7 +38467,6 @@
 		},
 		{
 			"name": "Nosferatu Thrall",
-			"isNpc": false,
 			"source": "B3",
 			"page": 284,
 			"level": 8,
@@ -38817,7 +38617,6 @@
 		},
 		{
 			"name": "Nucol",
-			"isNpc": false,
 			"source": "B3",
 			"page": 220,
 			"level": 4,
@@ -39037,7 +38836,6 @@
 		},
 		{
 			"name": "Nyktera",
-			"isNpc": false,
 			"source": "B3",
 			"page": 254,
 			"level": -1,
@@ -39175,7 +38973,6 @@
 		},
 		{
 			"name": "Oil Living Graffiti",
-			"isNpc": false,
 			"source": "B3",
 			"page": 162,
 			"level": 3,
@@ -39316,7 +39113,6 @@
 		},
 		{
 			"name": "Omox",
-			"isNpc": false,
 			"source": "B3",
 			"page": 63,
 			"level": 12,
@@ -39552,7 +39348,6 @@
 		},
 		{
 			"name": "Ostovite",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Impossible Lands"
@@ -39698,7 +39493,6 @@
 		},
 		{
 			"name": "Ouroboros",
-			"isNpc": false,
 			"source": "B3",
 			"page": 194,
 			"level": 21,
@@ -39982,7 +39776,6 @@
 		},
 		{
 			"name": "Ovinnik",
-			"isNpc": false,
 			"source": "B3",
 			"page": 137,
 			"level": 4,
@@ -40158,7 +39951,6 @@
 		},
 		{
 			"name": "Owb",
-			"isNpc": false,
 			"source": "B3",
 			"page": 196,
 			"level": 6,
@@ -40368,7 +40160,6 @@
 		},
 		{
 			"name": "Owb Prophet",
-			"isNpc": false,
 			"source": "B3",
 			"page": 197,
 			"level": 13,
@@ -40631,7 +40422,6 @@
 		},
 		{
 			"name": "Pairaka",
-			"isNpc": false,
 			"source": "B3",
 			"page": 70,
 			"level": 7,
@@ -40876,7 +40666,6 @@
 		},
 		{
 			"name": "Pakalchi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 220,
 			"level": 9,
@@ -41151,7 +40940,6 @@
 		},
 		{
 			"name": "Palace Skelm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 240,
 			"level": 8,
@@ -41424,7 +41212,6 @@
 		},
 		{
 			"name": "Penanggalan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 200,
 			"level": 5,
@@ -41610,7 +41397,6 @@
 		},
 		{
 			"name": "Peri",
-			"isNpc": false,
 			"source": "B3",
 			"page": 201,
 			"level": 14,
@@ -41870,7 +41656,6 @@
 		},
 		{
 			"name": "Phantom Beast",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -42048,7 +41833,6 @@
 		},
 		{
 			"name": "Phantom Knight",
-			"isNpc": false,
 			"source": "B3",
 			"page": 202,
 			"foundIn": [
@@ -42190,7 +41974,6 @@
 		},
 		{
 			"name": "Piranha Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 99,
 			"level": 3,
@@ -42297,7 +42080,6 @@
 		},
 		{
 			"name": "Plague Giant",
-			"isNpc": false,
 			"source": "B3",
 			"page": 111,
 			"level": 14,
@@ -42542,7 +42324,6 @@
 		},
 		{
 			"name": "Platecarpus",
-			"isNpc": false,
 			"source": "B3",
 			"page": 178,
 			"level": 3,
@@ -42661,7 +42442,6 @@
 		},
 		{
 			"name": "Popobawa",
-			"isNpc": false,
 			"source": "B3",
 			"page": 206,
 			"level": 15,
@@ -42932,7 +42712,6 @@
 		},
 		{
 			"name": "Procyal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 12,
 			"level": 8,
@@ -43170,7 +42949,6 @@
 		},
 		{
 			"name": "Pufferfish",
-			"isNpc": false,
 			"source": "B3",
 			"page": 99,
 			"level": -1,
@@ -43301,7 +43079,6 @@
 		},
 		{
 			"name": "Pukwudgie",
-			"isNpc": false,
 			"source": "B3",
 			"page": 208,
 			"level": 7,
@@ -43547,7 +43324,6 @@
 		},
 		{
 			"name": "Quintessivore",
-			"isNpc": false,
 			"source": "B3",
 			"page": 209,
 			"level": 10,
@@ -43791,7 +43567,6 @@
 		},
 		{
 			"name": "Raktavarna",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -43995,7 +43770,6 @@
 		},
 		{
 			"name": "Rancorous Priesthood",
-			"isNpc": false,
 			"source": "B3",
 			"page": 213,
 			"level": 11,
@@ -44179,7 +43953,6 @@
 		},
 		{
 			"name": "Rat Snake Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 249,
 			"level": 2,
@@ -44304,7 +44077,6 @@
 		},
 		{
 			"name": "Red Fox",
-			"isNpc": false,
 			"source": "B3",
 			"page": 102,
 			"level": -1,
@@ -44406,7 +44178,6 @@
 		},
 		{
 			"name": "Rhu-chalik",
-			"isNpc": false,
 			"source": "B3",
 			"page": 214,
 			"level": 6,
@@ -44606,7 +44377,6 @@
 		},
 		{
 			"name": "Ringhorn Ram",
-			"isNpc": false,
 			"source": "B3",
 			"page": 212,
 			"level": 0,
@@ -44719,7 +44489,6 @@
 		},
 		{
 			"name": "Roiling Incant",
-			"isNpc": false,
 			"source": "B3",
 			"page": 215,
 			"level": 9,
@@ -44885,7 +44654,6 @@
 		},
 		{
 			"name": "Rokurokubi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 216,
 			"level": 2,
@@ -45047,7 +44815,6 @@
 		},
 		{
 			"name": "Rosethorn Ram",
-			"isNpc": false,
 			"source": "B3",
 			"page": 212,
 			"level": 2,
@@ -45175,7 +44942,6 @@
 		},
 		{
 			"name": "Sabosan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 217,
 			"level": 5,
@@ -45357,7 +45123,6 @@
 		},
 		{
 			"name": "Samsaran Anchorite",
-			"isNpc": false,
 			"source": "B3",
 			"page": 224,
 			"level": 1,
@@ -45546,7 +45311,6 @@
 		},
 		{
 			"name": "Sasquatch",
-			"isNpc": false,
 			"source": "B3",
 			"page": 225,
 			"level": 2,
@@ -45716,7 +45480,6 @@
 		},
 		{
 			"name": "Scalescribe",
-			"isNpc": false,
 			"source": "B3",
 			"page": 226,
 			"level": 3,
@@ -45914,7 +45677,6 @@
 		},
 		{
 			"name": "Seaweed Leshy",
-			"isNpc": false,
 			"source": "B3",
 			"page": 161,
 			"level": 3,
@@ -46083,7 +45845,6 @@
 		},
 		{
 			"name": "Seething Spirit",
-			"isNpc": false,
 			"source": "B3",
 			"page": 228,
 			"level": 11,
@@ -46312,7 +46073,6 @@
 		},
 		{
 			"name": "Sepid",
-			"isNpc": false,
 			"source": "B3",
 			"page": 71,
 			"level": 14,
@@ -46571,7 +46331,6 @@
 		},
 		{
 			"name": "Severed Head",
-			"isNpc": false,
 			"source": "B3",
 			"page": 30,
 			"level": -1,
@@ -46673,7 +46432,6 @@
 		},
 		{
 			"name": "Shabti Redeemer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 229,
 			"foundIn": [
@@ -46870,7 +46628,6 @@
 		},
 		{
 			"name": "Shae",
-			"isNpc": false,
 			"source": "B3",
 			"page": 230,
 			"level": 4,
@@ -47100,7 +46857,6 @@
 		},
 		{
 			"name": "Shambler Troop",
-			"isNpc": false,
 			"source": "B3",
 			"page": 302,
 			"foundIn": [
@@ -47234,7 +46990,6 @@
 		},
 		{
 			"name": "Shantak",
-			"isNpc": false,
 			"source": "B3",
 			"page": 231,
 			"level": 8,
@@ -47379,7 +47134,6 @@
 		},
 		{
 			"name": "Shaukeen",
-			"isNpc": false,
 			"source": "B3",
 			"page": 22,
 			"foundIn": [
@@ -47597,7 +47351,6 @@
 		},
 		{
 			"name": "Shikigami",
-			"isNpc": false,
 			"source": "B3",
 			"page": 142,
 			"level": 1,
@@ -47770,7 +47523,6 @@
 		},
 		{
 			"name": "Shrine Skelm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 239,
 			"level": 5,
@@ -47968,7 +47720,6 @@
 		},
 		{
 			"name": "Shulsaga",
-			"isNpc": false,
 			"source": "B3",
 			"page": 93,
 			"level": 3,
@@ -48191,7 +47942,6 @@
 		},
 		{
 			"name": "Silvanshee",
-			"isNpc": false,
 			"source": "B3",
 			"page": 10,
 			"level": 1,
@@ -48379,7 +48129,6 @@
 		},
 		{
 			"name": "Skeleton Infantry",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Alkenstar",
@@ -48551,7 +48300,6 @@
 		},
 		{
 			"name": "Skinstitch",
-			"isNpc": false,
 			"source": "B3",
 			"page": 242,
 			"level": 5,
@@ -48696,7 +48444,6 @@
 		},
 		{
 			"name": "Skull Peeler",
-			"isNpc": false,
 			"source": "B3",
 			"page": 243,
 			"level": 6,
@@ -48825,7 +48572,6 @@
 		},
 		{
 			"name": "Skunk",
-			"isNpc": false,
 			"source": "B3",
 			"page": 246,
 			"level": -1,
@@ -48936,7 +48682,6 @@
 		},
 		{
 			"name": "Slithering Pit",
-			"isNpc": false,
 			"source": "B3",
 			"page": 247,
 			"level": 7,
@@ -49087,7 +48832,6 @@
 		},
 		{
 			"name": "Sorcerous Skull Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 245,
 			"level": 14,
@@ -49252,7 +48996,6 @@
 		},
 		{
 			"name": "Soul Skelm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 241,
 			"level": 10,
@@ -49502,7 +49245,6 @@
 		},
 		{
 			"name": "Spiny Eurypterid",
-			"isNpc": false,
 			"source": "B3",
 			"page": 97,
 			"level": 5,
@@ -49648,7 +49390,6 @@
 		},
 		{
 			"name": "Squirming Swill",
-			"isNpc": false,
 			"source": "B3",
 			"page": 256,
 			"level": 2,
@@ -49810,7 +49551,6 @@
 		},
 		{
 			"name": "Squirrel Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 257,
 			"level": 1,
@@ -49919,7 +49659,6 @@
 		},
 		{
 			"name": "Stheno Harpist",
-			"isNpc": false,
 			"source": "B3",
 			"page": 258,
 			"level": 1,
@@ -50102,7 +49841,6 @@
 		},
 		{
 			"name": "Stone Lion",
-			"isNpc": false,
 			"source": "B3",
 			"page": 125,
 			"level": 4,
@@ -50298,7 +50036,6 @@
 		},
 		{
 			"name": "Stone Lion Cub",
-			"isNpc": false,
 			"source": "B3",
 			"page": 124,
 			"level": 2,
@@ -50475,7 +50212,6 @@
 		},
 		{
 			"name": "Storm Hag",
-			"isNpc": false,
 			"source": "B3",
 			"page": 128,
 			"level": 5,
@@ -50673,7 +50409,6 @@
 		},
 		{
 			"name": "Street Skelm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 238,
 			"level": 3,
@@ -50884,7 +50619,6 @@
 		},
 		{
 			"name": "Strix Kinmate",
-			"isNpc": false,
 			"source": "B3",
 			"page": 259,
 			"level": 2,
@@ -51034,7 +50768,6 @@
 		},
 		{
 			"name": "Sturzstromer",
-			"isNpc": false,
 			"source": "B3",
 			"page": 52,
 			"level": 19,
@@ -51210,7 +50943,6 @@
 		},
 		{
 			"name": "Sulfur Zombie",
-			"isNpc": false,
 			"source": "B3",
 			"page": 303,
 			"foundIn": [
@@ -51350,7 +51082,6 @@
 		},
 		{
 			"name": "Sumbreiva",
-			"isNpc": false,
 			"source": "B3",
 			"page": 260,
 			"level": 16,
@@ -51584,7 +51315,6 @@
 		},
 		{
 			"name": "Swordkeeper",
-			"isNpc": false,
 			"source": "B3",
 			"page": 261,
 			"level": 10,
@@ -51789,7 +51519,6 @@
 		},
 		{
 			"name": "Tattoo Guardian",
-			"isNpc": false,
 			"source": "B3",
 			"page": 262,
 			"level": 3,
@@ -51922,7 +51651,6 @@
 		},
 		{
 			"name": "Terra-cotta Garrison",
-			"isNpc": false,
 			"source": "B3",
 			"page": 263,
 			"level": 13,
@@ -52072,7 +51800,6 @@
 		},
 		{
 			"name": "Terra-cotta Soldier",
-			"isNpc": false,
 			"source": "B3",
 			"page": 263,
 			"level": 6,
@@ -52211,7 +51938,6 @@
 		},
 		{
 			"name": "Terror Bird",
-			"isNpc": false,
 			"source": "B3",
 			"page": 264,
 			"level": 2,
@@ -52328,7 +52054,6 @@
 		},
 		{
 			"name": "Terror Shrike",
-			"isNpc": false,
 			"source": "B3",
 			"page": 264,
 			"level": 4,
@@ -52481,7 +52206,6 @@
 		},
 		{
 			"name": "Thanatotic Titan",
-			"isNpc": false,
 			"source": "B3",
 			"page": 269,
 			"level": 22,
@@ -52811,7 +52535,6 @@
 		},
 		{
 			"name": "Three-toed Sloth",
-			"isNpc": false,
 			"source": "B3",
 			"page": 248,
 			"level": -1,
@@ -52914,7 +52637,6 @@
 		},
 		{
 			"name": "Tiddalik",
-			"isNpc": false,
 			"source": "B3",
 			"page": 265,
 			"level": 7,
@@ -53035,7 +52757,6 @@
 		},
 		{
 			"name": "Tidehawk",
-			"isNpc": false,
 			"source": "B3",
 			"page": 266,
 			"level": 12,
@@ -53258,7 +52979,6 @@
 		},
 		{
 			"name": "Tikbalang",
-			"isNpc": false,
 			"source": "B3",
 			"page": 267,
 			"level": 9,
@@ -53429,7 +53149,6 @@
 		},
 		{
 			"name": "Tolokand",
-			"isNpc": false,
 			"source": "B3",
 			"page": 272,
 			"level": 15,
@@ -53666,7 +53385,6 @@
 		},
 		{
 			"name": "Tomb Giant",
-			"isNpc": false,
 			"source": "B3",
 			"page": 110,
 			"level": 12,
@@ -53880,7 +53598,6 @@
 		},
 		{
 			"name": "Tooth Fairy",
-			"isNpc": false,
 			"source": "B3",
 			"page": 273,
 			"level": -1,
@@ -54028,7 +53745,6 @@
 		},
 		{
 			"name": "Tooth Fairy Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 273,
 			"level": 3,
@@ -54150,7 +53866,6 @@
 		},
 		{
 			"name": "Toshigami",
-			"isNpc": false,
 			"source": "B3",
 			"page": 145,
 			"level": 15,
@@ -54394,7 +54109,6 @@
 		},
 		{
 			"name": "Trailgaunt",
-			"isNpc": false,
 			"source": "B3",
 			"page": 274,
 			"level": 3,
@@ -54536,7 +54250,6 @@
 		},
 		{
 			"name": "Trilobite",
-			"isNpc": false,
 			"source": "B3",
 			"page": 275,
 			"level": -1,
@@ -54647,7 +54360,6 @@
 		},
 		{
 			"name": "Trilobite Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 275,
 			"level": 3,
@@ -54747,7 +54459,6 @@
 		},
 		{
 			"name": "Triumph Siktempora",
-			"isNpc": false,
 			"source": "B3",
 			"page": 233,
 			"level": 14,
@@ -54965,7 +54676,6 @@
 		},
 		{
 			"name": "Tupilaq",
-			"isNpc": false,
 			"source": "B3",
 			"page": 278,
 			"level": 7,
@@ -55094,7 +54804,6 @@
 		},
 		{
 			"name": "Tylosaurus",
-			"isNpc": false,
 			"source": "B3",
 			"page": 178,
 			"level": 8,
@@ -55233,7 +54942,6 @@
 		},
 		{
 			"name": "Tyrannosaurus Skeleton",
-			"isNpc": false,
 			"source": "B3",
 			"page": 236,
 			"foundIn": [
@@ -55393,7 +55101,6 @@
 		},
 		{
 			"name": "Tzitzimitl",
-			"isNpc": false,
 			"source": "B3",
 			"page": 279,
 			"level": 19,
@@ -55659,7 +55366,6 @@
 		},
 		{
 			"name": "Umasi",
-			"isNpc": false,
 			"source": "B3",
 			"page": 280,
 			"level": 6,
@@ -55850,7 +55556,6 @@
 		},
 		{
 			"name": "Valkyrie",
-			"isNpc": false,
 			"source": "B3",
 			"page": 281,
 			"level": 12,
@@ -56095,7 +55800,6 @@
 		},
 		{
 			"name": "Vanara Disciple",
-			"isNpc": false,
 			"source": "B3",
 			"page": 286,
 			"level": 1,
@@ -56281,7 +55985,6 @@
 		},
 		{
 			"name": "Vilderavn",
-			"isNpc": false,
 			"source": "B3",
 			"page": 287,
 			"level": 16,
@@ -56553,7 +56256,6 @@
 		},
 		{
 			"name": "Vine Leshy",
-			"isNpc": false,
 			"source": "B3",
 			"page": 160,
 			"level": 0,
@@ -56723,7 +56425,6 @@
 		},
 		{
 			"name": "Viper Swarm",
-			"isNpc": false,
 			"source": "B3",
 			"page": 249,
 			"level": 4,
@@ -56858,7 +56559,6 @@
 		},
 		{
 			"name": "Vishkanya Infiltrator",
-			"isNpc": false,
 			"source": "B3",
 			"foundIn": [
 				"Jalmeray"
@@ -57054,7 +56754,6 @@
 		},
 		{
 			"name": "Vulpinal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 11,
 			"level": 6,
@@ -57270,7 +56969,6 @@
 		},
 		{
 			"name": "Water Wisp",
-			"isNpc": false,
 			"source": "B3",
 			"page": 91,
 			"level": 0,
@@ -57428,7 +57126,6 @@
 		},
 		{
 			"name": "Wayang Whisperblade",
-			"isNpc": false,
 			"source": "B3",
 			"page": 290,
 			"level": 1,
@@ -57562,7 +57259,6 @@
 		},
 		{
 			"name": "Weasel",
-			"isNpc": false,
 			"source": "B3",
 			"page": 291,
 			"level": -1,
@@ -57675,7 +57371,6 @@
 		},
 		{
 			"name": "Werebat",
-			"isNpc": false,
 			"source": "B3",
 			"page": 293,
 			"level": 2,
@@ -57904,7 +57599,6 @@
 		},
 		{
 			"name": "Werecrocodile",
-			"isNpc": false,
 			"source": "B3",
 			"page": 293,
 			"level": 2,
@@ -58124,7 +57818,6 @@
 		},
 		{
 			"name": "Wihsaak",
-			"isNpc": false,
 			"source": "B3",
 			"page": 220,
 			"level": 6,
@@ -58333,7 +58026,6 @@
 		},
 		{
 			"name": "Winter Hag",
-			"isNpc": false,
 			"source": "B3",
 			"page": 129,
 			"level": 7,
@@ -58551,7 +58243,6 @@
 		},
 		{
 			"name": "Wizard Sponge",
-			"isNpc": false,
 			"source": "B3",
 			"page": 294,
 			"level": 5,
@@ -58684,7 +58375,6 @@
 		},
 		{
 			"name": "Wolliped",
-			"isNpc": false,
 			"source": "B3",
 			"page": 295,
 			"level": 3,
@@ -58821,7 +58511,6 @@
 		},
 		{
 			"name": "Wyrmwraith",
-			"isNpc": false,
 			"source": "B3",
 			"page": 296,
 			"level": 17,
@@ -59146,7 +58835,6 @@
 		},
 		{
 			"name": "Wyrwood Sneak",
-			"isNpc": false,
 			"source": "B3",
 			"page": 298,
 			"level": 1,
@@ -59276,7 +58964,6 @@
 		},
 		{
 			"name": "Ximtal",
-			"isNpc": false,
 			"source": "B3",
 			"page": 222,
 			"level": 17,
@@ -59556,7 +59243,6 @@
 		},
 		{
 			"name": "Xiuh Couatl",
-			"isNpc": false,
 			"source": "B3",
 			"page": 57,
 			"level": 12,
@@ -59879,7 +59565,6 @@
 		},
 		{
 			"name": "Yithian",
-			"isNpc": false,
 			"source": "B3",
 			"page": 299,
 			"level": 9,
@@ -60057,7 +59742,6 @@
 		},
 		{
 			"name": "Young Forest Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 74,
 			"level": 10,
@@ -60351,7 +60035,6 @@
 		},
 		{
 			"name": "Young Sea Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 77,
 			"level": 8,
@@ -60648,7 +60331,6 @@
 		},
 		{
 			"name": "Young Sky Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 79,
 			"level": 9,
@@ -60986,7 +60668,6 @@
 		},
 		{
 			"name": "Young Sovereign Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 81,
 			"level": 11,
@@ -61266,7 +60947,6 @@
 		},
 		{
 			"name": "Young Underworld Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 83,
 			"level": 7,
@@ -61522,7 +61202,6 @@
 		},
 		{
 			"name": "Yzobu",
-			"isNpc": false,
 			"source": "B3",
 			"page": 300,
 			"level": 1,
@@ -61628,7 +61307,6 @@
 		},
 		{
 			"name": "Zetogeki",
-			"isNpc": false,
 			"source": "B3",
 			"page": 301,
 			"level": 7,
@@ -61752,7 +61430,6 @@
 		},
 		{
 			"name": "Zombie Dragon",
-			"isNpc": false,
 			"source": "B3",
 			"page": 303,
 			"foundIn": [
@@ -61899,7 +61576,6 @@
 		},
 		{
 			"name": "Zuishin",
-			"isNpc": false,
 			"source": "B3",
 			"page": 144,
 			"level": 10,

--- a/data/bestiary/creatures-ec1.json
+++ b/data/bestiary/creatures-ec1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Abberton Ruffians",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 9,
 			"level": -1,
@@ -133,7 +132,6 @@
 		},
 		{
 			"name": "Abrikandilu",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 81,
 			"level": 4,
@@ -306,7 +304,6 @@
 		},
 		{
 			"name": "Blood Wolf",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 43,
 			"level": 3,
@@ -441,7 +438,6 @@
 		},
 		{
 			"name": "Bone Croupier",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 80,
 			"level": 5,
@@ -635,7 +631,6 @@
 		},
 		{
 			"name": "Cavnakash",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 89,
 			"level": 5,
@@ -882,7 +877,6 @@
 		},
 		{
 			"name": "Corrosive Lizard",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 45,
 			"level": 2,
@@ -1018,7 +1012,6 @@
 		},
 		{
 			"name": "Corrupted Priest",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 39,
 			"level": 3,
@@ -1195,7 +1188,6 @@
 		},
 		{
 			"name": "Corrupted Retainer",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 35,
 			"level": 2,
@@ -1333,7 +1325,6 @@
 		},
 		{
 			"name": "Daring Danika",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 28,
 			"level": 2,
@@ -1454,7 +1445,6 @@
 		},
 		{
 			"name": "Flea Swarm",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 83,
 			"level": 5,
@@ -1570,7 +1560,6 @@
 		},
 		{
 			"name": "Giant Flea",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 83,
 			"level": 3,
@@ -1676,7 +1665,6 @@
 		},
 		{
 			"name": "Jaleen And Rhovo",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 9,
 			"level": 1,
@@ -1802,7 +1790,6 @@
 		},
 		{
 			"name": "Jellico Bounce-bounce",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 28,
 			"level": 2,
@@ -1966,7 +1953,6 @@
 		},
 		{
 			"name": "Juvenile Boar",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 20,
 			"level": 0,
@@ -2072,7 +2058,6 @@
 		},
 		{
 			"name": "Luminous Ooze",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 85,
 			"level": 4,
@@ -2206,7 +2191,6 @@
 		},
 		{
 			"name": "Mechanical Carny",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 86,
 			"level": 2,
@@ -2328,7 +2312,6 @@
 		},
 		{
 			"name": "Nemmia Bramblecloak",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 91,
 			"level": 3,
@@ -2567,7 +2550,6 @@
 		},
 		{
 			"name": "Oil Living Graffiti",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 84,
 			"level": 3,
@@ -2695,7 +2677,6 @@
 		},
 		{
 			"name": "Pinacosaurus",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 50,
 			"level": 4,
@@ -2803,7 +2784,6 @@
 		},
 		{
 			"name": "Pruana Two-punch",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 22,
 			"level": 3,
@@ -2928,7 +2908,6 @@
 		},
 		{
 			"name": "Smiler",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 38,
 			"level": 3,
@@ -3154,7 +3133,6 @@
 		},
 		{
 			"name": "Smoldering Leopard",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 44,
 			"level": 3,
@@ -3318,7 +3296,6 @@
 		},
 		{
 			"name": "Vermlek",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 82,
 			"level": 3,
@@ -3520,7 +3497,6 @@
 		},
 		{
 			"name": "Viktor Volkano",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 29,
 			"level": 2,
@@ -3645,7 +3621,6 @@
 		},
 		{
 			"name": "Violet",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 22,
 			"level": 1,
@@ -3771,7 +3746,6 @@
 		},
 		{
 			"name": "Xulgath Bilebearer",
-			"isNpc": false,
 			"source": "EC1",
 			"page": 87,
 			"level": 2,

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aives The Smoke Dragon",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 16,
 			"level": 4,
@@ -179,7 +178,6 @@
 		},
 		{
 			"name": "Andera Paldreen",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 87,
 			"level": 10,
@@ -343,7 +341,6 @@
 		},
 		{
 			"name": "Bogey",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 78,
 			"level": 3,
@@ -490,7 +487,6 @@
 		},
 		{
 			"name": "Bogeyman",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 79,
 			"level": 10,
@@ -741,7 +737,6 @@
 		},
 		{
 			"name": "Bugaboo",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 78,
 			"level": 6,
@@ -950,7 +945,6 @@
 		},
 		{
 			"name": "Celestial Menagerie Bruiser",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 47,
 			"level": 8,
@@ -1095,7 +1089,6 @@
 		},
 		{
 			"name": "Chimpanzee Visitant",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 83,
 			"level": 3,
@@ -1220,7 +1213,6 @@
 		},
 		{
 			"name": "Darricus Stallit",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 57,
 			"level": 8,
@@ -1376,7 +1368,6 @@
 		},
 		{
 			"name": "Delamar Gianvin",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 16,
 			"level": 6,
@@ -1535,7 +1526,6 @@
 		},
 		{
 			"name": "Evora Yarket",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 52,
 			"level": 7,
@@ -1688,7 +1678,6 @@
 		},
 		{
 			"name": "Gluttondark Babau",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 23,
 			"level": 7,
@@ -1937,7 +1926,6 @@
 		},
 		{
 			"name": "Iridescent Elephant",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 80,
 			"level": 7,
@@ -2096,7 +2084,6 @@
 		},
 		{
 			"name": "Lion Visitant",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 83,
 			"level": 5,
@@ -2245,7 +2232,6 @@
 		},
 		{
 			"name": "Mistress Dusklight",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 89,
 			"level": 11,
@@ -2587,7 +2573,6 @@
 		},
 		{
 			"name": "Muse Phantom",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 81,
 			"level": 5,
@@ -2807,7 +2792,6 @@
 		},
 		{
 			"name": "Ruanna Nyamma",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 17,
 			"level": 4,
@@ -2995,7 +2979,6 @@
 		},
 		{
 			"name": "Ulthadar",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 91,
 			"level": 8,
@@ -3155,7 +3138,6 @@
 		},
 		{
 			"name": "Xulgath Spinesnapper",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 84,
 			"level": 5,
@@ -3319,7 +3301,6 @@
 		},
 		{
 			"name": "Yaashka",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 26,
 			"level": 5,
@@ -3546,7 +3527,6 @@
 		},
 		{
 			"name": "Zuipnyrn",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 85,
 			"level": 3,
@@ -3694,7 +3674,6 @@
 		},
 		{
 			"name": "Zunkri",
-			"isNpc": false,
 			"source": "EC2",
 			"page": 27,
 			"level": 7,

--- a/data/bestiary/creatures-ec3.json
+++ b/data/bestiary/creatures-ec3.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Bitter Truth Bandit",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 17,
 			"level": 6,
@@ -154,7 +153,6 @@
 		},
 		{
 			"name": "Bugul Noz",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 76,
 			"level": 12,
@@ -384,7 +382,6 @@
 		},
 		{
 			"name": "Cat Sith",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 77,
 			"level": 6,
@@ -560,7 +557,6 @@
 		},
 		{
 			"name": "Counteflora",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 78,
 			"level": 10,
@@ -726,7 +722,6 @@
 		},
 		{
 			"name": "Cu Sith",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 79,
 			"level": 7,
@@ -865,7 +860,6 @@
 		},
 		{
 			"name": "Ginjana Mindkeeper",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 87,
 			"level": 11,
@@ -1115,7 +1109,6 @@
 		},
 		{
 			"name": "Headless Xulgath",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 50,
 			"level": 11,
@@ -1256,7 +1249,6 @@
 		},
 		{
 			"name": "Herecite Of Zevgavizeb",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 80,
 			"level": 10,
@@ -1510,7 +1502,6 @@
 		},
 		{
 			"name": "Hooklimb Xulgath",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 55,
 			"level": 10,
@@ -1667,7 +1658,6 @@
 		},
 		{
 			"name": "Pin Tingwheely",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 20,
 			"level": 8,
@@ -1895,7 +1885,6 @@
 		},
 		{
 			"name": "Resin-seep Xulgath",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 51,
 			"level": 10,
@@ -2075,7 +2064,6 @@
 		},
 		{
 			"name": "Shoony Hierarch",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 83,
 			"level": 4,
@@ -2202,7 +2190,6 @@
 		},
 		{
 			"name": "Shoony Militia Member",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 83,
 			"level": 2,
@@ -2316,7 +2303,6 @@
 		},
 		{
 			"name": "Shoony Tiller",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 82,
 			"level": 0,
@@ -2438,7 +2424,6 @@
 		},
 		{
 			"name": "Skarja",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 88,
 			"level": 13,
@@ -2770,7 +2755,6 @@
 		},
 		{
 			"name": "Swardlands Delinquent",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 15,
 			"level": 4,
@@ -2911,7 +2895,6 @@
 		},
 		{
 			"name": "Tanessa Fleer",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 16,
 			"level": 9,
@@ -3085,7 +3068,6 @@
 		},
 		{
 			"name": "Thessekka",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 91,
 			"level": 14,
@@ -3336,7 +3318,6 @@
 		},
 		{
 			"name": "Xulgath Bomber",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 28,
 			"level": 7,
@@ -3553,7 +3534,6 @@
 		},
 		{
 			"name": "Xulgath Skirmisher",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 27,
 			"level": 6,
@@ -3727,7 +3707,6 @@
 		},
 		{
 			"name": "Xulgath Stoneliege",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 84,
 			"level": 8,
@@ -3939,7 +3918,6 @@
 		},
 		{
 			"name": "Yaganty",
-			"isNpc": false,
 			"source": "EC3",
 			"page": 85,
 			"level": 10,

--- a/data/bestiary/creatures-ec4.json
+++ b/data/bestiary/creatures-ec4.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Arskuva The Gnasher",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 55,
 			"level": 12,
@@ -123,7 +122,6 @@
 		},
 		{
 			"name": "Aukashungi Swarm",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 50,
 			"level": 10,
@@ -226,7 +224,6 @@
 		},
 		{
 			"name": "Brughadatch",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 78,
 			"level": 10,
@@ -427,7 +424,6 @@
 		},
 		{
 			"name": "Doblagub",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 79,
 			"level": 13,
@@ -675,7 +671,6 @@
 		},
 		{
 			"name": "Faceless Butcher",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 80,
 			"level": 11,
@@ -863,7 +858,6 @@
 		},
 		{
 			"name": "Gahlepod",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 78,
 			"level": 7,
@@ -972,7 +966,6 @@
 		},
 		{
 			"name": "Giant Aukashungi",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 77,
 			"level": 14,
@@ -1148,7 +1141,6 @@
 		},
 		{
 			"name": "Harrow Doll",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 81,
 			"level": 8,
@@ -1330,7 +1322,6 @@
 		},
 		{
 			"name": "Helg Eats-the-eaters",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 87,
 			"level": 15,
@@ -1709,7 +1700,6 @@
 		},
 		{
 			"name": "Ledorick Banyan",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 89,
 			"level": 14,
@@ -1918,7 +1908,6 @@
 		},
 		{
 			"name": "Lyrt Cozurn",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 40,
 			"level": 15,
@@ -2147,7 +2136,6 @@
 		},
 		{
 			"name": "Qurashith",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 82,
 			"level": 17,
@@ -2391,7 +2379,6 @@
 		},
 		{
 			"name": "Sodden Sentinels",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 32,
 			"level": 11,
@@ -2524,7 +2511,6 @@
 		},
 		{
 			"name": "Starved Staff",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 16,
 			"level": 14,
@@ -2685,7 +2671,6 @@
 		},
 		{
 			"name": "Stirvyn Banyan",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 39,
 			"level": 12,
@@ -2984,7 +2969,6 @@
 		},
 		{
 			"name": "Tallow Ooze",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 83,
 			"level": 11,
@@ -3131,7 +3115,6 @@
 		},
 		{
 			"name": "Tashlock Banyan",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 39,
 			"level": 12,
@@ -3324,7 +3307,6 @@
 		},
 		{
 			"name": "The Vanish Man",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 47,
 			"level": 16,
@@ -3568,7 +3550,6 @@
 		},
 		{
 			"name": "War Sauropelta",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 46,
 			"level": 12,
@@ -3711,7 +3692,6 @@
 		},
 		{
 			"name": "Wight Cultist",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 34,
 			"level": 12,
@@ -3912,7 +3892,6 @@
 		},
 		{
 			"name": "Xilvirek",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 84,
 			"level": 12,
@@ -4161,7 +4140,6 @@
 		},
 		{
 			"name": "Xulgath Gutrager",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 85,
 			"level": 10,
@@ -4329,7 +4307,6 @@
 		},
 		{
 			"name": "Xulgath Hardscale",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 53,
 			"level": 12,
@@ -4539,7 +4516,6 @@
 		},
 		{
 			"name": "Xulgath Herd-tender",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 10,
 			"level": 8,
@@ -4744,7 +4720,6 @@
 		},
 		{
 			"name": "Xulgath Roughrider",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 23,
 			"level": 11,
@@ -4926,7 +4901,6 @@
 		},
 		{
 			"name": "Zashathal Head-taker",
-			"isNpc": false,
 			"source": "EC4",
 			"page": 90,
 			"level": 15,

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Ammut",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 77,
 			"level": 18,
@@ -250,7 +249,6 @@
 		},
 		{
 			"name": "Ararda",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 79,
 			"level": 18,
@@ -548,7 +546,6 @@
 		},
 		{
 			"name": "Death Drider",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 35,
 			"level": 13,
@@ -711,7 +708,6 @@
 		},
 		{
 			"name": "Dyzallin Shraen",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 86,
 			"level": 19,
@@ -1204,7 +1200,6 @@
 		},
 		{
 			"name": "Hollow Hush",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 39,
 			"level": 18,
@@ -1427,7 +1422,6 @@
 		},
 		{
 			"name": "Iffdahsil",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 81,
 			"level": 21,
@@ -1668,7 +1662,6 @@
 		},
 		{
 			"name": "Kharostan",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 88,
 			"level": 16,
@@ -1969,7 +1962,6 @@
 		},
 		{
 			"name": "Muurfeli",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 78,
 			"level": 16,
@@ -2231,7 +2223,6 @@
 		},
 		{
 			"name": "Obsidian Golem",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 80,
 			"level": 16,
@@ -2399,7 +2390,6 @@
 		},
 		{
 			"name": "Qormintur",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 91,
 			"level": 16,
@@ -2669,7 +2659,6 @@
 		},
 		{
 			"name": "Raptor Guard Wight",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 32,
 			"level": 13,
@@ -2895,7 +2884,6 @@
 		},
 		{
 			"name": "Shraen Graveknight",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 52,
 			"level": 15,
@@ -3175,7 +3163,6 @@
 		},
 		{
 			"name": "Urdefhan Dominator",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 83,
 			"level": 14,
@@ -3458,7 +3445,6 @@
 		},
 		{
 			"name": "Urdefhan High Tormentor",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 82,
 			"level": 10,
@@ -3723,7 +3709,6 @@
 		},
 		{
 			"name": "Urdefhan Hunter",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 82,
 			"level": 12,
@@ -3948,7 +3933,6 @@
 		},
 		{
 			"name": "Vitalia",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 84,
 			"level": 18,
@@ -4162,7 +4146,6 @@
 		},
 		{
 			"name": "Xulgath Deepmouth",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 85,
 			"level": 12,
@@ -4427,7 +4410,6 @@
 		},
 		{
 			"name": "Zinogyvaz",
-			"isNpc": false,
 			"source": "EC5",
 			"page": 35,
 			"level": 16,

--- a/data/bestiary/creatures-ec6.json
+++ b/data/bestiary/creatures-ec6.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Barking Stag",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 40,
 			"level": 13,
@@ -141,7 +140,6 @@
 		},
 		{
 			"name": "Convergent Giant Eagle",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 12,
 			"level": 15,
@@ -255,7 +253,6 @@
 		},
 		{
 			"name": "Convergent Kendley Nathrael",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 87,
 			"level": 19,
@@ -653,7 +650,6 @@
 		},
 		{
 			"name": "Convergent Soldier",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 14,
 			"level": 16,
@@ -825,7 +821,6 @@
 		},
 		{
 			"name": "Elysian Sheep",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 32,
 			"level": 7,
@@ -954,7 +949,6 @@
 		},
 		{
 			"name": "Elysian Titan",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 82,
 			"level": 21,
@@ -1220,7 +1214,6 @@
 		},
 		{
 			"name": "Kimilekki",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 17,
 			"level": 17,
@@ -1531,7 +1524,6 @@
 		},
 		{
 			"name": "Kirosthrek",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 89,
 			"level": 20,
@@ -1944,7 +1936,6 @@
 		},
 		{
 			"name": "Sarvel Ever-hunger",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 90,
 			"level": 22,
@@ -2254,7 +2245,6 @@
 		},
 		{
 			"name": "Saurian Warmonger",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 80,
 			"level": 16,
@@ -2492,7 +2482,6 @@
 		},
 		{
 			"name": "Saurian Worldwatcher",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 81,
 			"level": 18,
@@ -2785,7 +2774,6 @@
 		},
 		{
 			"name": "Thanatotic Titan",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 83,
 			"level": 22,
@@ -3123,7 +3111,6 @@
 		},
 		{
 			"name": "Vavakia",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 79,
 			"level": 18,
@@ -3448,7 +3435,6 @@
 		},
 		{
 			"name": "Viskithrel",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 84,
 			"level": 15,
@@ -3634,7 +3620,6 @@
 		},
 		{
 			"name": "Xulgath Thoughtmaw",
-			"isNpc": false,
 			"source": "EC6",
 			"page": 85,
 			"level": 15,

--- a/data/bestiary/creatures-fop.json
+++ b/data/bestiary/creatures-fop.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Bee Swarm",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 11,
 			"level": 1,
@@ -92,7 +91,6 @@
 		},
 		{
 			"name": "Blood Ooze",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 63,
 			"level": 4,
@@ -227,7 +225,6 @@
 		},
 		{
 			"name": "Bloodlash Bush",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 62,
 			"level": 2,
@@ -346,7 +343,6 @@
 		},
 		{
 			"name": "Caustic Wolf",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 5,
 			"level": 2,
@@ -459,7 +455,6 @@
 		},
 		{
 			"name": "Drunken Farmer",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 8,
 			"level": -1,
@@ -565,7 +560,6 @@
 		},
 		{
 			"name": "Fiery Leopard",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 31,
 			"level": 1,
@@ -680,7 +674,6 @@
 		},
 		{
 			"name": "Giant Lightning Serpent",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 20,
 			"level": 2,
@@ -817,7 +810,6 @@
 		},
 		{
 			"name": "Graytusk",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 40,
 			"level": 3,
@@ -965,7 +957,6 @@
 		},
 		{
 			"name": "Hallod",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 21,
 			"level": 3,
@@ -1129,7 +1120,6 @@
 		},
 		{
 			"name": "Icy Rats",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 31,
 			"level": 0,
@@ -1229,7 +1219,6 @@
 		},
 		{
 			"name": "Lord Nar",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 38,
 			"level": 4,
@@ -1392,7 +1381,6 @@
 		},
 		{
 			"name": "Mangy Wolves",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 5,
 			"level": -1,
@@ -1484,7 +1472,6 @@
 		},
 		{
 			"name": "Mutant Wolves",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 27,
 			"level": 3,
@@ -1591,7 +1578,6 @@
 		},
 		{
 			"name": "Stone Horse",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 30,
 			"level": 2,
@@ -1678,7 +1664,6 @@
 		},
 		{
 			"name": "The Amalgam",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 44,
 			"level": 4,
@@ -1820,7 +1805,6 @@
 		},
 		{
 			"name": "The Behemoth",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 47,
 			"level": 3,
@@ -1956,7 +1940,6 @@
 		},
 		{
 			"name": "The Sculptor",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 34,
 			"level": 4,
@@ -2122,7 +2105,6 @@
 		},
 		{
 			"name": "Vilree",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 47,
 			"level": 5,
@@ -2305,7 +2287,6 @@
 		},
 		{
 			"name": "Vine Lasher",
-			"isNpc": false,
 			"source": "FoP",
 			"page": 62,
 			"level": 0,

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Agile Warrior",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 23,
 			"level": 13,
@@ -163,7 +162,6 @@
 		},
 		{
 			"name": "Anugobu Apprentice",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 80,
 			"level": 3,
@@ -371,7 +369,6 @@
 		},
 		{
 			"name": "Anugobu Wondercrafter",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 81,
 			"level": 7,
@@ -602,7 +599,6 @@
 		},
 		{
 			"name": "Archery Specialist",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 24,
 			"level": 13,
@@ -750,7 +746,6 @@
 		},
 		{
 			"name": "Berberoka",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 82,
 			"level": 15,
@@ -940,7 +935,6 @@
 		},
 		{
 			"name": "Blue Viper",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 63,
 			"level": 14,
@@ -1125,7 +1119,6 @@
 		},
 		{
 			"name": "Butterfly Blade Warrior",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 60,
 			"level": 13,
@@ -1287,7 +1280,6 @@
 		},
 		{
 			"name": "Caustic Monitor",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 86,
 			"level": 13,
@@ -1459,7 +1451,6 @@
 		},
 		{
 			"name": "Dread Roc",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 30,
 			"level": 15,
@@ -1632,7 +1623,6 @@
 		},
 		{
 			"name": "Dromornis",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 83,
 			"level": 10,
@@ -1779,7 +1769,6 @@
 		},
 		{
 			"name": "Elder Cauthooj",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 49,
 			"level": 14,
@@ -1936,7 +1925,6 @@
 		},
 		{
 			"name": "Ghost Monk",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 15,
 			"level": 9,
@@ -2124,7 +2112,6 @@
 		},
 		{
 			"name": "Gomwai",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 48,
 			"level": 12,
@@ -2270,7 +2257,6 @@
 		},
 		{
 			"name": "Grave Spinosaurus",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 32,
 			"level": 15,
@@ -2433,7 +2419,6 @@
 		},
 		{
 			"name": "Hana's Hundreds",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 51,
 			"level": 15,
@@ -2581,7 +2566,6 @@
 		},
 		{
 			"name": "Hantu Belian",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 85,
 			"level": 11,
@@ -2788,7 +2772,6 @@
 		},
 		{
 			"name": "Hantu Denai",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 84,
 			"level": 9,
@@ -2966,7 +2949,6 @@
 		},
 		{
 			"name": "Jaiban",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 41,
 			"level": 15,
@@ -3134,7 +3116,6 @@
 		},
 		{
 			"name": "Kannitri",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 19,
 			"level": 13,
@@ -3314,7 +3295,6 @@
 		},
 		{
 			"name": "Ki Adept",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 24,
 			"level": 13,
@@ -3505,7 +3485,6 @@
 		},
 		{
 			"name": "Koto Zekora",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 55,
 			"level": 17,
@@ -3890,7 +3869,6 @@
 		},
 		{
 			"name": "Mage Of Many Styles",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 25,
 			"level": 13,
@@ -4123,7 +4101,6 @@
 		},
 		{
 			"name": "Mammoth Turtle",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 31,
 			"level": 14,
@@ -4253,7 +4230,6 @@
 		},
 		{
 			"name": "Manananggal",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 87,
 			"level": 8,
@@ -4435,7 +4411,6 @@
 		},
 		{
 			"name": "Muckish Creep",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 88,
 			"level": 8,
@@ -4605,7 +4580,6 @@
 		},
 		{
 			"name": "Nai Yan Fei",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 91,
 			"level": 20,
@@ -4813,7 +4787,6 @@
 		},
 		{
 			"name": "Old Man Statue",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 21,
 			"level": 14,
@@ -5006,7 +4979,6 @@
 		},
 		{
 			"name": "Planar Terra-cotta Soldier",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 52,
 			"level": 11,
@@ -5155,7 +5127,6 @@
 		},
 		{
 			"name": "Planar Terra-cotta Squadron",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 53,
 			"level": 15,
@@ -5288,7 +5259,6 @@
 		},
 		{
 			"name": "Ran-to",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 64,
 			"level": 14,
@@ -5492,7 +5462,6 @@
 		},
 		{
 			"name": "Shino Hakusa",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 63,
 			"level": 14,
@@ -5674,7 +5643,6 @@
 		},
 		{
 			"name": "Sigbin",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 89,
 			"level": 5,
@@ -5828,7 +5796,6 @@
 		},
 		{
 			"name": "Syu Tak-nwa",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 63,
 			"level": 14,
@@ -6134,7 +6101,6 @@
 		},
 		{
 			"name": "Takatorra",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 11,
 			"level": 9,
@@ -6326,7 +6292,6 @@
 		},
 		{
 			"name": "Tamikan",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 39,
 			"level": 16,
@@ -6536,7 +6501,6 @@
 		},
 		{
 			"name": "Tino",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 10,
 			"level": 9,
@@ -6694,7 +6658,6 @@
 		},
 		{
 			"name": "Tyrannosaurus Imperator",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 31,
 			"level": 14,
@@ -6865,7 +6828,6 @@
 		},
 		{
 			"name": "Watchtower Poltergeist",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 35,
 			"level": 14,
@@ -7068,7 +7030,6 @@
 		},
 		{
 			"name": "Watchtower Shadow",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 36,
 			"level": 15,
@@ -7246,7 +7207,6 @@
 		},
 		{
 			"name": "Watchtower Wraith",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 36,
 			"level": 16,
@@ -7447,7 +7407,6 @@
 		},
 		{
 			"name": "Weapon Master",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 23,
 			"level": 13,
@@ -7598,7 +7557,6 @@
 		},
 		{
 			"name": "Yabin The Just",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 11,
 			"level": 9,
@@ -7873,7 +7831,6 @@
 		},
 		{
 			"name": "Yook",
-			"isNpc": false,
 			"source": "FRP1",
 			"page": 11,
 			"level": 9,

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Akila Stormheel",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 38,
 			"level": 13,
@@ -174,7 +173,6 @@
 		},
 		{
 			"name": "Amihan",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 40,
 			"level": 15,
@@ -365,7 +363,6 @@
 		},
 		{
 			"name": "Angoyang",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 78,
 			"level": 14,
@@ -533,7 +530,6 @@
 		},
 		{
 			"name": "Arm Of Balance",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 33,
 			"level": 15,
@@ -771,7 +767,6 @@
 		},
 		{
 			"name": "Artus Rodrivan",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 35,
 			"level": 15,
@@ -907,7 +902,6 @@
 		},
 		{
 			"name": "Blue Viper",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 36,
 			"level": 16,
@@ -1091,7 +1085,6 @@
 		},
 		{
 			"name": "Drake Courser",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 13,
 			"level": 12,
@@ -1282,7 +1275,6 @@
 		},
 		{
 			"name": "Grandfather Mantis",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 35,
 			"level": 15,
@@ -1433,7 +1425,6 @@
 		},
 		{
 			"name": "Halspin The Stung",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 41,
 			"level": 15,
@@ -1725,7 +1716,6 @@
 		},
 		{
 			"name": "Huldrin Skolsdottir",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 42,
 			"level": 14,
@@ -1898,7 +1888,6 @@
 		},
 		{
 			"name": "Hummingbird",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 39,
 			"level": 13,
@@ -2153,7 +2142,6 @@
 		},
 		{
 			"name": "Ji-yook",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 27,
 			"level": 13,
@@ -2380,7 +2368,6 @@
 		},
 		{
 			"name": "Joon-seo",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 41,
 			"level": 15,
@@ -2623,7 +2610,6 @@
 		},
 		{
 			"name": "Juspix Rammel",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 42,
 			"level": 14,
@@ -2910,7 +2896,6 @@
 		},
 		{
 			"name": "Kas Xi Rai",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 23,
 			"level": 17,
@@ -3101,7 +3086,6 @@
 		},
 		{
 			"name": "Kun",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 79,
 			"level": 14,
@@ -3314,7 +3298,6 @@
 		},
 		{
 			"name": "Lantondo",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 35,
 			"level": 15,
@@ -3566,7 +3549,6 @@
 		},
 		{
 			"name": "Maalya",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 40,
 			"level": 15,
@@ -3757,7 +3739,6 @@
 		},
 		{
 			"name": "Mafika Ayuwari",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 38,
 			"level": 17,
@@ -4083,7 +4064,6 @@
 		},
 		{
 			"name": "Master Xun",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 23,
 			"level": 14,
@@ -4236,7 +4216,6 @@
 		},
 		{
 			"name": "Melodic Squall",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 57,
 			"level": 16,
@@ -4429,7 +4408,6 @@
 		},
 		{
 			"name": "Minister Of Tumult",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 87,
 			"level": 14,
@@ -4624,7 +4602,6 @@
 		},
 		{
 			"name": "Peng",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 82,
 			"level": 12,
@@ -4816,7 +4793,6 @@
 		},
 		{
 			"name": "Phuthi",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 39,
 			"level": 13,
@@ -5071,7 +5047,6 @@
 		},
 		{
 			"name": "Portal Eater",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 56,
 			"level": 18,
@@ -5270,7 +5245,6 @@
 		},
 		{
 			"name": "Provincial Jiang-shi",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 86,
 			"level": 11,
@@ -5477,7 +5451,6 @@
 		},
 		{
 			"name": "Ran-to",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 37,
 			"level": 16,
@@ -5687,7 +5660,6 @@
 		},
 		{
 			"name": "Razu",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 91,
 			"level": 18,
@@ -5994,7 +5966,6 @@
 		},
 		{
 			"name": "Rivka",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 83,
 			"level": 13,
@@ -6140,7 +6111,6 @@
 		},
 		{
 			"name": "Shadow Yai",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 80,
 			"level": 16,
@@ -6426,7 +6396,6 @@
 		},
 		{
 			"name": "Shino Hakusa",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 36,
 			"level": 16,
@@ -6607,7 +6576,6 @@
 		},
 		{
 			"name": "Sixth Pillar Student",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 14,
 			"level": 14,
@@ -6887,7 +6855,6 @@
 		},
 		{
 			"name": "Surjit Hamelan",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 39,
 			"level": 13,
@@ -7070,7 +7037,6 @@
 		},
 		{
 			"name": "Syu Tak-nwa",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 35,
 			"level": 16,
@@ -7375,7 +7341,6 @@
 		},
 		{
 			"name": "Taiga Yai",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 81,
 			"level": 15,
@@ -7659,7 +7624,6 @@
 		},
 		{
 			"name": "Takatorra",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 27,
 			"level": 13,
@@ -7855,7 +7819,6 @@
 		},
 		{
 			"name": "Tino Tung",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 26,
 			"level": 13,
@@ -8037,7 +8000,6 @@
 		},
 		{
 			"name": "Troff Frostknuckles",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 43,
 			"level": 14,
@@ -8211,7 +8173,6 @@
 		},
 		{
 			"name": "Umbasi",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 40,
 			"level": 13,
@@ -8477,7 +8438,6 @@
 		},
 		{
 			"name": "Urnak Lostwind",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 41,
 			"level": 14,
@@ -8639,7 +8599,6 @@
 		},
 		{
 			"name": "Yabin The Just",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 27,
 			"level": 13,
@@ -8975,7 +8934,6 @@
 		},
 		{
 			"name": "Yarrika Mulandez",
-			"isNpc": false,
 			"source": "FRP2",
 			"page": 34,
 			"level": 15,

--- a/data/bestiary/creatures-frp3.json
+++ b/data/bestiary/creatures-frp3.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Abbot Tsujon",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 15,
 			"level": 18,
@@ -293,7 +292,6 @@
 		},
 		{
 			"name": "Blue Viper",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 54,
 			"level": 20,
@@ -528,7 +526,6 @@
 		},
 		{
 			"name": "Bul-gae",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 79,
 			"level": 14,
@@ -708,7 +705,6 @@
 		},
 		{
 			"name": "Canopy Elder",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 78,
 			"level": 19,
@@ -951,7 +947,6 @@
 		},
 		{
 			"name": "Cloudsplitter",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 19,
 			"level": 18,
@@ -1209,7 +1204,6 @@
 		},
 		{
 			"name": "Dancing Night Parade",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 41,
 			"level": 19,
@@ -1403,7 +1397,6 @@
 		},
 		{
 			"name": "Desecrated Guardian",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 80,
 			"level": 18,
@@ -1628,7 +1621,6 @@
 		},
 		{
 			"name": "Flying Mountain Kaminari",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 23,
 			"level": 18,
@@ -1842,7 +1834,6 @@
 		},
 		{
 			"name": "Gumiho",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 81,
 			"level": 17,
@@ -2107,7 +2098,6 @@
 		},
 		{
 			"name": "Inmyeonjo",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 82,
 			"level": 16,
@@ -2351,7 +2341,6 @@
 		},
 		{
 			"name": "Jin-hae",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 18,
 			"level": 18,
@@ -2620,7 +2609,6 @@
 		},
 		{
 			"name": "Laruhao",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 41,
 			"level": 19,
@@ -2774,7 +2762,6 @@
 		},
 		{
 			"name": "Lophiithu",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 83,
 			"level": 21,
@@ -3010,7 +2997,6 @@
 		},
 		{
 			"name": "Orochi",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 84,
 			"level": 18,
@@ -3231,7 +3217,6 @@
 		},
 		{
 			"name": "Rai Sho Disciple",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 14,
 			"level": 16,
@@ -3428,7 +3413,6 @@
 		},
 		{
 			"name": "Rai Sho Postulant",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 13,
 			"level": 16,
@@ -3635,7 +3619,6 @@
 		},
 		{
 			"name": "Ran-to",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 54,
 			"level": 20,
@@ -3864,7 +3847,6 @@
 		},
 		{
 			"name": "Sanzuwu",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 85,
 			"level": 15,
@@ -4081,7 +4063,6 @@
 		},
 		{
 			"name": "Shino Hakusa",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 53,
 			"level": 20,
@@ -4297,7 +4278,6 @@
 		},
 		{
 			"name": "Spinel Leviathan Syndara",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 58,
 			"level": 24,
@@ -4556,7 +4536,6 @@
 		},
 		{
 			"name": "Spirit Turtle",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 86,
 			"level": 21,
@@ -4846,7 +4825,6 @@
 		},
 		{
 			"name": "Sthira",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 87,
 			"level": 20,
@@ -5068,7 +5046,6 @@
 		},
 		{
 			"name": "Syndara The Sculptor",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 88,
 			"level": 22,
@@ -5378,7 +5355,6 @@
 		},
 		{
 			"name": "Syu Tak-nwa",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 52,
 			"level": 20,
@@ -5709,7 +5685,6 @@
 		},
 		{
 			"name": "Yoh Souran",
-			"isNpc": false,
 			"source": "FRP3",
 			"page": 91,
 			"level": 15,

--- a/data/bestiary/creatures-gmg.json
+++ b/data/bestiary/creatures-gmg.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Acolyte Of Nethys",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 212,
 			"level": 1,
@@ -123,7 +122,6 @@
 		},
 		{
 			"name": "Acrobat",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 237,
 			"level": 2,
@@ -296,7 +294,6 @@
 		},
 		{
 			"name": "Adept",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 228,
 			"level": -1,
@@ -441,7 +438,6 @@
 		},
 		{
 			"name": "Advisor",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 208,
 			"level": 5,
@@ -642,7 +638,6 @@
 		},
 		{
 			"name": "Antipaladin",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 247,
 			"level": 5,
@@ -794,7 +789,6 @@
 		},
 		{
 			"name": "Apothecary",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 221,
 			"level": -1,
@@ -908,7 +902,6 @@
 		},
 		{
 			"name": "Apprentice",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 244,
 			"level": -1,
@@ -1022,7 +1015,6 @@
 		},
 		{
 			"name": "Archer Sentry",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 234,
 			"level": 2,
@@ -1143,7 +1135,6 @@
 		},
 		{
 			"name": "Assassin",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 212,
 			"level": 8,
@@ -1334,7 +1325,6 @@
 		},
 		{
 			"name": "Astronomer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 241,
 			"level": 2,
@@ -1442,7 +1432,6 @@
 		},
 		{
 			"name": "Bandit",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 209,
 			"level": 2,
@@ -1599,7 +1588,6 @@
 		},
 		{
 			"name": "Barkeep",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 238,
 			"level": 1,
@@ -1757,7 +1745,6 @@
 		},
 		{
 			"name": "Barrister",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 233,
 			"level": -1,
@@ -1875,7 +1862,6 @@
 		},
 		{
 			"name": "Beast Tamer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 238,
 			"level": 4,
@@ -2057,7 +2043,6 @@
 		},
 		{
 			"name": "Beggar",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 214,
 			"level": -1,
@@ -2169,7 +2154,6 @@
 		},
 		{
 			"name": "Bodyguard",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 226,
 			"level": 1,
@@ -2280,7 +2264,6 @@
 		},
 		{
 			"name": "Bosun",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 243,
 			"level": 3,
@@ -2437,7 +2420,6 @@
 		},
 		{
 			"name": "Bounty Hunter",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 227,
 			"level": 4,
@@ -2578,7 +2560,6 @@
 		},
 		{
 			"name": "Burglar",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 212,
 			"level": 4,
@@ -2745,7 +2726,6 @@
 		},
 		{
 			"name": "Captain Of The Guard",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 236,
 			"level": 6,
@@ -2922,7 +2902,6 @@
 		},
 		{
 			"name": "Charlatan",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 210,
 			"level": 3,
@@ -3143,7 +3122,6 @@
 		},
 		{
 			"name": "Chronicler",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 216,
 			"level": 3,
@@ -3336,7 +3314,6 @@
 		},
 		{
 			"name": "Commoner",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 214,
 			"level": -1,
@@ -3440,7 +3417,6 @@
 		},
 		{
 			"name": "Cult Leader",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 231,
 			"level": 7,
@@ -3683,7 +3659,6 @@
 		},
 		{
 			"name": "Cultist",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 229,
 			"level": 1,
@@ -3813,7 +3788,6 @@
 		},
 		{
 			"name": "Dancer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 237,
 			"level": 1,
@@ -3952,7 +3926,6 @@
 		},
 		{
 			"name": "Demonologist",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 231,
 			"level": 7,
@@ -4166,7 +4139,6 @@
 		},
 		{
 			"name": "Despot",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 249,
 			"level": 5,
@@ -4370,7 +4342,6 @@
 		},
 		{
 			"name": "Dockhand",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": 0,
@@ -4502,7 +4473,6 @@
 		},
 		{
 			"name": "Drunkard",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 239,
 			"level": 2,
@@ -4618,7 +4588,6 @@
 		},
 		{
 			"name": "Executioner",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 236,
 			"level": 6,
@@ -4734,7 +4703,6 @@
 		},
 		{
 			"name": "False Priest",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 229,
 			"level": 4,
@@ -4892,7 +4860,6 @@
 		},
 		{
 			"name": "Farmer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": 0,
@@ -5007,7 +4974,6 @@
 		},
 		{
 			"name": "Fence",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 210,
 			"level": 5,
@@ -5181,7 +5147,6 @@
 		},
 		{
 			"name": "Gang Leader",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 249,
 			"level": 7,
@@ -5365,7 +5330,6 @@
 		},
 		{
 			"name": "Grave Robber",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 209,
 			"level": 1,
@@ -5479,7 +5443,6 @@
 		},
 		{
 			"name": "Gravedigger",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": 1,
@@ -5577,7 +5540,6 @@
 		},
 		{
 			"name": "Guard",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 233,
 			"level": 1,
@@ -5714,7 +5676,6 @@
 		},
 		{
 			"name": "Guide",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 217,
 			"level": 4,
@@ -5844,7 +5805,6 @@
 		},
 		{
 			"name": "Guildmaster",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 245,
 			"level": 8,
@@ -5983,7 +5943,6 @@
 		},
 		{
 			"name": "Harbormaster",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 225,
 			"level": 3,
@@ -6114,7 +6073,6 @@
 		},
 		{
 			"name": "Harrow Reader",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 228,
 			"level": -1,
@@ -6214,7 +6172,6 @@
 		},
 		{
 			"name": "Hunter",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 220,
 			"level": 7,
@@ -6376,7 +6333,6 @@
 		},
 		{
 			"name": "Innkeeper",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 239,
 			"level": 1,
@@ -6509,7 +6465,6 @@
 		},
 		{
 			"name": "Jailer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 234,
 			"level": 3,
@@ -6665,7 +6620,6 @@
 		},
 		{
 			"name": "Judge",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": -1,
@@ -6786,7 +6740,6 @@
 		},
 		{
 			"name": "Librarian",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 240,
 			"level": -1,
@@ -6913,7 +6866,6 @@
 		},
 		{
 			"name": "Mage For Hire",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 226,
 			"level": 3,
@@ -7077,7 +7029,6 @@
 		},
 		{
 			"name": "Mastermind",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 247,
 			"level": 4,
@@ -7314,7 +7265,6 @@
 		},
 		{
 			"name": "Merchant",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 244,
 			"level": -1,
@@ -7433,7 +7383,6 @@
 		},
 		{
 			"name": "Miner",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": 0,
@@ -7539,7 +7488,6 @@
 		},
 		{
 			"name": "Monster Hunter",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 227,
 			"level": 6,
@@ -7685,7 +7633,6 @@
 		},
 		{
 			"name": "Navigator",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 242,
 			"level": 2,
@@ -7815,7 +7762,6 @@
 		},
 		{
 			"name": "Necromancer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 231,
 			"level": 5,
@@ -8022,7 +7968,6 @@
 		},
 		{
 			"name": "Noble",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 207,
 			"level": 3,
@@ -8161,7 +8106,6 @@
 		},
 		{
 			"name": "Palace Guard",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 207,
 			"level": 4,
@@ -8282,7 +8226,6 @@
 		},
 		{
 			"name": "Physician",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 221,
 			"level": -1,
@@ -8403,7 +8346,6 @@
 		},
 		{
 			"name": "Pirate",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 242,
 			"level": 2,
@@ -8558,7 +8500,6 @@
 		},
 		{
 			"name": "Plague Doctor",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 222,
 			"level": 5,
@@ -8758,7 +8699,6 @@
 		},
 		{
 			"name": "Poacher",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 219,
 			"level": 2,
@@ -8893,7 +8833,6 @@
 		},
 		{
 			"name": "Priest Of Pharasma",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 213,
 			"level": 6,
@@ -9098,7 +9037,6 @@
 		},
 		{
 			"name": "Prisoner",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 215,
 			"level": 1,
@@ -9233,7 +9171,6 @@
 		},
 		{
 			"name": "Prophet",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 212,
 			"level": 2,
@@ -9414,7 +9351,6 @@
 		},
 		{
 			"name": "Reckless Scientist",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 249,
 			"level": 6,
@@ -9586,7 +9522,6 @@
 		},
 		{
 			"name": "Ruffian",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 210,
 			"level": 2,
@@ -9735,7 +9670,6 @@
 		},
 		{
 			"name": "Saboteur",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 247,
 			"level": 2,
@@ -9873,7 +9807,6 @@
 		},
 		{
 			"name": "Sage",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 241,
 			"level": 6,
@@ -10012,7 +9945,6 @@
 		},
 		{
 			"name": "Servant",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": -1,
@@ -10115,7 +10047,6 @@
 		},
 		{
 			"name": "Server",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 238,
 			"level": -1,
@@ -10226,7 +10157,6 @@
 		},
 		{
 			"name": "Ship Captain",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 243,
 			"level": 6,
@@ -10396,7 +10326,6 @@
 		},
 		{
 			"name": "Smith",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 245,
 			"level": 3,
@@ -10514,7 +10443,6 @@
 		},
 		{
 			"name": "Spy",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 208,
 			"level": 6,
@@ -10671,7 +10599,6 @@
 		},
 		{
 			"name": "Surgeon",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 222,
 			"level": 2,
@@ -10785,7 +10712,6 @@
 		},
 		{
 			"name": "Tax Collector",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 224,
 			"level": -1,
@@ -10915,7 +10841,6 @@
 		},
 		{
 			"name": "Teacher",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 240,
 			"level": -1,
@@ -11023,7 +10948,6 @@
 		},
 		{
 			"name": "Tomb Raider",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 217,
 			"level": 5,
@@ -11162,7 +11086,6 @@
 		},
 		{
 			"name": "Torchbearer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 216,
 			"level": 0,
@@ -11287,7 +11210,6 @@
 		},
 		{
 			"name": "Tracker",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 220,
 			"level": 3,
@@ -11423,7 +11345,6 @@
 		},
 		{
 			"name": "Troubadour",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 238,
 			"level": 3,
@@ -11610,7 +11531,6 @@
 		},
 		{
 			"name": "Urchin",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 215,
 			"level": -1,
@@ -11742,7 +11662,6 @@
 		},
 		{
 			"name": "Warden",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 225,
 			"level": 6,
@@ -11863,7 +11782,6 @@
 		},
 		{
 			"name": "Watch Officer",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 236,
 			"level": 3,
@@ -12021,7 +11939,6 @@
 		},
 		{
 			"name": "Zealot Of Asmodeus",
-			"isNpc": false,
 			"source": "GMG",
 			"page": 213,
 			"level": 4,

--- a/data/bestiary/creatures-lome.json
+++ b/data/bestiary/creatures-lome.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Aigamuxa",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 293,
 			"level": 8,
@@ -166,7 +165,6 @@
 		},
 		{
 			"name": "Anadi Elder",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 292,
 			"level": 6,
@@ -422,7 +420,6 @@
 		},
 		{
 			"name": "Anadi Hunter",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 291,
 			"level": 2,
@@ -604,7 +601,6 @@
 		},
 		{
 			"name": "Anadi Sage",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 292,
 			"level": 4,
@@ -823,7 +819,6 @@
 		},
 		{
 			"name": "Asanbosam",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 294,
 			"level": 6,
@@ -947,7 +942,6 @@
 		},
 		{
 			"name": "Biloko Veteran",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 296,
 			"level": 4,
@@ -1126,7 +1120,6 @@
 		},
 		{
 			"name": "Biloko Warrior",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 296,
 			"level": 1,
@@ -1288,7 +1281,6 @@
 		},
 		{
 			"name": "Charau-ka Acolyte Of Angazhan",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 298,
 			"level": 3,
@@ -1513,7 +1505,6 @@
 		},
 		{
 			"name": "Charau-ka Butcher",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 298,
 			"level": 6,
@@ -1727,7 +1718,6 @@
 		},
 		{
 			"name": "Charau-ka Warrior",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 229977,
 			"level": 1,
@@ -1924,7 +1914,6 @@
 		},
 		{
 			"name": "Eloko",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 296,
 			"level": 7,
@@ -2117,7 +2106,6 @@
 		},
 		{
 			"name": "Grootslang",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 298,
 			"level": 16,
@@ -2357,7 +2345,6 @@
 		},
 		{
 			"name": "K'nonna",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 300,
 			"level": 8,
@@ -2488,7 +2475,6 @@
 		},
 		{
 			"name": "Kaava Stalker",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 301,
 			"level": 1,
@@ -2630,7 +2616,6 @@
 		},
 		{
 			"name": "Karina",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 302,
 			"level": 5,
@@ -2804,7 +2789,6 @@
 		},
 		{
 			"name": "Maliadi",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 302,
 			"level": 17,
@@ -3074,7 +3058,6 @@
 		},
 		{
 			"name": "Mamlambo",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 304,
 			"level": 9,
@@ -3246,7 +3229,6 @@
 		},
 		{
 			"name": "Pygmy Kaava",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 301,
 			"level": 0,
@@ -3385,7 +3367,6 @@
 		},
 		{
 			"name": "Rompo",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 305,
 			"level": 5,
@@ -3543,7 +3524,6 @@
 		},
 		{
 			"name": "Sié Goluo",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 306,
 			"level": 14,
@@ -3729,7 +3709,6 @@
 		},
 		{
 			"name": "Solar Ibis",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 307,
 			"level": 7,
@@ -3876,7 +3855,6 @@
 		},
 		{
 			"name": "Zinba",
-			"isNpc": false,
 			"source": "LOME",
 			"page": 308,
 			"level": 10,

--- a/data/bestiary/creatures-lomm.json
+++ b/data/bestiary/creatures-lomm.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Ainamuuren",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 9,
 			"level": 14,
@@ -208,7 +207,6 @@
 		},
 		{
 			"name": "Cuetzmonquali",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 16,
 			"level": 17,
@@ -537,7 +535,6 @@
 		},
 		{
 			"name": "Desert's Howl",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 22,
 			"level": 19,
@@ -832,7 +829,6 @@
 		},
 		{
 			"name": "Howling Spawn",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 23,
 			"level": 11,
@@ -1079,7 +1075,6 @@
 		},
 		{
 			"name": "Fafnheir",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 28,
 			"level": 24,
@@ -1423,7 +1418,6 @@
 		},
 		{
 			"name": "Young Linnorm",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 29,
 			"level": 7,
@@ -1611,7 +1605,6 @@
 		},
 		{
 			"name": "Grogrisant",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 34,
 			"level": 16,
@@ -1838,7 +1831,6 @@
 		},
 		{
 			"name": "Grisantian Lion",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 34,
 			"level": 12,
@@ -1998,7 +1990,6 @@
 		},
 		{
 			"name": "Kallas Devil",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 46,
 			"level": 9,
@@ -2359,7 +2350,6 @@
 		},
 		{
 			"name": "Kothogaz, Dance of Disharmony",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 52,
 			"level": 21,
@@ -2652,7 +2642,6 @@
 		},
 		{
 			"name": "Spawn of Kothogaz",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 53,
 			"level": 6,
@@ -2787,7 +2776,6 @@
 		},
 		{
 			"name": "Krampus Celebrant",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 58,
 			"level": 8,
@@ -3015,7 +3003,6 @@
 			"alias": [
 				"The Horned Miser"
 			],
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 59,
 			"level": 21,
@@ -3342,7 +3329,6 @@
 		},
 		{
 			"name": "Kuworsys",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 64,
 			"level": 12,
@@ -3559,7 +3545,6 @@
 		},
 		{
 			"name": "Melfesh Monster",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 70,
 			"level": 6,
@@ -3779,7 +3764,6 @@
 		},
 		{
 			"name": "Mosquito Witch",
-			"isNpc": false,
 			"source": "LOMM",
 			"page": 76,
 			"level": 10,

--- a/data/bestiary/creatures-sli.json
+++ b/data/bestiary/creatures-sli.json
@@ -12,7 +12,6 @@
 	"creature": [
 		{
 			"name": "Ahvothian",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 62,
 			"level": 7,
@@ -245,7 +244,6 @@
 		},
 		{
 			"name": "Angazhani Cultist",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 30,
 			"level": 4,
@@ -438,7 +436,6 @@
 		},
 		{
 			"name": "Aspis Guard",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 44,
 			"level": 5,
@@ -623,7 +620,6 @@
 		},
 		{
 			"name": "Aspis Technician",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 45,
 			"level": 7,
@@ -829,7 +825,6 @@
 		},
 		{
 			"name": "Croakchief Globblit Skink-eater",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 22,
 			"level": 5,
@@ -1002,7 +997,6 @@
 		},
 		{
 			"name": "Cursebreaker",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 38,
 			"level": 9,
@@ -1172,7 +1166,6 @@
 		},
 		{
 			"name": "Fuming Sludge",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 63,
 			"level": 7,
@@ -1336,7 +1329,6 @@
 		},
 		{
 			"name": "Nyamat Mshwe",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 33,
 			"level": 6,
@@ -1583,7 +1575,6 @@
 		},
 		{
 			"name": "Paga Nikohian",
-			"isNpc": false,
 			"source": "Sli",
 			"page": 51,
 			"level": 9,

--- a/data/bestiary/creatures-sot1.json
+++ b/data/bestiary/creatures-sot1.json
@@ -17,7 +17,6 @@
 	"creature": [
 		{
 			"name": "Anadi Fateweaver",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 79,
 			"level": 5,
@@ -296,7 +295,6 @@
 		},
 		{
 			"name": "Anadi Lurker",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 78,
 			"level": 3,
@@ -524,7 +522,6 @@
 		},
 		{
 			"name": "Anadi Seeker",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 78,
 			"level": 1,
@@ -774,7 +771,6 @@
 		},
 		{
 			"name": "Bramble Champion Construct",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 41,
 			"level": 3,
@@ -886,7 +882,6 @@
 		},
 		{
 			"name": "Giant Mining Bee",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 80,
 			"level": 2,
@@ -995,7 +990,6 @@
 		},
 		{
 			"name": "Giant Silverfish",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 84,
 			"level": 0,
@@ -1098,7 +1092,6 @@
 		},
 		{
 			"name": "Giant Tsetse Fly",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 81,
 			"level": 2,
@@ -1238,7 +1231,6 @@
 		},
 		{
 			"name": "Giant Worker Bee",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 80,
 			"level": 0,
@@ -1343,7 +1335,6 @@
 		},
 		{
 			"name": "Gnagrif",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 83,
 			"level": 2,
@@ -1765,7 +1756,6 @@
 		},
 		{
 			"name": "Scrit",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 82,
 			"level": 0,
@@ -1899,7 +1889,6 @@
 		},
 		{
 			"name": "Shieldbearer Construct",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 40,
 			"level": 2,
@@ -2016,7 +2005,6 @@
 		},
 		{
 			"name": "Sicklehand Construct",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 41,
 			"level": 0,
@@ -2132,7 +2120,6 @@
 		},
 		{
 			"name": "Silverfish Swarm",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 84,
 			"level": -1,
@@ -2232,7 +2219,6 @@
 		},
 		{
 			"name": "Spellskein",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 85,
 			"level": 0,
@@ -2777,7 +2763,6 @@
 		},
 		{
 			"name": "Umbo",
-			"isNpc": false,
 			"source": "SoT1",
 			"page": 22,
 			"level": 3,

--- a/data/bestiary/creatures-sot2.json
+++ b/data/bestiary/creatures-sot2.json
@@ -2,7 +2,6 @@
 	"creature": [
 		{
 			"name": "Damibwa",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 80,
 			"level": 4,
@@ -141,7 +140,6 @@
 		},
 		{
 			"name": "Fire-pot Ubanu",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 89,
 			"level": 8,
@@ -367,7 +365,6 @@
 		},
 		{
 			"name": "Froglegs",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 91,
 			"level": 8,
@@ -561,7 +558,6 @@
 		},
 		{
 			"name": "Gbahali",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 81,
 			"level": 9,
@@ -747,7 +743,6 @@
 		},
 		{
 			"name": "Great Grodair",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 59,
 			"level": 7,
@@ -939,7 +934,6 @@
 		},
 		{
 			"name": "Grippli Jinxer",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 83,
 			"level": 6,
@@ -1201,7 +1195,6 @@
 		},
 		{
 			"name": "Grippli Skirmisher",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 82,
 			"level": 4,
@@ -1389,7 +1382,6 @@
 		},
 		{
 			"name": "I'iko Dragon",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 84,
 			"level": 6,
@@ -1573,7 +1565,6 @@
 		},
 		{
 			"name": "Kiru",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 27,
 			"level": 3,
@@ -1721,7 +1712,6 @@
 		},
 		{
 			"name": "Kolbo",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 49,
 			"level": 6,
@@ -1870,7 +1860,6 @@
 		},
 		{
 			"name": "Kreekoss",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 53,
 			"level": 6,
@@ -2005,7 +1994,6 @@
 		},
 		{
 			"name": "Loakan",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 28,
 			"level": 6,
@@ -2154,7 +2142,6 @@
 		},
 		{
 			"name": "Mashkudu The Bully",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 27,
 			"level": 5,
@@ -2294,7 +2281,6 @@
 		},
 		{
 			"name": "Mpeshi",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 85,
 			"level": 6,
@@ -2445,7 +2431,6 @@
 		},
 		{
 			"name": "Mutated Sewer Ooze",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 37,
 			"level": 6,
@@ -2580,7 +2565,6 @@
 		},
 		{
 			"name": "Old Thrasher",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 40,
 			"level": 8,
@@ -2715,7 +2699,6 @@
 		},
 		{
 			"name": "Reth",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 29,
 			"level": 7,
@@ -2882,7 +2865,6 @@
 		},
 		{
 			"name": "Salathiss",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 93,
 			"level": 9,
@@ -3198,7 +3180,6 @@
 		},
 		{
 			"name": "Serpentfolk Granitescale",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 86,
 			"level": 6,
@@ -3393,7 +3374,6 @@
 		},
 		{
 			"name": "Serpentfolk Venom Caller",
-			"isNpc": false,
 			"source": "SoT2",
 			"page": 87,
 			"level": 7,

--- a/data/bestiary/creatures-sot6.json
+++ b/data/bestiary/creatures-sot6.json
@@ -485,7 +485,6 @@
 		},
 		{
 			"name": "Aspect of Hunger",
-			"isNpc": false,
 			"source": "SoT6",
 			"page": 58,
 			"level": 19,

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -178,6 +178,12 @@ function updateFolder (folder) {
 						delete cr.creatureType
 						cr.traits = [...new Set(cr.traits.flat())]
 					}
+					if (cr.isNpc === false) {
+						delete cr.isNpc
+					}
+					if (cr.hasImages === false) {
+						delete cr.hasImages
+					}
 					if (cr.skills && Object.keys(cr.skills).find(k => k.match(/[A-Z]/g))) {
 						// Stolen from https://bobbyhadz.com/blog/javascript-lowercase-object-keys
 						console.log(`\tUpdating ${cr.name} skill to lowercase in ${file}...`)


### PR DESCRIPTION
These default to false if not set so remove unneeded entries that set false explicitly. This matches the current text converter output that avoids the redundant entries as well.

Removal is implemented in update-jsons.js.