### PR TITLE
Add 'healing' trait to items in CRB that where missing it

### DIFF
--- a/data/items/items-crb.json
+++ b/data/items/items-crb.json
@@ -1160,7 +1160,8 @@
 			"traits": [
 				"alchemical",
 				"consumable",
-				"elixir"
+				"elixir",
+				"healing"
 			],
 			"usage": "held in 1 hand",
 			"bulk": "L",
@@ -1356,7 +1357,8 @@
 			"traits": [
 				"alchemical",
 				"consumable",
-				"elixir"
+				"elixir",
+				"healing"
 			],
 			"usage": "held in 1 hand",
 			"bulk": "L",
@@ -7917,7 +7919,8 @@
 				"uncommon",
 				"alchemical",
 				"consumable",
-				"elixir"
+				"elixir",
+				"healing"
 			],
 			"usage": "held in 1 hand",
 			"bulk": "L",


### PR DESCRIPTION
Didn't find a contribution guide, so I haven't done anything other than running the `clean-jsons` command.

My source is 4th printing, in case that matters.