### PR TITLE
Correctly render Witch Hexes creature spellcasting entries

### DIFF
--- a/data/bestiary/creatures-afof.json
+++ b/data/bestiary/creatures-afof.json
@@ -445,7 +445,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -609,7 +610,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -746,7 +748,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -896,7 +899,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoa1.json
+++ b/data/bestiary/creatures-aoa1.json
@@ -315,7 +315,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -698,7 +699,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1403,7 +1405,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2247,7 +2250,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2423,7 +2427,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3141,10 +3146,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Wizard School",
+					"name": "Wizard School Spells",
 					"type": "Focus",
 					"DC": 23,
 					"fp": 1,

--- a/data/bestiary/creatures-aoa2.json
+++ b/data/bestiary/creatures-aoa2.json
@@ -296,7 +296,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -499,7 +500,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -676,7 +678,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -841,7 +844,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1056,7 +1060,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1507,7 +1512,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1917,7 +1923,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2108,7 +2115,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2665,7 +2673,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3190,7 +3199,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"DC": 25,
 					"fp": 2,
@@ -3226,7 +3235,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3377,7 +3387,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3927,10 +3938,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 24,
 					"fp": 2,
@@ -3977,7 +3989,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"items": [

--- a/data/bestiary/creatures-aoa3.json
+++ b/data/bestiary/creatures-aoa3.json
@@ -119,7 +119,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -455,10 +456,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Wizard School",
+					"name": "Wizard School Spells",
 					"type": "Focus",
 					"DC": 22,
 					"fp": 2,
@@ -1288,7 +1290,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1479,7 +1482,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1724,7 +1728,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -2361,7 +2366,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2988,7 +2994,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -3220,7 +3227,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3644,7 +3652,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4995,7 +5004,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -5010,7 +5020,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [

--- a/data/bestiary/creatures-aoa4.json
+++ b/data/bestiary/creatures-aoa4.json
@@ -350,7 +350,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -640,7 +641,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1192,7 +1194,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1402,7 +1405,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1948,7 +1952,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2892,10 +2897,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 36,
 					"fp": 3,
@@ -3312,7 +3318,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3517,7 +3524,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3823,7 +3831,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4285,7 +4294,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4710,7 +4720,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4975,7 +4986,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -5191,7 +5203,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -243,7 +243,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -493,7 +494,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -773,7 +775,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1271,10 +1274,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 37,
 					"attack": 31,
@@ -1499,7 +1503,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1726,7 +1731,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -2298,7 +2304,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -2312,7 +2319,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -2612,7 +2620,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2859,7 +2868,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3417,7 +3427,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoa6.json
+++ b/data/bestiary/creatures-aoa6.json
@@ -506,7 +506,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -878,7 +879,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1081,7 +1083,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -1566,7 +1569,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -2014,10 +2018,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Wizard School",
+					"name": "Wizard School Spells",
 					"type": "Focus",
 					"DC": 44,
 					"fp": 3,
@@ -2718,7 +2723,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3185,7 +3191,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3674,7 +3681,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -4485,10 +4493,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				},
 				{
-					"name": "Bloodline",
+					"name": "Bloodline Spells",
 					"type": "Focus",
 					"DC": 42,
 					"fp": 3,
@@ -5041,7 +5050,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -5299,7 +5309,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5546,7 +5557,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [

--- a/data/bestiary/creatures-aoe1.json
+++ b/data/bestiary/creatures-aoe1.json
@@ -197,7 +197,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"defenses": {
@@ -1362,7 +1363,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1653,7 +1655,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2372,7 +2375,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe2.json
+++ b/data/bestiary/creatures-aoe2.json
@@ -269,7 +269,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -553,7 +554,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -191,7 +191,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2265,7 +2266,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2661,7 +2663,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe4.json
+++ b/data/bestiary/creatures-aoe4.json
@@ -318,7 +318,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -937,7 +938,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1409,7 +1411,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1647,7 +1650,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1972,7 +1976,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2222,7 +2227,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -2237,7 +2243,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3152,7 +3159,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -3450,7 +3458,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3732,7 +3741,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe5.json
+++ b/data/bestiary/creatures-aoe5.json
@@ -1703,7 +1703,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1966,7 +1967,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2280,7 +2282,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2531,7 +2534,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2782,7 +2786,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
 					"type": "Prepared",
@@ -2806,7 +2811,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				}
 			],
 			"rituals": [
@@ -3159,7 +3165,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3421,7 +3428,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3664,7 +3672,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3847,7 +3856,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4528,7 +4538,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4879,7 +4890,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5289,7 +5301,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-aoe6.json
+++ b/data/bestiary/creatures-aoe6.json
@@ -189,7 +189,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -437,7 +438,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -888,7 +890,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1103,7 +1106,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1444,7 +1448,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1604,7 +1609,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1822,7 +1828,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2370,7 +2377,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -2393,10 +2401,11 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 46,
 					"fp": 3,
@@ -2665,7 +2674,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2910,7 +2920,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3433,7 +3444,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -3954,7 +3966,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4366,7 +4379,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4671,7 +4685,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -5065,7 +5080,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -5081,7 +5097,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5460,7 +5477,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5957,7 +5975,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6260,7 +6279,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6587,7 +6607,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6821,7 +6842,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -7120,7 +7142,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -7522,7 +7545,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -7815,7 +7839,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -8104,7 +8129,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -652,7 +652,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -875,7 +876,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1790,7 +1792,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2098,7 +2101,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2664,10 +2668,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Domain",
+					"name": "Domain Spells",
 					"type": "Focus",
 					"DC": 22,
 					"fp": 1,
@@ -3229,7 +3234,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3477,7 +3483,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -3504,7 +3511,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3801,10 +3809,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				},
 				{
-					"name": "Bloodline",
+					"name": "Bloodline Spells",
 					"type": "Focus",
 					"DC": 22,
 					"fp": 1,

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -355,7 +355,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -1450,7 +1451,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1726,7 +1728,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -1749,7 +1752,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2297,7 +2301,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2495,7 +2500,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2720,7 +2726,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2974,7 +2981,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3248,7 +3256,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3886,7 +3895,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4107,7 +4117,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -259,10 +259,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"DC": 33,
 					"fp": 2,
@@ -503,7 +504,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -614,7 +616,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1022,7 +1025,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1511,7 +1515,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1902,7 +1907,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2104,7 +2110,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2330,7 +2337,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2538,7 +2546,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2755,7 +2764,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -2769,7 +2779,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2986,7 +2997,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
 					"type": "Prepared",
@@ -3096,7 +3108,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3315,7 +3328,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3540,7 +3554,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -3652,7 +3667,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3893,7 +3909,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4084,7 +4101,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4516,7 +4534,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4711,7 +4730,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -4808,7 +4828,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -5025,7 +5046,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5220,7 +5242,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -101,10 +101,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"DC": 20,
 					"fp": 1,
@@ -512,7 +513,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -792,7 +794,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1034,7 +1037,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1289,7 +1293,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1547,7 +1552,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1809,7 +1815,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2084,7 +2091,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2342,7 +2350,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2597,7 +2606,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2843,7 +2853,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3086,7 +3097,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3441,7 +3453,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3652,7 +3665,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3952,7 +3966,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4210,7 +4225,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4480,7 +4496,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4772,7 +4789,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5069,7 +5087,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5364,7 +5383,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5645,7 +5665,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5933,7 +5954,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -6215,7 +6237,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -7262,7 +7285,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -7433,7 +7457,8 @@
 					"DC": 26,
 					"entry": {
 						"constant": {}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -7858,7 +7883,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -8111,7 +8137,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -8481,7 +8508,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -8882,7 +8910,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -9307,7 +9336,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -9970,7 +10000,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -10227,7 +10258,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -11073,7 +11105,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -11491,7 +11524,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -12525,7 +12559,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -12741,7 +12776,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -12908,7 +12944,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -13096,7 +13133,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -13286,7 +13324,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14246,7 +14285,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14437,10 +14477,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
-					"name": "Druid Order",
+					"name": "Druid Order Spells",
 					"type": "Focus",
 					"DC": 21,
 					"fp": 1,
@@ -14831,7 +14872,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -15669,7 +15711,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -15975,7 +16018,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -16866,7 +16910,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -16891,7 +16936,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -17129,7 +17175,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -17145,7 +17192,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -17497,7 +17545,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -17511,7 +17560,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true,
@@ -17634,7 +17684,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -17760,7 +17811,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -18197,7 +18249,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -18470,7 +18523,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -18542,7 +18596,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -18724,7 +18779,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -18916,7 +18972,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -19516,7 +19573,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -19844,7 +19902,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -20000,7 +20059,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -20524,7 +20584,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				},
 				{
 					"type": "Prepared",
@@ -20574,7 +20635,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -20767,7 +20829,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -20997,7 +21060,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -21050,7 +21114,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -21229,7 +21294,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -21445,7 +21511,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -21737,7 +21804,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -21813,7 +21881,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -22054,7 +22123,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -22235,7 +22305,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -22394,7 +22465,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -22417,7 +22489,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -23046,7 +23119,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -23255,7 +23329,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -24575,7 +24650,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -25032,7 +25108,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -25201,7 +25278,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -25243,7 +25321,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -25561,7 +25640,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -26704,7 +26784,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -26914,7 +26995,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -27459,7 +27541,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -27764,7 +27847,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -28412,7 +28496,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -31717,7 +31802,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -32127,7 +32213,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -33036,7 +33123,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -33211,7 +33299,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -33944,7 +34033,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -34473,7 +34563,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -34677,7 +34768,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -34815,7 +34907,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -35037,7 +35130,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -35396,7 +35490,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -35745,7 +35840,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -36410,7 +36506,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -36704,7 +36801,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -38064,7 +38162,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -38809,7 +38908,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -39058,7 +39158,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -39657,7 +39758,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -39810,7 +39912,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -40306,7 +40409,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -40584,7 +40688,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -41081,7 +41186,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -41259,7 +41365,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -41719,7 +41826,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -41932,7 +42040,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -41981,7 +42090,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -42162,7 +42272,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -42349,7 +42460,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -42585,7 +42697,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -43035,7 +43148,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -43299,7 +43413,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -43641,7 +43756,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -43955,7 +44071,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -45142,7 +45259,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -45322,7 +45440,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -45844,7 +45963,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -46091,7 +46211,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -46942,7 +47063,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -47371,7 +47493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -47657,7 +47780,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -47686,7 +47810,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -48799,7 +48924,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -49037,7 +49163,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -49062,7 +49189,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -49370,7 +49498,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -49832,7 +49961,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -50048,7 +50178,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -50260,7 +50391,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -50420,7 +50552,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -52307,7 +52440,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -52586,7 +52720,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -52895,7 +53030,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -53226,7 +53362,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -53639,7 +53776,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -53829,7 +53967,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -54311,7 +54450,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -54711,7 +54851,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -54940,7 +55081,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -55119,7 +55261,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -55532,7 +55675,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -55547,7 +55691,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -57394,7 +57539,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -58023,7 +58169,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -59489,7 +59636,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -59856,7 +60004,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -60103,7 +60252,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -60356,7 +60506,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -61800,7 +61951,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -62669,7 +62821,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -62870,7 +63023,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -63167,7 +63321,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -63953,7 +64108,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -64323,7 +64479,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -64600,7 +64757,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -65431,7 +65589,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -65445,7 +65604,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -65769,7 +65929,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -66117,7 +66278,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"rituals": [
@@ -67042,7 +67204,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -67799,7 +67962,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -68334,7 +68498,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -68880,7 +69045,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -69118,7 +69284,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -70515,7 +70682,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"rituals": [
@@ -73380,7 +73548,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -73617,7 +73786,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -73841,7 +74011,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -74073,7 +74244,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -74322,7 +74494,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -74577,7 +74750,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -74814,7 +74988,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -75051,7 +75226,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -75531,7 +75707,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -342,7 +342,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -603,7 +604,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -865,7 +867,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1148,7 +1151,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1425,7 +1429,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2044,7 +2049,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2575,7 +2581,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2879,7 +2886,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3165,7 +3173,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3495,7 +3504,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3803,7 +3813,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4036,7 +4047,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4253,7 +4265,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4405,7 +4418,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5252,7 +5266,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -5490,7 +5505,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5913,7 +5929,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6200,7 +6217,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6475,7 +6493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -6857,7 +6876,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -7104,7 +7124,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -8178,7 +8199,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -8509,7 +8531,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -9416,7 +9439,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -9464,7 +9488,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -9790,7 +9815,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -10092,7 +10118,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -10279,7 +10306,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -10559,7 +10587,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -11120,7 +11149,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -11315,7 +11345,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -12072,7 +12103,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -12758,7 +12790,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -13396,7 +13429,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -13737,7 +13771,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14295,7 +14330,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -14478,7 +14514,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -14740,7 +14777,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -14955,7 +14993,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -15617,7 +15656,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -16787,7 +16827,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -16971,7 +17012,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -17833,7 +17875,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -18087,7 +18130,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -18576,7 +18620,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -19079,7 +19124,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -19298,7 +19344,8 @@
 					"DC": 37,
 					"entry": {
 						"constant": {}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -19529,7 +19576,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -23817,7 +23865,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -24520,7 +24569,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -24989,7 +25039,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -25222,7 +25273,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -25557,7 +25609,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -25985,7 +26038,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -26723,7 +26777,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -26924,7 +26979,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -27463,7 +27519,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -28305,7 +28362,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28580,7 +28638,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -28755,7 +28814,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28977,7 +29037,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -29172,7 +29233,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -29559,7 +29621,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -30352,7 +30415,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -30687,7 +30751,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -30995,7 +31060,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -31223,7 +31289,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -31430,7 +31497,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -31820,7 +31888,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -32332,7 +32401,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"abilities": {
@@ -32555,7 +32625,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -33265,7 +33336,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -33477,7 +33549,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -33712,7 +33785,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -34191,7 +34265,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -34940,7 +35015,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -35526,7 +35602,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -35910,7 +35987,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -36135,7 +36213,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -36531,7 +36610,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -36777,7 +36857,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -37169,7 +37250,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -37413,7 +37495,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -37810,7 +37893,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -38219,7 +38303,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -38476,7 +38561,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -38621,7 +38707,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -39069,7 +39156,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -39363,7 +39451,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -40588,7 +40677,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -40890,7 +40980,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -41282,7 +41373,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -41522,7 +41614,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -41750,7 +41843,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -42116,7 +42210,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -42558,7 +42653,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -43524,7 +43620,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -43751,7 +43848,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -44135,7 +44233,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -44402,7 +44501,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -44680,7 +44780,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -45112,7 +45213,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -46180,7 +46282,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -46581,7 +46684,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -48660,7 +48764,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -48968,7 +49073,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -49170,7 +49276,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -49421,7 +49528,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -49607,7 +49715,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -50067,7 +50176,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -50271,7 +50381,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -50418,7 +50529,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -50992,7 +51104,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -51625,7 +51738,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -51842,7 +51956,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -52204,7 +52319,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -53386,7 +53502,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -54108,10 +54225,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"fp": 1,
 					"DC": 17,
@@ -54845,7 +54963,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -55109,7 +55228,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -55404,7 +55524,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -56316,7 +56437,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -56555,7 +56677,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -57422,7 +57545,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -58106,7 +58230,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -58382,7 +58507,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -58754,7 +58880,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -59340,7 +59467,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -59552,7 +59680,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -59892,7 +60021,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -60483,7 +60613,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -60682,7 +60813,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -60927,7 +61059,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -61171,7 +61304,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				},
 				{
 					"type": "Prepared",
@@ -61235,7 +61369,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -61477,7 +61612,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -61732,7 +61868,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -61958,7 +62095,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -62180,7 +62318,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -62418,7 +62557,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -62670,7 +62810,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -105,7 +105,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -310,7 +311,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -519,7 +521,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1110,7 +1113,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1423,7 +1427,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -1719,7 +1724,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2003,7 +2009,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2303,7 +2310,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2542,7 +2550,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2874,7 +2883,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3301,7 +3311,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3628,7 +3639,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3939,7 +3951,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4248,7 +4261,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4566,7 +4580,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4960,7 +4975,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5973,7 +5989,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6157,7 +6174,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -6355,7 +6373,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -6539,7 +6558,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -7731,7 +7751,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -8472,7 +8493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -8673,7 +8695,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -9007,7 +9030,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -9215,7 +9239,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -9568,7 +9593,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -9934,7 +9960,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -10665,7 +10692,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -11425,7 +11453,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -12655,7 +12684,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -12838,7 +12868,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -13085,7 +13116,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -13325,7 +13357,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -13698,10 +13731,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Divine Domain",
+					"name": "Divine Domain Spells",
 					"type": "Focus",
 					"fp": 1,
 					"DC": 19,
@@ -13896,7 +13930,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -14079,7 +14114,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14328,7 +14364,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14546,7 +14583,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -14773,7 +14811,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -14927,7 +14966,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -15118,7 +15158,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -15293,7 +15334,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -15475,7 +15517,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -15820,7 +15863,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 29,
@@ -16077,7 +16120,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -16288,7 +16332,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -16660,7 +16705,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -17006,7 +17052,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -17266,7 +17313,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -17470,7 +17518,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -17809,7 +17858,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -19066,7 +19116,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -19419,7 +19470,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -19632,7 +19684,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -19997,7 +20050,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -20021,7 +20075,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -21306,7 +21361,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -21700,7 +21756,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -22094,7 +22151,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"rituals": [
@@ -22378,7 +22436,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -22583,7 +22642,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -22615,7 +22675,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -22873,7 +22934,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -23070,7 +23132,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -23611,7 +23674,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -23739,7 +23803,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -24124,7 +24189,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -24377,7 +24443,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -24590,7 +24657,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -25096,7 +25164,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -25393,7 +25462,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -25706,7 +25776,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -25732,7 +25803,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -26117,7 +26189,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -26455,7 +26528,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -26765,7 +26839,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -27133,7 +27208,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28055,7 +28131,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28347,7 +28424,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28526,7 +28604,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -28755,7 +28834,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -28915,7 +28995,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -29505,7 +29586,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -29749,7 +29831,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -30344,7 +30427,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -30568,7 +30652,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -30866,7 +30951,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"type": "Innate",
@@ -30926,7 +31012,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -32103,10 +32190,11 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 37,
@@ -32357,7 +32445,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -32566,7 +32655,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -32958,7 +33048,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -32997,7 +33088,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -33202,7 +33294,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Ki",
+					"name": "Monk Ki Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 24,
@@ -33645,7 +33737,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -34332,7 +34425,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -34782,7 +34876,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -35021,7 +35116,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -35570,7 +35666,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -35929,7 +36026,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -36152,7 +36250,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -37093,7 +37192,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -37451,7 +37551,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -37782,7 +37883,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -37983,7 +38085,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -38583,7 +38686,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -38787,7 +38891,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -39085,7 +39190,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -39730,7 +39836,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -39948,7 +40055,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -40175,7 +40283,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -40394,7 +40503,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -40680,7 +40790,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -40942,7 +41053,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -41382,7 +41494,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -41606,7 +41719,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -42043,7 +42157,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -42417,7 +42532,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -42717,7 +42833,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -43057,7 +43174,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -43319,7 +43437,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -43506,7 +43625,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -43688,7 +43808,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -44103,7 +44224,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -44394,7 +44516,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -45048,7 +45171,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -45422,7 +45546,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -45592,7 +45717,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -45782,7 +45908,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -46046,7 +46173,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -46349,10 +46477,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"DC": 19,
 					"fp": 2,
@@ -46566,7 +46695,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -47079,7 +47209,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -47281,7 +47412,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -47448,7 +47580,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -47640,7 +47773,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -47876,7 +48010,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -48713,7 +48848,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -48955,7 +49091,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -49589,7 +49726,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -49720,7 +49858,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -49913,7 +50052,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -50129,7 +50269,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -50634,7 +50775,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -50999,7 +51141,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -52160,7 +52303,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -52668,7 +52812,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -52858,7 +53003,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -53016,7 +53162,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -53059,7 +53206,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -53279,7 +53427,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -53453,7 +53602,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -53776,7 +53926,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -54327,7 +54478,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -54504,7 +54656,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -55028,7 +55181,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -55451,7 +55605,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -55677,7 +55832,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -55904,7 +56060,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -56110,7 +56267,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -56668,10 +56826,11 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Champion Focus",
+					"name": "Champion Focus Spells",
 					"type": "Focus",
 					"DC": 24,
 					"fp": 1,
@@ -57678,7 +57837,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -57921,7 +58081,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -58405,7 +58566,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -58857,7 +59019,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -59177,7 +59340,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -59433,7 +59597,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -59644,7 +59809,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -59933,7 +60099,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -60208,7 +60375,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"type": "Prepared",
@@ -60295,7 +60463,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -60552,7 +60721,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -60827,7 +60997,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -61464,7 +61635,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-bb.json
+++ b/data/bestiary/creatures-bb.json
@@ -1328,7 +1328,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2574,7 +2575,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3334,7 +3336,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-botd.json
+++ b/data/bestiary/creatures-botd.json
@@ -120,7 +120,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -756,7 +757,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -1447,7 +1449,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2116,7 +2119,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2318,7 +2322,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2685,7 +2690,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3295,7 +3301,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3563,7 +3570,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3858,7 +3866,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4121,7 +4130,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4351,7 +4361,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4573,10 +4584,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 1,
 					"DC": 19,
@@ -4796,10 +4808,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 25,
@@ -6651,10 +6664,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 23,
@@ -7366,10 +7380,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 1,
 					"DC": 24,
@@ -7557,10 +7572,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 25,
@@ -7816,7 +7832,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -8707,7 +8724,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -9112,7 +9130,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -10185,7 +10204,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -10720,7 +10740,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Ki",
+					"name": "Monk Ki Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 29,
@@ -11054,7 +11074,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -11316,7 +11337,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -11491,7 +11513,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -12597,10 +12620,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
-					"name": "Druid Order",
+					"name": "Druid Order Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 41,
@@ -13087,7 +13111,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"defenses": {
@@ -13506,7 +13531,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -13685,7 +13711,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -13932,7 +13959,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -14619,7 +14647,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -14776,7 +14805,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Focus",
+					"name": "Monk Focus Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 34,
@@ -15182,7 +15211,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
 					"tradition": "occult",
@@ -15298,7 +15328,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				}
 			],
 			"abilities": {
@@ -15546,7 +15577,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -16198,7 +16230,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -16887,7 +16920,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -17446,7 +17480,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-da.json
+++ b/data/bestiary/creatures-da.json
@@ -360,7 +360,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec1.json
+++ b/data/bestiary/creatures-ec1.json
@@ -235,7 +235,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -543,7 +544,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -803,7 +805,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1130,7 +1133,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2440,7 +2444,8 @@
 							]
 						},
 						"constant": {}
-					}
+					},
+					"name": "Innate Primal Spells"
 				},
 				{
 					"type": "Spontaneous",
@@ -2488,7 +2493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3406,7 +3412,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -100,7 +100,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -429,7 +430,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -628,7 +630,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -845,7 +848,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1803,7 +1807,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -2444,10 +2449,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 30,
@@ -2692,7 +2698,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2927,7 +2934,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3449,10 +3457,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 1,
 					"DC": 24,
@@ -3839,10 +3848,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
-					"name": "Bloodline",
+					"name": "Bloodline Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 26,

--- a/data/bestiary/creatures-ec3.json
+++ b/data/bestiary/creatures-ec3.json
@@ -265,7 +265,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -477,7 +478,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -976,7 +978,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1371,7 +1374,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1792,7 +1796,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2622,7 +2627,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3181,7 +3187,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3804,7 +3811,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4024,7 +4032,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec4.json
+++ b/data/bestiary/creatures-ec4.json
@@ -356,7 +356,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -571,7 +572,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1236,7 +1238,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1558,10 +1561,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Wizard School",
+					"name": "Wizard School Spells",
 					"type": "Focus",
 					"DC": 36,
 					"fp": 1,
@@ -2032,7 +2036,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2269,7 +2274,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2870,10 +2876,11 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"DC": 32,
 					"fp": 3,
@@ -3425,7 +3432,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3803,7 +3811,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4016,7 +4025,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -140,7 +140,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -435,7 +436,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -994,7 +996,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -1028,7 +1031,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -1321,7 +1325,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1533,7 +1538,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1816,7 +1822,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2122,7 +2129,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2522,7 +2530,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3021,7 +3030,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3353,7 +3363,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3589,7 +3600,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -3816,7 +3828,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4009,7 +4022,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4309,7 +4323,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4586,7 +4601,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"type": "Innate",
@@ -4633,7 +4649,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ec6.json
+++ b/data/bestiary/creatures-ec6.json
@@ -388,7 +388,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -587,7 +588,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1119,7 +1121,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -1414,7 +1417,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -1775,7 +1779,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -1815,7 +1820,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -2101,7 +2107,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2399,7 +2406,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2670,7 +2678,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2928,7 +2937,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"rituals": [
@@ -3267,7 +3277,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3788,7 +3799,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"type": "Innate",
@@ -3820,7 +3832,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -317,7 +317,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -541,7 +542,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2652,7 +2654,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3339,7 +3342,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Focus",
+					"name": "Monk Focus Spells",
 					"type": "Focus",
 					"DC": 32,
 					"attack": 25,
@@ -3698,7 +3701,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -3746,7 +3750,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3899,7 +3904,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Wizard Prepared",
+					"name": "Wizard Prepared Spells",
 					"type": "Prepared",
 					"DC": 32,
 					"attack": 26,
@@ -4015,7 +4020,7 @@
 					}
 				},
 				{
-					"name": "Wizard School",
+					"name": "Wizard School Spells",
 					"type": "Focus",
 					"fp": 2,
 					"entry": {
@@ -4322,7 +4327,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4833,7 +4839,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"type": "Focus",
@@ -4857,7 +4864,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Focus Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5932,7 +5940,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				},
 				{
 					"name": "Witch Hexes",
@@ -6466,7 +6475,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Focus",
+					"name": "Focus Spells",
 					"type": "Focus",
 					"DC": 24,
 					"fp": 3,
@@ -6812,7 +6821,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -6994,7 +7004,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -7637,10 +7648,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"DC": 27,
 					"fp": 2,
@@ -7851,7 +7863,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -1349,7 +1349,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1648,10 +1649,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 34,
 					"fp": 3,
@@ -2072,7 +2074,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2283,7 +2286,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2579,7 +2583,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"defenses": {
@@ -2832,7 +2837,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"name": "Witch Hexes",
@@ -3029,7 +3035,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Ki",
+					"name": "Monk Ki Spells",
 					"type": "Focus",
 					"DC": 38,
 					"fp": 3,
@@ -3242,7 +3248,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3553,7 +3560,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3844,10 +3852,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Druid Order",
+					"name": "Druid Order Spells",
 					"type": "Focus",
 					"DC": 41,
 					"fp": 2,
@@ -4373,7 +4382,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Focus",
+					"name": "Monk Focus Spells",
 					"type": "Focus",
 					"DC": 34,
 					"fp": 3,
@@ -4598,7 +4607,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4867,7 +4877,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -5287,7 +5298,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -5794,10 +5806,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 42,
 					"fp": 2,
@@ -5949,7 +5962,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -6191,7 +6205,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -6673,10 +6688,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"DC": 35,
 					"fp": 3,
@@ -7157,7 +7173,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				},
 				{
 					"name": "Witch Hexes",
@@ -7428,7 +7445,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -7806,7 +7824,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Focus",
+					"name": "Focus Spells",
 					"type": "Focus",
 					"DC": 30,
 					"fp": 3,
@@ -8297,10 +8315,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 34,
 					"fp": 3,
@@ -8756,10 +8775,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
-					"name": "Sorcerer Bloodline",
+					"name": "Sorcerer Bloodline Spells",
 					"type": "Focus",
 					"DC": 32,
 					"fp": 3,
@@ -9063,7 +9083,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-frp3.json
+++ b/data/bestiary/creatures-frp3.json
@@ -126,7 +126,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Ki",
+					"name": "Monk Ki Spells",
 					"type": "Focus",
 					"DC": 40,
 					"attack": 32,
@@ -833,7 +833,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1076,7 +1077,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1984,7 +1986,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2254,7 +2257,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2458,7 +2462,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2899,7 +2904,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3290,7 +3296,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Monk Ki",
+					"name": "Monk Ki Spells",
 					"type": "Focus",
 					"DC": 37,
 					"attack": 28,
@@ -3487,7 +3493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4685,7 +4692,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4907,7 +4915,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -5527,7 +5536,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				},
 				{
 					"name": "Witch Hexes",

--- a/data/bestiary/creatures-gmg.json
+++ b/data/bestiary/creatures-gmg.json
@@ -82,7 +82,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 17,
 					"fp": 1,
@@ -375,7 +375,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Occult Spells Known",
+					"name": "Occult Spells Known Spells",
 					"tradition": "occult",
 					"DC": 14,
 					"entry": {
@@ -600,7 +600,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -716,7 +717,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Champion Devotion",
+					"name": "Champion Devotion Spells",
 					"type": "Focus",
 					"DC": 20,
 					"fp": 1,
@@ -1986,10 +1987,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
-					"name": "Druid Order",
+					"name": "Druid Order Spells",
 					"type": "Focus",
 					"DC": 22,
 					"fp": 1,
@@ -3046,10 +3048,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 19,
 					"attack": 10,
@@ -3254,7 +3257,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3576,7 +3580,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4063,7 +4068,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -4272,7 +4278,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -6964,7 +6971,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -7158,10 +7166,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 22,
 					"entry": {
@@ -7793,7 +7802,7 @@
 			],
 			"spellcasting": [
 				{
-					"name": "Wizard Prepared",
+					"name": "Wizard Prepared Spells",
 					"type": "Prepared",
 					"DC": 21,
 					"attack": 13,
@@ -8603,10 +8612,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 23,
 					"fp": 1,
@@ -8943,7 +8953,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"rituals": [
@@ -9269,10 +9280,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"DC": 18,
 					"fp": 1,
@@ -11426,7 +11438,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -12007,7 +12020,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-loil.json
+++ b/data/bestiary/creatures-loil.json
@@ -501,7 +501,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1041,7 +1042,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1589,7 +1591,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1759,7 +1762,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-lome.json
+++ b/data/bestiary/creatures-lome.json
@@ -335,7 +335,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -733,7 +734,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1052,7 +1054,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1220,7 +1223,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1440,7 +1444,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2028,7 +2033,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2940,7 +2946,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3600,7 +3607,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-lomm.json
+++ b/data/bestiary/creatures-lomm.json
@@ -199,7 +199,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true
@@ -526,7 +527,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true
@@ -819,7 +821,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"hasImages": true
@@ -1065,7 +1068,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			]
 		},
@@ -1406,7 +1410,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true
@@ -1818,7 +1823,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true
@@ -2336,7 +2342,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"hasImages": true
@@ -2985,7 +2992,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true
@@ -3177,7 +3185,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4006,7 +4015,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"hasImages": true

--- a/data/bestiary/creatures-ngd.json
+++ b/data/bestiary/creatures-ngd.json
@@ -1153,10 +1153,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 40,
@@ -1526,7 +1527,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"tradition": "occult",
@@ -1560,7 +1562,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2079,7 +2082,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2322,7 +2326,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -2548,7 +2553,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ooa1.json
+++ b/data/bestiary/creatures-ooa1.json
@@ -473,7 +473,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1177,7 +1178,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Focus Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ooa2.json
+++ b/data/bestiary/creatures-ooa2.json
@@ -661,7 +661,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1068,7 +1069,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1429,7 +1431,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1592,7 +1595,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1789,7 +1793,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3396,7 +3401,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-ooa3.json
+++ b/data/bestiary/creatures-ooa3.json
@@ -2296,7 +2296,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -2530,7 +2531,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sli.json
+++ b/data/bestiary/creatures-sli.json
@@ -169,7 +169,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1492,7 +1493,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
 					"tradition": "divine",
@@ -1510,7 +1512,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Focus Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1785,10 +1788,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
-					"name": "Bard Composition",
+					"name": "Bard Composition Spells",
 					"type": "Focus",
 					"DC": 28,
 					"fp": 2,

--- a/data/bestiary/creatures-sot1.json
+++ b/data/bestiary/creatures-sot1.json
@@ -134,7 +134,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -181,7 +182,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -425,7 +427,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -643,7 +646,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1448,7 +1452,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1673,7 +1678,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2515,7 +2521,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2705,7 +2712,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3050,7 +3058,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sot2.json
+++ b/data/bestiary/creatures-sot2.json
@@ -318,7 +318,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"abilities": {
@@ -858,7 +859,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1101,7 +1103,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3049,7 +3052,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -3097,7 +3101,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3583,7 +3588,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Arcane Spells"
 				},
 				{
 					"type": "Innate",
@@ -3621,7 +3627,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sot3.json
+++ b/data/bestiary/creatures-sot3.json
@@ -456,10 +456,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				},
 				{
-					"name": "Cleric Domain",
+					"name": "Cleric Domain Spells",
 					"type": "Focus",
 					"fp": 2,
 					"DC": 30,
@@ -1551,7 +1552,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -1843,7 +1845,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"rituals": [
@@ -2123,10 +2126,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				},
 				{
-					"name": "Revelation",
+					"name": "Revelation Spells",
 					"type": "Focus",
 					"fp": 3,
 					"DC": 30,
@@ -2389,7 +2393,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2611,7 +2616,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -2784,7 +2790,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3160,7 +3167,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -3527,7 +3535,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3969,7 +3978,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4152,7 +4162,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sot4.json
+++ b/data/bestiary/creatures-sot4.json
@@ -186,7 +186,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -639,7 +640,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -912,7 +914,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -1367,7 +1370,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2344,7 +2348,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3252,7 +3257,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3448,7 +3454,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -3690,7 +3697,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				},
 				{
 					"tradition": "primal",
@@ -3817,7 +3825,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Primal Spells"
 				}
 			],
 			"abilities": {
@@ -4024,7 +4033,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4189,7 +4199,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4410,7 +4421,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {
@@ -4865,7 +4877,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Divine Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sot5.json
+++ b/data/bestiary/creatures-sot5.json
@@ -276,7 +276,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -481,7 +482,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -727,7 +729,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -1255,7 +1258,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1711,7 +1715,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"rituals": [
@@ -2391,10 +2396,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Magus Conflux",
+					"name": "Magus Conflux Spells",
 					"type": "Focus",
 					"fp": 2,
 					"entry": {
@@ -2873,7 +2879,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				}
 			],
 			"abilities": {
@@ -3149,10 +3156,11 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
-					"name": "Magus Conflux",
+					"name": "Magus Conflux Spells",
 					"type": "Focus",
 					"fp": 2,
 					"entry": {
@@ -3381,7 +3389,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4570,7 +4579,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-sot6.json
+++ b/data/bestiary/creatures-sot6.json
@@ -1800,7 +1800,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -2945,7 +2946,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
 					"tradition": "arcane",
@@ -2962,7 +2964,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Arcane Spells"
 				}
 			],
 			"rituals": [
@@ -3216,7 +3219,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Primal Spells"
 				}
 			],
 			"abilities": {
@@ -3637,7 +3641,8 @@
 								]
 							}
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"rituals": [
@@ -4144,7 +4149,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"tradition": "occult",
@@ -4185,7 +4191,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4497,7 +4504,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				},
 				{
 					"tradition": "occult",
@@ -4520,7 +4528,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -4849,7 +4858,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				},
 				{
 					"tradition": "occult",
@@ -4872,7 +4882,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {
@@ -5161,7 +5172,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Occult Spells"
 				},
 				{
 					"tradition": "occult",
@@ -5184,7 +5196,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				},
 				{
 					"name": "Witch Hexes",
@@ -5576,7 +5589,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Spontaneous Occult Spells"
 				},
 				{
 					"tradition": "occult",
@@ -5599,7 +5613,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Occult Spells"
 				}
 			],
 			"abilities": {

--- a/data/bestiary/creatures-tal.json
+++ b/data/bestiary/creatures-tal.json
@@ -74,7 +74,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Primal Spells"
 				}
 			]
 		}

--- a/data/bestiary/creatures-tio.json
+++ b/data/bestiary/creatures-tio.json
@@ -513,7 +513,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Divine Spells"
 				}
 			],
 			"abilities": {
@@ -862,7 +863,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {
@@ -1102,7 +1104,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Prepared Arcane Spells"
 				}
 			],
 			"abilities": {
@@ -1569,7 +1572,8 @@
 								}
 							]
 						}
-					}
+					},
+					"name": "Innate Divine Spells"
 				}
 			],
 			"abilities": {

--- a/js/converter.js
+++ b/js/converter.js
@@ -1099,18 +1099,12 @@ class Converter {
 		const spellMatch = reSpellCast.exec(castingToken.value);
 		const name = spellMatch[1].trim();
 
+		casting.name = name.toTitleCase();
 		const tradition = this._tokenizerUtils.spellTraditions.find(it => it.regex.test(name));
 		const type = this._tokenizerUtils.spellTypes.find(it => it.regex.test(name));
 		if (tradition) casting.tradition = tradition.unit.toLowerCase();
 		if (type) casting.type = type.unit.toTitleCase();
 		else casting.type = "Focus";
-
-		if (!casting.type || !casting.tradition
-			|| (!name.localeCompare(`${casting.type} ${casting.tradition}`, { sensitivity: "base" })
-				&& !name.localeCompare(`${casting.tradition} ${casting.type}`, { sensitivity: "base" }))
-		) {
-			casting.name = name;
-		}
 
 		this._parseSpells_parseProperties(casting);
 		casting.entry = this._parseSpellEntry();

--- a/js/render.js
+++ b/js/render.js
@@ -4477,11 +4477,10 @@ Renderer.creature = {
 			let renderStack = [];
 			for (let sc of cr.spellcasting) {
 				const meta = [];
-				let spellcastingName = sc.name ? sc.name : `${sc.tradition} ${sc.type}`.toTitleCase();
 				if (sc.DC != null) meta.push(`DC ${sc.DC}`);
 				if (sc.attack != null) meta.push(`attack {@hit ${sc.attack}||Spell attack}`);
 				if (sc.fp != null) meta.push(`${sc.fp} Focus Points`);
-				renderStack.push(`<p class="pf2-stat pf2-stat__section"><strong>${spellcastingName}${/Spell/.test(spellcastingName) ? "" : " Spells"}&nbsp;</strong>`)
+				renderStack.push(`<p class="pf2-stat pf2-stat__section"><strong>${sc.name}&nbsp;</strong>`)
 				if (sc.note != null) renderStack.push(`${renderer.render(sc.note)} `)
 				renderStack.push(renderer.render(meta.join(", ")))
 				Object.keys(sc.entry).sort(SortUtil.sortSpellLvlCreature).forEach((lvl) => {

--- a/js/tokenizer.js
+++ b/js/tokenizer.js
@@ -305,9 +305,9 @@ class TokenizerUtils {
 	// We would need to predict or test next tokens to do this cleanly. Other alternative is checking while converting (easier)
 	static get spellCasting () {
 		return [
-			{regex: /^((?:Arcane|Divine|Occult|Primal)\s(?:Innate|Prepared|Spontaneous)?)\s?Spells?/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
-			{regex: /^((?:Innate|Prepared|Spontaneous)\s(?:Arcane|Divine|Occult|Primal)?)\s?Spells?/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
-			{regex: /^((?:[A-Z][a-z]+ )+)Spells\s(?![A-Z][a-z])/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
+			{regex: /^((?:Arcane|Divine|Occult|Primal)\s(?:Innate|Prepared|Spontaneous)?\s?Spells?)/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
+			{regex: /^((?:Innate|Prepared|Spontaneous)\s(?:Arcane|Divine|Occult|Primal)?\s?Spells?)/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
+			{regex: /^((?:[A-Z][a-z]+\s)+Spells)\s(?![A-Z][a-z])/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
 			{regex: /^(Witch Hexes)/, type: "SPELL_CASTING", lookbehind: /\n$/, mode: "cr_spells"},
 		]
 	}

--- a/node/update-jsons.js
+++ b/node/update-jsons.js
@@ -314,6 +314,14 @@ function updateFolder (folder) {
 							) {
 								delete k.name;
 							}
+							if (!k.name && k.type && k.tradition) {
+								k.name = `${k.type} ${k.tradition} Spells`.toTitleCase();
+							} else if (!k.name.endsWith(" Spells")) {
+								// Exceptions to spellcasting naming that don't end in " Spells"
+								if (k.name !== "Witch Hexes") {
+									k.name = `${k.name} Spells`.toTitleCase();
+								}
+							}
 
 							const mapSpellLevel = (l) => {
 								l.spells = l.spells.map(s => {


### PR DESCRIPTION
`Witch Hexes` spellcasting entries are currently rendered as `Witch Hexes Spells` as we add the trailing ` Spells` in the renderer.

This PR takes the approach of simply storing the full spellcasting name in the data which the renderer outputs unmodified.
The current data is updated via `update-jsons.js` and the text converter is adjusted as well.

Alternatively, `Witch Hexes` could also be special cased in the renderer or a data property added if ` Spells` should be appended when rendering.