### PR TITLE
Add parentheses for resistance/weakness notes in renderer

### DIFF
--- a/data/bestiary/creatures-aoa3.json
+++ b/data/bestiary/creatures-aoa3.json
@@ -3506,7 +3506,7 @@
 					{
 						"amount": 8,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -3963,9 +3963,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": [
-							"(except bludgeoning)"
-						]
+						"note": "except bludgeoning"
 					}
 				]
 			}
@@ -5100,7 +5098,7 @@
 					{
 						"amount": 12,
 						"name": "physical",
-						"note": "(except piercing)"
+						"note": "except piercing"
 					}
 				]
 			}

--- a/data/bestiary/creatures-aoa4.json
+++ b/data/bestiary/creatures-aoa4.json
@@ -3405,7 +3405,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except magic bludgeoning)"
+						"note": "except magic bludgeoning"
 					}
 				]
 			}
@@ -4395,7 +4395,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -135,7 +135,7 @@
 					{
 						"name": "physical",
 						"amount": 10,
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			},
@@ -626,9 +626,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": [
-							"(except silver)"
-						]
+						"note": "except silver"
 					},
 					{
 						"amount": 15,
@@ -865,7 +863,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			},
@@ -3013,9 +3011,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": [
-							"(except bludgeoning)"
-						]
+						"note": "except bludgeoning"
 					}
 				]
 			}

--- a/data/bestiary/creatures-aoa6.json
+++ b/data/bestiary/creatures-aoa6.json
@@ -150,7 +150,7 @@
 					{
 						"amount": 15,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -5165,7 +5165,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					}
 				]
 			},
@@ -5714,7 +5714,7 @@
 					{
 						"amount": 20,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},

--- a/data/bestiary/creatures-aoe6.json
+++ b/data/bestiary/creatures-aoe6.json
@@ -1689,7 +1689,7 @@
 					{
 						"amount": 10,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or lawful; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or lawful; double resistance against non-magical"
 					}
 				]
 			}
@@ -1941,7 +1941,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					}
 				]
 			},
@@ -3548,7 +3548,7 @@
 					{
 						"amount": 15,
 						"name": "energy",
-						"note": "(see Choose Weakness)"
+						"note": "see Choose Weakness"
 					}
 				]
 			}

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -2965,7 +2965,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -3977,7 +3977,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -104,7 +104,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -372,7 +372,7 @@
 					{
 						"amount": 20,
 						"name": "physical",
-						"note": "(except vorpal adamantine)"
+						"note": "except vorpal adamantine"
 					}
 				]
 			}
@@ -3304,7 +3304,7 @@
 					{
 						"amount": 12,
 						"name": "physical",
-						"note": "(except adamantine or bludgeoning)"
+						"note": "except adamantine or bludgeoning"
 					}
 				]
 			}
@@ -9637,7 +9637,7 @@
 					{
 						"amount": 12,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -10086,7 +10086,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,
@@ -10299,7 +10299,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except magical)"
+						"note": "except magical"
 					}
 				]
 			}
@@ -15383,7 +15383,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -16956,7 +16956,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except piercing)"
+						"note": "except piercing"
 					}
 				]
 			}
@@ -18346,7 +18346,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					}
 				]
 			}
@@ -26224,7 +26224,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -27124,7 +27124,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -27527,7 +27527,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,
@@ -28254,7 +28254,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -28516,7 +28516,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -34568,7 +34568,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except magical)"
+						"note": "except magical"
 					}
 				]
 			}
@@ -34897,7 +34897,7 @@
 					{
 						"amount": 10,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance against non-magical"
 					}
 				]
 			}
@@ -35604,7 +35604,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -36813,7 +36813,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -39500,7 +39500,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -40656,7 +40656,7 @@
 					{
 						"amount": 5,
 						"name": "poison",
-						"note": "(see dragonscaled)"
+						"note": "see dragonscaled"
 					}
 				]
 			}
@@ -43748,7 +43748,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except magic bludgeoning)"
+						"note": "except magic bludgeoning"
 					}
 				]
 			}
@@ -52394,7 +52394,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,
@@ -53074,7 +53074,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 15,
@@ -53959,7 +53959,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance against non-magical"
 					}
 				]
 			}
@@ -55624,7 +55624,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except piercing)"
+						"note": "except piercing"
 					}
 				]
 			}
@@ -59317,7 +59317,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance against non-magical"
 					}
 				]
 			}
@@ -63651,7 +63651,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -66259,7 +66259,7 @@
 					{
 						"amount": 20,
 						"name": "physical",
-						"note": "(except cold iron)"
+						"note": "except cold iron"
 					}
 				]
 			}
@@ -67613,7 +67613,7 @@
 					{
 						"amount": 7,
 						"name": "physical",
-						"note": "(except magical silver)"
+						"note": "except magical silver"
 					}
 				]
 			}
@@ -67970,7 +67970,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except magical silver)"
+						"note": "except magical silver"
 					}
 				]
 			}
@@ -72055,7 +72055,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -11754,7 +11754,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine or slashing)"
+						"note": "except adamantine or slashing"
 					}
 				]
 			}
@@ -12881,7 +12881,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except cold iron)"
+						"note": "except cold iron"
 					}
 				]
 			}
@@ -13862,7 +13862,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 15,
@@ -16420,7 +16420,7 @@
 					{
 						"amount": 10,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -21085,7 +21085,7 @@
 					{
 						"amount": 3,
 						"name": "physical",
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					}
 				]
 			}
@@ -23526,7 +23526,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine or bludgeoning)"
+						"note": "except adamantine or bludgeoning"
 					}
 				]
 			}
@@ -24404,7 +24404,7 @@
 					{
 						"amount": 15,
 						"name": "all",
-						"note": "(except unarmed attacks)"
+						"note": "except unarmed attacks"
 					}
 				]
 			}
@@ -25312,7 +25312,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					}
 				]
 			}
@@ -25654,7 +25654,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,
@@ -27176,7 +27176,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine and slashing)"
+						"note": "except adamantine and slashing"
 					}
 				]
 			}
@@ -37910,7 +37910,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except cold iron)"
+						"note": "except cold iron"
 					}
 				]
 			}
@@ -42213,7 +42213,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -43290,7 +43290,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except slashing)"
+						"note": "except slashing"
 					}
 				]
 			}
@@ -44799,7 +44799,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					},
 					{
 						"amount": 10,
@@ -48144,7 +48144,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -50153,7 +50153,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -58985,7 +58985,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -7486,7 +7486,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -12529,7 +12529,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -13444,7 +13444,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					}
 				]
 			}
@@ -18947,7 +18947,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine or bludgeoning)"
+						"note": "except adamantine or bludgeoning"
 					}
 				]
 			}
@@ -21795,7 +21795,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or negative; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or negative; double resistance against non-magical"
 					}
 				]
 			}
@@ -32505,9 +32505,7 @@
 				},
 				"ruins lore": {
 					"std": 15,
-					"note": [
-						"applies only to their home ruins"
-					]
+					"note": "applies only to their home ruins"
 				}
 			},
 			"abilityMods": {
@@ -33081,7 +33079,7 @@
 					{
 						"amount": 20,
 						"name": "physical",
-						"note": "(except piercing)"
+						"note": "except piercing"
 					}
 				]
 			}
@@ -34609,7 +34607,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -36238,7 +36236,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except silver)"
+						"note": "except silver"
 					}
 				]
 			}
@@ -37582,7 +37580,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -38317,7 +38315,7 @@
 					{
 						"amount": 15,
 						"name": "physical",
-						"note": "(except magical wood)"
+						"note": "except magical wood"
 					}
 				]
 			}
@@ -45877,7 +45875,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except emotion, force, {@item ghost touch}, mental, or positive; double resistance vs. non-magical)"
+						"note": "except emotion, force, {@item ghost touch}, mental, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -58574,7 +58572,7 @@
 					{
 						"amount": 20,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-bb.json
+++ b/data/bestiary/creatures-bb.json
@@ -2225,7 +2225,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -3382,7 +3382,7 @@
 					{
 						"amount": 5,
 						"name": "poison",
-						"note": "(see dragonscaled)"
+						"note": "see dragonscaled"
 					}
 				]
 			}
@@ -4806,7 +4806,7 @@
 					{
 						"amount": 5,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance against non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-botd.json
+++ b/data/bestiary/creatures-botd.json
@@ -1093,7 +1093,7 @@
 					{
 						"name": "all damage",
 						"amount": 5,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -1513,7 +1513,7 @@
 					{
 						"name": "all damage",
 						"amount": 15,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -2209,7 +2209,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -4442,7 +4442,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -5942,7 +5942,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -6302,7 +6302,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -6954,7 +6954,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -8475,7 +8475,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -8850,7 +8850,7 @@
 					{
 						"name": "physical",
 						"amount": 10,
-						"note": "(except magic bludgeoning)"
+						"note": "except magic bludgeoning"
 					}
 				]
 			},
@@ -9256,7 +9256,7 @@
 					{
 						"name": "physical",
 						"amount": 10,
-						"note": "(except magic bludgeoning)"
+						"note": "except magic bludgeoning"
 					}
 				]
 			},
@@ -9590,7 +9590,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -11773,7 +11773,7 @@
 					{
 						"name": "all",
 						"amount": 5,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -15633,7 +15633,7 @@
 					{
 						"name": "all damage",
 						"amount": 5,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},

--- a/data/bestiary/creatures-ec1.json
+++ b/data/bestiary/creatures-ec1.json
@@ -2311,7 +2311,7 @@
 					{
 						"amount": 3,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			},

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -2774,7 +2774,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},
@@ -3119,7 +3119,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-ec4.json
+++ b/data/bestiary/creatures-ec4.json
@@ -1309,7 +1309,7 @@
 					{
 						"amount": 5,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			},
@@ -2121,7 +2121,7 @@
 					{
 						"amount": 15,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -5132,7 +5132,7 @@
 					{
 						"amount": 14,
 						"name": "physical",
-						"note": "(from weapons only)"
+						"note": "from weapons only"
 					}
 				]
 			}

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -4799,7 +4799,7 @@
 					{
 						"amount": 20,
 						"name": "physical",
-						"note": "(except magical silver)"
+						"note": "except magical silver"
 					}
 				]
 			}

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -2066,7 +2066,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -3238,7 +3238,7 @@
 					{
 						"amount": 10,
 						"name": "all damage",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}
@@ -4924,7 +4924,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except adamantine)"
+						"note": "except adamantine"
 					}
 				]
 			}
@@ -7289,7 +7289,7 @@
 					{
 						"amount": 15,
 						"name": "all",
-						"note": "(except force, {@item ghost touch}, or positive; double resistance against non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance against non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -4497,7 +4497,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except magical darkwood)"
+						"note": "except magical darkwood"
 					}
 				]
 			},
@@ -5359,7 +5359,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except darkwood)"
+						"note": "except darkwood"
 					}
 				]
 			},

--- a/data/bestiary/creatures-lomm.json
+++ b/data/bestiary/creatures-lomm.json
@@ -1685,7 +1685,7 @@
 					{
 						"name": "physical",
 						"amount": 15,
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					},
 					{
 						"name": "poison",
@@ -1909,7 +1909,7 @@
 					{
 						"name": "physical",
 						"amount": 10,
-						"note": "(except bludgeoning)"
+						"note": "except bludgeoning"
 					}
 				]
 			},

--- a/data/bestiary/creatures-ngd.json
+++ b/data/bestiary/creatures-ngd.json
@@ -1920,7 +1920,7 @@
 					{
 						"name": "all damage",
 						"amount": 15,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-ooa3.json
+++ b/data/bestiary/creatures-ooa3.json
@@ -1709,7 +1709,7 @@
 					{
 						"name": "all",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},

--- a/data/bestiary/creatures-sli.json
+++ b/data/bestiary/creatures-sli.json
@@ -1156,7 +1156,7 @@
 					{
 						"amount": 10,
 						"name": "physical",
-						"note": "(except {@item adamantine (generic)||adamantine})"
+						"note": "except {@item adamantine (generic)||adamantine}"
 					}
 				]
 			}

--- a/data/bestiary/creatures-sot1.json
+++ b/data/bestiary/creatures-sot1.json
@@ -2570,7 +2570,7 @@
 					{
 						"amount": 5,
 						"name": "all damage",
-						"note": "(except force or {@item ghost touch}; double resistance vs. non-magical, stone, or effects with the earth trait)"
+						"note": "except force or {@item ghost touch}; double resistance vs. non-magical, stone, or effects with the earth trait"
 					}
 				]
 			},

--- a/data/bestiary/creatures-sot3.json
+++ b/data/bestiary/creatures-sot3.json
@@ -3386,7 +3386,7 @@
 					{
 						"name": "all damage",
 						"amount": 10,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			},

--- a/data/bestiary/creatures-sot4.json
+++ b/data/bestiary/creatures-sot4.json
@@ -4307,7 +4307,7 @@
 					{
 						"name": "all damage",
 						"amount": 5,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/data/bestiary/creatures-sot5.json
+++ b/data/bestiary/creatures-sot5.json
@@ -4651,7 +4651,7 @@
 					{
 						"name": "all damage",
 						"amount": 15,
-						"note": "(except force, {@item ghost touch}, or positive; double resistance vs. non-magical)"
+						"note": "except force, {@item ghost touch}, or positive; double resistance vs. non-magical"
 					}
 				]
 			}

--- a/js/render.js
+++ b/js/render.js
@@ -4443,7 +4443,7 @@ Renderer.creature = {
 	getDefenses_getResWeakPart (arr, prop) {
 		if (!arr || arr.length === 0) return null;
 		const renderer = Renderer.get();
-		const vals = arr.map(it => `${it.name}${it.amount ? ` ${it.amount}` : ""}${it.note ? ` ${renderer.render(it.note)}` : ""}`);
+		const vals = arr.map(it => `${it.name}${it.amount ? ` ${it.amount}` : ""}${it.note ? ` (${renderer.render(it.note)})` : ""}`);
 		return `<strong>${prop}&nbsp;</strong>${renderer.render(vals.join(", "))}`;
 	},
 

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -203,6 +203,22 @@ function updateFolder (folder) {
 							}
 						}
 					}
+					if (cr.defenses && cr.defenses.resistances) {
+						cr.defenses.resistances = cr.defenses.resistances.map(r => {
+							if (r.note) {
+								r.note = r.note.trimAnyChar("()");
+							}
+							return r;
+						})
+					}
+					if (cr.defenses && cr.defenses.weaknesses) {
+						cr.defenses.weaknesses = cr.defenses.weaknesses.map(r => {
+							if (r.note) {
+								r.note = r.note.trimAnyChar("()");
+							}
+							return r;
+						})
+					}
 					if (cr.languages && cr.languages.languages && cr.languages.languages.length && cr.languages.languages.find(k => k.match(/[A-Z]/g))) {
 						console.log(`\tUpdating ${cr.name} languages to lowercase in ${file}...`)
 						cr.languages.languages = cr.languages.languages.map(k => k.toLowerCase())


### PR DESCRIPTION
text converter already removes parentheses so only renderer and older data needed to be adjusted