### PR TITLE
Add range alias for Range Increment trait

### DIFF
--- a/data/traits.json
+++ b/data/traits.json
@@ -866,6 +866,9 @@
 		},
 		{
 			"name": "Range Increment",
+			"alias": [
+				"Range"
+			],
 			"source": "CRB",
 			"variable": true,
 			"page": 279,


### PR DESCRIPTION
Some creature abilities use `range <...>` instead of `range increment <...>` spelling.