### PR TITLE
improve handling of creatures with a lore skill using a note

### DIFF
--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -3351,8 +3351,9 @@
 				"occultism": {
 					"std": 16
 				},
-				"lore (any one subcategory)": {
-					"std": 14
+				"lore": {
+					"std": 14,
+					"note": "any one subcategory"
 				}
 			},
 			"abilityMods": {
@@ -11364,8 +11365,9 @@
 				"stealth": {
 					"std": 17
 				},
-				"lore (all subcategories)": {
-					"std": 18
+				"lore": {
+					"std": 18,
+					"note": "all subcategories"
 				}
 			},
 			"abilityMods": {
@@ -68177,8 +68179,9 @@
 				"stealth": {
 					"std": 24
 				},
-				"lore (any one subcategory)": {
-					"std": 29
+				"lore": {
+					"std": 29,
+					"note": "any one subcategory"
 				}
 			},
 			"abilityMods": {

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -37044,8 +37044,9 @@
 				"religion": {
 					"std": 34
 				},
-				"lore (all)": {
-					"std": 28
+				"lore": {
+					"std": 28,
+					"note": "all"
 				}
 			},
 			"abilityMods": {

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -2809,8 +2809,9 @@
 				"occultism": {
 					"std": 27
 				},
-				"lore (any one subcategory)": {
-					"std": 27
+				"lore": {
+					"std": 27,
+					"note": "any one subcategory"
 				}
 			},
 			"abilityMods": {
@@ -13997,8 +13998,9 @@
 				"stealth": {
 					"std": 7
 				},
-				"lore (any one)": {
-					"std": 10
+				"lore": {
+					"std": 10,
+					"note": "any one"
 				}
 			},
 			"abilityMods": {

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -34,8 +34,9 @@
 				"stealth": {
 					"std": 26
 				},
-				"lore (any one terrain)": {
-					"std": 22
+				"lore": {
+					"std": 22,
+					"note": "any one terrain"
 				}
 			},
 			"abilityMods": {

--- a/data/bestiary/creatures-gmg.json
+++ b/data/bestiary/creatures-gmg.json
@@ -3333,8 +3333,9 @@
 				"society": {
 					"std": 2
 				},
-				"lore (any one related to their trade)": {
-					"std": 6
+				"lore": {
+					"std": 6,
+					"note": "any one related to their trade"
 				}
 			},
 			"abilityMods": {

--- a/js/converter.js
+++ b/js/converter.js
@@ -820,13 +820,25 @@ class Converter {
 	_parseSkills (creature) {
 		this._consumeToken(this._tokenizerUtils.skillsProp);
 		const skills = {};
+		const loreSkillSome = /\((.*)\)/
 		const regexBonus = /\+(\d+)/;
 		const regexOtherBonus = /\+(\d+)\s([\w\s]+)/g;
 		// skill entries should be followed by the skill bonus
 		while (this._tokenIsType(this._tokenizerUtils.skills) && this._tokenIsType("SKILL_BONUS", this._peek(1))) {
 			const token = this._consumeToken(this._tokenizerUtils.skills);
-			const skill = token.value.trim().toLowerCase().replace(/\s/g, " ");
-			skills[skill] = {};
+
+			let skill = "";
+			if (token.type === "LORE_SOME") {
+				// "Lore (any that match these criteria) +10"
+				skill = "lore";
+				const match = loreSkillSome.exec(token.value);
+				const note = match[1].trim().replace(/\s/g, " ");
+				skills[skill] = {};
+				skills[skill].note = note;
+			} else {
+				skill = token.value.trim().toLowerCase().replace(/\s/g, " ");
+				skills[skill] = {};
+			}
 
 			const bonusToken = this._consumeToken("SKILL_BONUS");
 			skills[skill].std = Number(regexBonus.exec(bonusToken.value.replace(/\s/g, ""))[1]);

--- a/js/render.js
+++ b/js/render.js
@@ -4322,7 +4322,12 @@ Renderer.creature = {
 			renderStack.push(`<strong>Skills&nbsp;</strong>`)
 			let skills = []
 			Object.keys(cr.skills).filter(k => k !== "notes").forEach(skill => {
-				let renderedSkill = `${skill.toTitleCase()} ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std"], raw: ["note"], dice: { name: skill } })}`;
+				let renderedSkill = "";
+				if (skill === "lore") {
+					renderedSkill = `${skill.toTitleCase()} (${renderer.render(cr.skills[skill].note)}) ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std", "note"], dice: { name: skill } })}`;
+				} else {
+					renderedSkill = `${skill.toTitleCase()} ${renderer.render(`{@d20 ${cr.skills[skill].std}||${skill.toTitleCase()}}`)}${Renderer.utils.getNotes(cr.skills[skill], { exclude: ["std"], raw: ["note"], dice: { name: skill } })}`;
+				}
 				skills.push(renderedSkill)
 			});
 			let notes = cr.skills["notes"] || [];

--- a/js/tokenizer.js
+++ b/js/tokenizer.js
@@ -201,6 +201,7 @@ class TokenizerUtils {
 			{regex: /^([A-Z][a-z]*?)\sLore\s/, type: "LORE"},
 			// We are back with ugly regex
 			{regex: /^((?:\b[\w-]*?\s)+)Lore\s/, type: "LORE"},
+			{regex: /^Lore\s+\(.*?\)\s/, type: "LORE_SOME"},
 			{regex: /^Lore\s/, type: "LORE_ALL"},
 			{regex: /^Medicine\s/, type: "MEDICINE"},
 			{regex: /^Nature\s/, type: "NATURE"},

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -193,6 +193,15 @@ function updateFolder (folder) {
 							return accumulator;
 						}, {})
 					}
+					if (cr.skills) {
+						for (const skill of Object.keys(cr.skills).filter(s => s.match(/[Ll]ore\s+\(.*\)/g))) {
+							cr.skills["lore"] = cr.skills[skill];
+							const match = /\((.*)\)/.exec(skill);
+							const note = match[1].trim().replace(/\s/g, " ");
+							cr.skills["lore"].note = note;
+							delete cr.skills[skill];
+						}
+					}
 					if (cr.ac || cr.savingThrows || cr.hardness || cr.hp || cr.bt || cr.immunities || cr.weaknesses || cr.resistances) {
 						cr.defenses = cr.defenses || {};
 						console.log(`\tUpdating ${cr.name} defenses in ${file}...`)


### PR DESCRIPTION
Some creatures have a blank "Lore" skill entry that is narrowed using a note in parentheses before the bonus, e.g.

  Lore (any one related to their trade) +6

Currently this is stored as part of the skill name.

* Add text converter support for parsing such skill entries
* For existing data, move the text inside the parentheses to the skill's note property instead
* Adjust the renderer to handle this case