### PR TITLE
Creature schema fixes/improvements

### DIFF
--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -28,10 +28,14 @@
 						"type": "string"
 					},
 					"page": {
-						"type": "integer"
+						"type": "integer",
+						"exclusiveMinimum": 0
+					},
+					"hasImages": {
+						"const": true
 					},
 					"isNpc": {
-						"type": "boolean"
+						"const": true
 					},
 					"_copy": {
 						"type": "object",
@@ -149,7 +153,7 @@
 									"pattern": "([a-z]+ |)lore( \\(.+?\\)|)$"
 								},
 								{
-									"const": "note"
+									"const": "notes"
 								}
 							]
 						},
@@ -169,6 +173,9 @@
 								"default": {
 									"type": "integer",
 									"minimum": 1
+								},
+								"note": {
+									"type": "string"
 								}
 							},
 							"additionalProperties": {
@@ -279,21 +286,6 @@
 						"additionalProperties": false,
 						"minProperties": 1
 					},
-					"misc": {
-						"type": "array",
-						"items": {
-							"type": "string",
-							"enum": [
-								"MA",
-								"RA",
-								"UW",
-								"CC",
-								"TA"
-							]
-						},
-						"minItems": 1,
-						"uniqueItems": true
-					},
 					"spellcasting": {
 						"type": "array",
 						"items": {
@@ -307,6 +299,7 @@
 									"enum": [
 										"Innate",
 										"Prepared",
+										"Spontaneous",
 										"Focus"
 									]
 								},
@@ -330,49 +323,18 @@
 								"entry": {
 									"type": "object",
 									"patternProperties": {
-										"^[0-9]$": {
+										"^([0-9]|10)$": {
+											"$ref": "utils.json#/definitions/spellsByLevelBlock"
+										},
+										"constant": {
 											"type": "object",
-											"properties": {
-												"level": {
-													"type": "integer",
-													"minimum": 1
-												},
-												"spells": {
-													"type": "array",
-													"items": {
-														"type": "object",
-														"properties": {
-															"name": {
-																"type": "string"
-															},
-															"source": {
-																"type": "string",
-																"$ref": "utils.json#/definitions/sourceList"
-															},
-															"amount": {
-																"type": "integer",
-																"minimum": 2
-															},
-															"note": {
-																"type": "array",
-																"items": {
-																	"type": "string"
-																}
-															}
-														},
-														"additionalProperties": false,
-														"required": [
-															"name"
-														]
-													},
-													"minItems": 1,
-													"uniqueItems": true
+											"patternProperties": {
+												"^([0-9]|10)$": {
+													"$ref": "utils.json#/definitions/spellsByLevelBlock"
 												}
 											},
 											"additionalProperties": false,
-											"required": [
-												"spells"
-											]
+											"minProperties": 1
 										}
 									},
 									"additionalProperties": false,
@@ -383,7 +345,6 @@
 							"required": [
 								"name",
 								"type",
-								"tradition",
 								"DC",
 								"entry"
 							]
@@ -407,14 +368,22 @@
 									"minimum": 10
 								},
 								"rituals": {
-									"type": "object",
-									"properties": {
-										"name": {
-											"type": "string"
-										}
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"name": {
+												"type": "string"
+											},
+											"source": {
+												"type": "string",
+												"$ref": "utils.json#/definitions/sourceList"
+											}
+										},
+										"additionalProperties": false,
+										"minProperties": 1
 									},
-									"additionalProperties": false,
-									"minProperties": 1
+									"minItems": 1
 								}
 							},
 							"additionalProperties": false,

--- a/test/schema-template/utils.json
+++ b/test/schema-template/utils.json
@@ -6,6 +6,61 @@
 	"type": "object",
 	"version": "0.0.1",
 	"definitions": {
+		"spellsByLevelBlock": {
+			"type": "object",
+			"properties": {
+				"level": {
+					"type": "integer",
+					"minimum": 1
+				},
+				"slots": {
+					"type": "integer",
+					"minimum": 1
+				},
+				"spells": {
+					"type": "array",
+					"items": {
+						"type": "object",
+						"properties": {
+							"name": {
+								"type": "string"
+							},
+							"source": {
+								"type": "string",
+								"$ref": "utils.json#/definitions/sourceList"
+							},
+							"amount": {
+								"oneOf": [
+									{
+										"type": "integer",
+										"minimum": 2
+									},
+									{
+										"const": "at will"
+									}
+								]
+							},
+							"note": {
+								"type": "array",
+								"items": {
+									"type": "string"
+								}
+							}
+						},
+						"additionalProperties": false,
+						"required": [
+							"name"
+						]
+					},
+					"minItems": 1,
+					"uniqueItems": true
+				}
+			},
+			"additionalProperties": false,
+			"required": [
+				"spells"
+			]
+		},
 		"range": {
 			"type": "object",
 			"properties": {
@@ -102,6 +157,13 @@
 			"properties": {
 				"speedNote": {
 					"type": "string"
+				},
+				"abilities": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"minItems": 1
 				}
 			},
 			"additionalProperties": {


### PR DESCRIPTION
No changes to actual data, just bringing schema more in line with the actual data layout.

* spellcasting tradition is optional
* add speed abilities
* add Spontaneous spellcasting type
* add hasImages
* add exclusiveMinimum for page
* isNpc is always true if present
* fix name of skill notes property (note->notes)
* add note property for individual skills
* add constant spells (shared spell definition schema is moved to utils)
* add slots property for spell levels
* fix & expand rituals schema
* remove unused misc property