### PR TITLE
text converter: improve _splitSemiOrComma

### DIFF
--- a/js/converter.js
+++ b/js/converter.js
@@ -1322,7 +1322,11 @@ class Converter {
 		// TODO:
 		opts = opts || {};
 		const rendered = opts.isText ? entries : this._renderEntries(entries, {asString: true, noTags: true});
-		return rendered.split(", ")
+
+		const sep = /\s*(?:;|,|$)\s*/;
+		const parts = rendered.split(sep);
+		if (opts.keepEmpty) return parts
+		else return parts.filter(s => s.length > 0)
 	}
 
 	_parseHazardProperties (obj) {


### PR DESCRIPTION
* actually split on semicolons as well
* prune arbitrary leading/trailing whitespace while stripping
* filter out empty string by default

**NB**:

`_splitSemiOrComma` is used in a lot of places. Contrary to its name, until now it only actually split on commas and not semicolons.

While this change will improve/fix cases where code was written with the expectation that this function split on semicolons, it can also potentially introduce new issues since written code was tested with the old behaviour.

I tested some creature statblocks which seemed to still work fine but things could of course still break on various edge cases or other kinds of entries.

Alternatively, we could rename the existing function to e.g. `_splitComma` and introduce a new `_splitSemiOrComma` version and start using that on a case-by-case basis for a "safer" migration.