### PR TITLE
Various fixes and add some missing AoA5 elements

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -6992,6 +6992,574 @@
 					}
 				}
 			]
+		},
+		{
+			"name": "Haul Supplies",
+			"source": "AoA5",
+			"page": 13,
+			"traits": [
+				"exploration",
+				"move"
+			],
+			"entries": [
+				"You pack up as many supplies as you can carry and make your way back to Bazal's Basin with food and water. Attempt a DC 34 {@skill Athletics} check to determine the amount and quality of the food you manage to haul and keep safe from being damaged in the storm. A character who uses powerful magic (such as {@spell teleport}) to aid in transporting the food automatically achieves a result one category higher than they roll.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "You return with 15 Bulk of supplies.",
+						"Success": "You return with 10 Bulk of supplies.",
+						"Failure": "Some of the food was damaged in transport, and you return with only 5 Bulk of supplies.",
+						"Critical Failure": "All of the supplies you attempted to transport are ruined."
+					}
+				}
+			]
+		},
+		{
+			"name": "Build Connections",
+			"source": "AoA5",
+			"page": 18,
+			"traits": [
+				"downtime"
+			],
+			"entries": [
+				"You dedicate a day to making friends in high places, typically by inviting yourself to parties, performing small favors to be repaid later, and generally projecting an aura of confidence and capability. Attempt a DC 36 {@skill Crafting}, {@skill Diplomacy}, {@skill Performance}, or appropriate {@skill Lore} check. The result determines the impact of your efforts. If you have the {@feat Connections} skill feat and roll a success, you get a critical success instead.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "For 1 month, you gain a +1 circumstance bonus to your skill checks to pursue the downtime activities listed here. You also earn a single favor that you can call in when you or an ally you're working with attempts a skill check for one of these downtime actions. That creature can roll twice and use the better result, after which the favor is considered repaid; calling in the favor is a fortune effect.",
+						"Success": "For 1 week, you gain a +1 circumstance bonus to your skill checks for the downtime activities listed here.",
+						"Critical Failure": "A faux pas embarrasses you, and rumors recount the incident widely. For 3 days, you take a \u20131 circumstance penalty to skill checks for the downtime activities listed here."
+					}
+				}
+			]
+		},
+		{
+			"name": "Host Event",
+			"source": "AoA5",
+			"page": 18,
+			"traits": [
+				"downtime"
+			],
+			"entries": [
+				"You dedicate a day to planning and hosting a special event, such as a feast, a small festival, or a public performance. Doing so requires an expenditure of 250 gp. Attempt a DC 36 {@skill Diplomacy}, {@skill Performance}, {@skill Society}, or appropriate {@skill Lore} check. The result determines the impact of your efforts. You gain a cumulative +1 circumstance bonus to this check (maximum +4) for each additional 250 gp you spend on the event.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "Each PC gains a +2 circumstance bonus to skill checks to perform downtime activities for the next 3 days. Also, reduce the Support Points of two different guilds of your choice by 1 (see {@action Influence Guild}).",
+						"Success": "Each PC gains a +1 circumstance bonus to skill checks to perform downtime activities the following day. In addition, reduce the Support Points of one guild of your choice by 1 (see {@action Influence Guild}).",
+						"Critical Failure": "The party is a disaster. Each PC takes a \u20132 circumstance penalty to skill checks to perform downtime activities the following day."
+					}
+				}
+			]
+		},
+		{
+			"name": "Influence Guild",
+			"source": "AoA5",
+			"page": 19,
+			"traits": [
+				"downtime"
+			],
+			"entries": [
+				"You dedicate a day to befriending members of a particular guild, assisting the organization, and convincing the guild members not to support the Scarlet Triad. Attempt a DC 34 skill check tied to one of the organization's favored skills (pages 20\u201321).",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "Reduce that organization's Support Points by 3.",
+						"Success": "Reduce that organization's Support Points by 1.",
+						"Critical Failure": "Increase that organization's Support Points by 1."
+					}
+				}
+			]
+		},
+		{
+			"name": "Issue Challange",
+			"source": "AoA5",
+			"page": 20,
+			"traits": [
+				"downtime"
+			],
+			"entries": [
+				"You spend a day promoting your combat abilities, trash-talking the competition, calling out the leadership of the Gladiators' Guild, or performing public feats of bravado to compel the guildmaster of the Gladiators' Guild to accept your challenge to rule over the arena. This action ties specifically into Task 3: Blood on the Sand (page 32). Attempt a DC 36 {@skill Athletics}, {@skill Deception}, {@skill Intimidation}, {@skill Performance}, or appropriate {@skill Lore} skill check.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "You provoke Bshez Shak into accepting your challenge.",
+						"Success": "You weaken Bshez's resolve. For the next 7 days, your checks to Issue Challenges gain a cumulative +1 circumstance bonus (maximum +4).",
+						"Critical Failure": "Your boisterousness accidentally leads to embarrassment that undermines your stature. You lose any circumstance bonuses you've earned as a result of successful Issued Challenges, and can't Issue a Challenge the next day."
+					}
+				}
+			]
+		},
+		{
+			"name": "Contact Steel Falcons",
+			"source": "AoA5",
+			"page": 23,
+			"traits": [
+				"downtime"
+			],
+			"overcome": "DC 32 {@skill Lore||Andoran Lore}, DC 36 {@skill Diplomacy}, DC 34 {@skill Society}",
+			"special": [
+				"If the PCs don't succeed at this Opportunity, the Steel Falcons independently decide to launch their own heist that overlaps with\u2014and potentially interferes with\u2014the PCs' heist. See the Unexpected Falcons Complication on page 26."
+			],
+			"entries": [
+				"The PC surreptitiously tries to contact the Steel Falcons in Katapesh.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Success": "The PC arranges a meeting with the Steel Falcons. They're eager to combine forces with powerful operatives like the PCs in the name of liberating the oppressed, and they can provide information about the upcoming auction equivalent to a {@action Gather Information} success. In addition, the Steel Falcons grant the PCs 1 Edge Point.",
+						"Failure": "The PC fails to make contact.",
+						"Critical Failure": "The PC's clumsy attempt spooks the Steel Falcons. Future attempts at this activity take a \u20132 circumstance penalty."
+					}
+				}
+			]
+		},
+		{
+			"name": "Forge Documents",
+			"source": "AoA5",
+			"page": 23,
+			"traits": [
+				"downtime",
+				"secret"
+			],
+			"overcome": "DC 34 {@skill Society}",
+			"entries": [
+				"The PC prepares several forgeries that might serve as convincing props during the heist.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Success": "The PC creates convincing documents that grant the PCs 1 Edge Point they can use when presenting proper credentials, work orders, or invitations.",
+						"Failure": "The PC creates somewhat unconvincing documents. Inform the PCs the forgeries grant 1 Edge Point. However, when they use that Edge Point, it grants no benefit.",
+						"Critical Failure": "As failure, but a PC who uses the Edge Point on a failure gets a critical failure instead."
+					}
+				}
+			]
+		},
+		{
+			"name": "Gather Information",
+			"source": "AoA5",
+			"page": 24,
+			"traits": [
+				"downtime",
+				"secret"
+			],
+			"overcome": "DC 35 {@skill Diplomacy}",
+			"entries": [
+				"The PC seeks out rumors about Exavisu's status and location.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "The PCs learn information as a success, plus supporting details that assist in their preparations. The PCs gain a +2 circumstance bonus to checks to perform legwork tasks from this point on. In addition, the PC learns that the scheduling of the auction experienced some delays due to disagreements between the Scarlet Triad and Fleshmongers' Federation over how to split profits\u2014in the face of the gradual constriction of slave market, the longtime allies are both great taking pains to maintain their own profits without undercutting each other.",
+						"Success": "The PC learns that while nobody knows where Exavisu Kerndallion and her enslaved colleagues are, a private auction has been scheduled for the evening of 15 Neth, to be held at the Bhetshamtal Estate in Katapesh's Inner City. Invitations are nearly impossible to come by, and the audience is expected to include a large number of extraplanar bidders. Exavisu is among the slaves up for sale. Shipments into and out of the estate suggest preparations are already underway for the exclusive event, and the slaves are likely being kept off-site until the event begins.",
+						"Failure": "The PC learns nothing.",
+						"Critical Failure": "The PC learns a few misleading rumors that give the PCs a \u20132 circumstance penalty to their next check for a legwork task."
+					}
+				}
+			]
+		},
+		{
+			"name": "Secure Disguises",
+			"source": "AoA5",
+			"page": 24,
+			"traits": [
+				"downtime"
+			],
+			"overcome": "DC 35 {@skill Crafting}, DC 33 {@skill Deception}, DC 35 {@skill Performance}, DC 37 {@skill Society}",
+			"entries": [
+				"The PC tries to find disguises of a certain type (guards, for example, or socialites).",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Success": "The PC finds or creates useful disguises that grant 1 Edge Point that the PCs can use for maintaining a cover identity.",
+						"Failure": "The PC finds no disguises."
+					}
+				}
+			]
+		},
+		{
+			"name": "Secure Invitation",
+			"source": "AoA5",
+			"page": 24,
+			"traits": [
+				"downtime"
+			],
+			"overcome": "DC 35 {@skill Crafting}, DC 35 {@skill Society}",
+			"entries": [
+				"The PC seeks out someone with an invitation they're willing to sell.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "The PC finds an invitation-holder and convinces them to give away the invitation for free. The PCs gain 1 Edge Point.",
+						"Success": "The PC finds someone willing to sell their invitation for 250 gp. If they pay, the group gets 1 Edge Point. They can attempt to steal it instead (DC 34 {@skill Thievery}), but if they do, increase Awareness at the beginning of Phase 2: Infiltration by 2.",
+						"Failure": "The PC is unable to find an invitation."
+					}
+				}
+			]
+		},
+		{
+			"name": "Scout the Facility",
+			"source": "AoA5",
+			"page": 24,
+			"traits": [
+				"downtime"
+			],
+			"overcome": "DC 36 {@skill Perception}, DC 38 {@skill Society}, DC 34 {@skill Stealth}",
+			"entries": [
+				"The PC spends part of the day observing the Bhetshamtal Estate, recording patrols, noting escape routes, and creating a mental map.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Success": "The PC makes decisive observations that grant the PCs 1 Edge Point that can be used for sneaking through or navigating the estate.",
+						"Failure": "The PC learns nothing noteworthy.",
+						"Critical Failure": "The PC misjudges some element of the security. Inform the PCs that the scouting grants 1 Edge Point. When they use that Edge Point, they don't get the normal benefit, and if they rolled a normal failure they get a critical failure instead."
+					}
+				}
+			]
+		},
+		{
+			"name": "Dimensional Interference",
+			"source": "AoA5",
+			"page": 26,
+			"traits": [
+				"exploration"
+			],
+			"trigger": "The PCs attempt to use a teleportation effect.",
+			"overcome": "2 successes; DC 35 {@skill Arcana}, {@skill Nature}, {@skill Occultism}, or {@skill Religion}",
+			"entries": [
+				"Some of the protective wards in Bhetshamtal Estate provide magical static that causes teleportation effects to fail. If the PCs intend to just teleport away to safety, they need to disable these wards. This Complication is unlikely to arise until the PCs try to teleport and fail."
+			]
+		},
+		{
+			"name": "Do I Know You?",
+			"source": "AoA5",
+			"page": 26,
+			"traits": [
+				"exploration"
+			],
+			"trigger": "Awareness reaches 5 or 10.",
+			"overcome": "DC 30 {@skill Deception}, DC 35 {@skill Diplomacy}, DC 28 {@skill Performance}, DC 32 {@skill Stealth}",
+			"entries": [
+				"A partygoer or worker thinks they recognize one of the PCs, attracting unwanted attention. That PC either convinces them otherwise before slipping away or finds a way to dodge the bystander entirely."
+			]
+		},
+		{
+			"name": "Unexpected Falcons",
+			"source": "AoA5",
+			"page": 26,
+			"traits": [
+				"exploration"
+			],
+			"requirements": "The PCs got a critical failure while attempting to {@action Contact Steel Falcons|AoA5}. This Complication can occur whenever the GM sees fit.",
+			"overcome": "3 successes; DC 35 {@skill Deception}, DC 33 {@skill Diplomacy}, DC 37 {@skill Intimidation}",
+			"entries": [
+				"The Steel Falcons are performing their own heist to rescue their captain, Wallen Iuphasti, and they and the PCs encounter each other suddenly. Expecting trouble, the Steel Falcons have weapons drawn and are poised to attack. To overcome this encounter, the PCs quickly talk down the Andoren operatives.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Failure": "The Steel Falcons become more vocal and threatening, and a brief fight breaks out. This increases the Awareness Point total by 3 (instead of the normal 1 for a failure).",
+						"Critical Failure": "As failure, but increase Awareness by 5."
+					}
+				}
+			]
+		},
+		{
+			"name": "Unexpected Patrol",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"trigger": "Awareness reaches 6 or 10.",
+			"overcome": "2 successes; DC 37 {@skill Deception}, DC 37 {@skill Perception}, DC 35 {@skill Stealth}",
+			"entries": [
+				"The PCs notice a group of guards on patrol that's only seconds away from stumbling upon them. The PCs seek out a place to hide, look for a alternate route around the guards, or craft cunning lies."
+			]
+		},
+		{
+			"name": "Blend In",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "DC 35 {@skill Deception}, DC 37 {@skill Society}, DC 35 {@skill Stealth}",
+			"entries": [
+				"Sometimes the best option for crossing a crowded party is to act natural and join the crowd.",
+				"If a PC successfully Blends In, roll a secret DC 34 {@skill Perception} check for them to notice that something seems off about one of the guests. On a success, inform them about the {@action Dispel a Disguise|AoA5} Opportunity."
+			]
+		},
+		{
+			"name": "Breaking and Entering",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "DC 37 {@skill Acrobatics}, DC 35 {@skill Athletics}, DC 35 {@skill Nature}, DC 35 {@skill Stealth}, DC 35 {@skill Thievery}",
+			"special": [
+				"If a PC successfully Breaks and Enters, they can attempt a DC 35 {@skill Perception} check to notice a set of keys carried by a guard or resting in a somewhat hard-to-reach area, allowing for that PC to take the {@action Steal Keys|AoA5} Opportunity."
+			],
+			"entries": [
+				"The PCs scale the walls, calm the guard dogs, hide from guards, and unlock gates."
+			]
+		},
+		{
+			"name": "Cunning Disguise",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "DC 35 {@skill Deception} or DC 33 (see below)",
+			"entries": [
+				"The PCs conceal their true identities, relying on false personas to be admitted onto the estate. A PC can use a skill closely connected to their chosen disguise in place of {@skill Deception}, such as {@skill Intimidation} for a guard, {@skill Lore||Guild Lore} for a merchant, or any food-related {@skill Lore} for a caterer.",
+				"If a PC succeeds at a Cunning Disguise, roll a secret DC 34 {@skill Perception} check for them to notice something off about one of the guests. On a success, inform them about the {@action Dispel a Disguise|AoA5} Opportunity."
+			]
+		},
+		{
+			"name": "Smuggled",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "DC 33 {@skill Stealth}",
+			"special": [
+				"This process leaves participating PCs disheveled, imposing a \u20131 circumstance penalty to checks tied to appearing well groomed or professional."
+			],
+			"entries": [
+				"The PCs hide themselves inside carts, wine barrels, or other large containers that are bound for the estate. This deposits them inside the walls but a distance from the manor."
+			]
+		},
+		{
+			"name": "Dispel a Disguise",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration",
+				"secret"
+			],
+			"requirements": "When {@action Blending In|AoA5} or using a {@action Cunning Disguise|AoA5}, a PC has noticed something is off about a guest.",
+			"overcome": "DC 35 {@skill Arcana}, DC 33 {@skill Occultism}, DC 37 {@skill Perception}",
+			"entries": [
+				"The PC is sure there's more to Baroness Epminia Fahlspar than meets the eye. They're right\u2014she's Reloon, a rakshasa in disguise!",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "The PC sees through the disguise and identifies a way to unveil the rakshasa without magic. Rakshasas are not unwelcome here, but the sudden reveal of Reloon's natural form and her dismayed outburst draws the attention of many partyers. Reduce Awareness by 2 (minimum 0).",
+						"Success": "The PC senses the magical disguise. To overcome this Opportunity, a PC must either magically counteract the disguise or succeed at a DC 40 {@skill Deception} or {@skill Intimidation} check to cause the baroness's concentration to waver, briefly disrupting her disguise. This reveals her, as described under critical success.",
+						"Failure": "The PC sees no evidence of a disguise.",
+						"Critical Failure": "The PC sees no evidence of a disguise, and their scrutiny invites a loud dressing down by the baroness."
+					}
+				}
+			]
+		},
+		{
+			"name": "Smooth the Path",
+			"source": "AoA5",
+			"page": 27,
+			"traits": [
+				"exploration"
+			],
+			"requirements": "The PC has successfully infiltrated the estate.",
+			"entries": [
+				"Now that they're on the inside, the PC helps an ally who's still trying to infiltrate. They describe what they're doing to help, and give the ally the benefits of {@action Following the Expert}. The GM might require the PC to attempt a relevant skill check (typically DC 32) to Smooth the Path."
+			]
+		},
+		{
+			"name": "Steal Keys",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"requirements": "PCs noticed the keys while {@action Breaking and Entering|AoA5}.",
+			"overcome": "DC 35 {@skill Thievery}",
+			"entries": [
+				"The PC steals a ring of keys that can unlock many of the manor's doors.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Success": "The PCs gain 1 Edge Point usable for opening locks."
+					}
+				}
+			]
+		},
+		{
+			"name": "Diviner on Duty",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"trigger": "A PC uses magic to aid in overcoming an Obstacle during infiltration.",
+			"overcome": "3 successes; DC 35 {@skill Arcana}, DC 37 {@skill Deception}, DC 35 {@skill Nature}, DC 35 {@skill Occultism}, DC 35 {@skill Religion}",
+			"entries": [
+				"Among the Scarlet Triad's security is a highly competent diviner! With spells such as {@spell discern lies}, {@spell mind reading}, {@spell see invisibility}, and {@spell true seeing}, this diviner can see through most magical schemes the PCs might use.",
+				"The diviner is watching for magical threats, not poison. With a successful DC 33 {@skill Deception}, {@skill Thievery}, or food-related {@skill Lore} check, a PC can trick her into consuming something laden with an ingested poison. Her Fortitude save bonus is +23, and she withdraws if successfully poisoned. If not successfully poisoned, increase the PCs' Awareness Points by 2."
+			]
+		},
+		{
+			"name": "Deadly Traps",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "2 successes; DC 34 {@skill Arcana} or DC 34 {@skill Thievery}",
+			"special": [
+				"If a PC fails a check to overcome this scene, they trigger a trap that deals {@damage 16d6} damage to that PC (DC 36 basic Reflex). If the PC critically fails, it deals this damage to all PCs in the scene."
+			],
+			"entries": [
+				"The PCs suppress or disable dangerous traps set to kill would-be thieves and make an explosive ruckus."
+			]
+		},
+		{
+			"name": "Find the Cells",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "3 successes; DC 33 {@skill Lore||Architecture Lore}, DC 35 {@skill Perception}, DC 35 {@skill Survival}",
+			"entries": [
+				"The PCs identify an efficient route through the manor and reach the holding cells and vaults in the basement\u2014all without opening too many doors, making too much noise, or wasting time searching for secret doors."
+			]
+		},
+		{
+			"name": "Locked Doors",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "2 successes; DC 35 {@skill Athletics}, DC 35 {@skill Thievery}",
+			"entries": [
+				"Most of the manor is locked to prevent guests from wandering into restricted areas. The PCs quietly break into rooms or unlock doors."
+			]
+		},
+		{
+			"name": "Breaking the Chains",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"requirements": "The PCs have overcome the other three Obstacles for this phase.",
+			"overcome": "2 successes; DC 37 {@skill Athletics}, DC 33 {@skill Thievery}",
+			"entries": [
+				"The captives are sealed behind bars and chained to the walls. The PCs undo these bindings as quietly as possible. Once the PCs defeat this Obstacle, they have freed Exavisu and one of her assistants and can begin Phase 4: Extraction. See the {@action That's Not Everyone|AoA5} Complication for more options."
+			]
+		},
+		{
+			"name": "Loot the Vaults",
+			"source": "AoA5",
+			"page": 28,
+			"traits": [
+				"exploration"
+			],
+			"requirements": "The PCs have reached the basement by Overcoming the {@action Find the Cells|AoA5} Obstacle.",
+			"overcome": "2 successes; {@skill Arcana} DC 33, {@skill Perception} DC 35, {@skill Thievery} DC 35",
+			"entries": [
+				"In addition to the captives, the Scarlet Triad has stored numerous treasures in the manor's basement. The PCs take several minutes to unlock a vault and identify the best objects to steal.",
+				"This Opportunity can be completed twice. The first time, the PCs recover a {@item Nethysian bulwark|AoA5}, a broad crystal bowl inlaid with faience designs of ibises (worth 300 gp), and an onyx-and-marble statue of {@deity Nethys} (worth 200 gp). In addition, the PCs also find a ledger detailing many Scarlet Triad transactions. With a successful DC 28 {@skill Lore||Guild Lore} or a DC 35 {@skill Society} check, a PC paging through the ledger determines that the Scarlet Triad has been dodging taxes, undercutting competition, and attempting to accumulate a lot of money very quickly\u2014all in ways that quietly harm the Fleshmonger Federation, Aspis Consortium, and church of Abadar. Once for each guild, a PC can use the ledger when Influencing a Guild to reduce that organization's Support Points by an additional 2 points.",
+				"The second time the PCs complete this Opportunity, they recover a {@item belt of regeneration}, as well as an alabaster-and-silver amphoriskos perfume bottle within which is bound the djinni vizier (Bestiary 162) Palqari the Wise. The Scarlet Triad trapped Palqari and offered him freedom in exchange for three wishes. Uri Zandivar already used two of these wishes to assist with the repair of the {@i Orb of Gold Dragonkind}, but then refrained from redeeming his last wish. Palqari is amenable to granting this last wish to the PCs if they help him escape; until then, he can't travel more than 20 feet from his amphoriskos, nor can he move it himself. This {@spell wish} can be used to automatically rescue all of the slaves, but the PCs will still need to escape on their own (see Extraction below). Although Palqari is eager to return to the {@place Plane of Air}, he could become a recurring ally later in the adventure at your discretion.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Failure": "The PCs are noticed by a group of guards. Play out this combat using the Basement Rooms map on page 24; this encounter is with a {@creature Scarlet Triad enforcer|AoA5}, a {@creature Scarlet Triad mage|AoA5}, and two {@creature calikang|AoA5|calikangs}. At the end of every round of combat, Awareness increases by 1."
+					}
+				}
+			]
+		},
+		{
+			"name": "That's Not Everyone",
+			"source": "AoA5",
+			"page": 29,
+			"traits": [
+				"exploration"
+			],
+			"trigger": "The PCs complete {@action Break the Chains|AoA5}",
+			"entries": [
+				"The enslaved members of the Jewelers' Guild were not all kept in one place. If the PCs intend to rescue all three assistants and Benneb, the missing antiquities dealer from Finderplain, they need to repeat either the {@action Break the Chains|AoA5} or {@action Locked Doors|AoA5} Obstacle a second time. The PCs can skip this Complication, but doing so impacts their rewards (page 30)."
+			]
+		},
+		{
+			"name": "Impromptu Tour",
+			"source": "AoA5",
+			"page": 29,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "3 successes; DC 33 {@skill Lore||Architecture Lore}, DC 36 {@skill Deception}, DC 34 {@skill Society}, DC 37 {@skill Stealth}",
+			"entries": [
+				"In anticipation of the auction, Jelek Jaziman has gathered groups of guests to explore the manor in guided tours. The PCs can try to avoid notice, or\u2014by blending in with a group and making informed statements about the artwork\u2014they can deflect attention long enough to slip away."
+			]
+		},
+		{
+			"name": "Obstructed Route",
+			"source": "AoA5",
+			"page": 29,
+			"traits": [
+				"exploration"
+			],
+			"overcome": "2 successes; DC 33 {@skill Acrobatics}, DC 33 {@skill Lore||Architecture Lore}, DC 37 {@skill Athletics}, DC 35 {@skill Perception}",
+			"entries": [
+				"The PCs' intended route is utterly impassible, perhaps due to witnesses, magical barriers, or collateral damage. The PCs squeeze through tight spaces, push aside the obstruction, or identify a quick alternate route."
+			]
+		},
+		{
+			"name": "Pander to the Crowd",
+			"source": "AoA5",
+			"page": 33,
+			"traits": [
+				"auditory",
+				"concentrate",
+				"emotion",
+				"visual"
+			],
+			"requirements": "This is your first action in a gladiatorial match, or you've damaged or visibly impeded a foe while fighting a gladiatorial match.",
+			"entries": [
+				"With a mocking gesture, a triumphant flourish, or a bold challenge, you inspire the crowd to cheer you on. Attempt an {@skill Acrobatics}, {@skill Athletics}, {@skill Intimidation}, or {@skill Performance} check, with a DC typically set by the encounter's level. Crowds grow bored with repetition though; and attempting to Pander to the Crowd using the same skill that was used the last time someone used this action imposes a \u20132 circumstance penalty on the check. If you critically succeeded at an attack roll this turn, you gain a +2 circumstance bonus to your Pander to the Crowd attempt.",
+				{
+					"type": "successDegree",
+					"entries": {
+						"Critical Success": "The crowd goes wild! You can either give yourself a +3 status bonus to attack rolls, damage rolls, saving throws, and skill checks until the end of your next turn, or give yourself and all your allies a +2 status bonus to the same rolls until the end of your next turn.",
+						"Success": "You appeal to the crowd. As critical success, but the bonus is +2 just for you, or +1 for you and your allies.",
+						"Failure": "You don't make an impression.",
+						"Critical Failure": "Your pandering is laughable, and the crowd begins to favor your opponents. The next creature hostile to you that attempts to Pander to the Crowd gains a +4 circumstance bonus to the check."
+					}
+				}
+			]
+		},
+		{
+			"name": "Scout Duneshadow",
+			"source": "AoA5",
+			"page": 36,
+			"traits": [
+				"concentrate",
+				"exploration",
+				"move"
+			],
+			"entries": [
+				"Duneshadow's known to traverse a wide territory in north- central Katapesh, and the PCs first need to narrow down his current location to within a few miles. A full scouting attempt takes 4 hours, during which each PC attempts a skill check chosen from the following options, depending on how they wish to scout: {@skill Diplomacy} DC 40 (to ask local nomads about sightings) or {@skill Nature} DC 36 (to know about camel behavior and where Duneshadow might best be found). At your discretion, a PC can substitute an appropriate {@skill Lore} skill for any of these skills, in which case the DC is reduced by 2.",
+				"To find the camel's trail, the party must successfully Scout Duneshadow three times. Critical successes count as two successes, and critical failures negate one success. If all PCs abandon this task and no one is Scouting Duneshadow, the number of accumulated successes resets to zero. Magic such as {@spell discern location} gives two successes toward finding Duneshadow, though he moves so often and in such odd ways that even in the 10 minutes it takes to {@spell teleport}, only his trail will remain.",
+				"Once they get three successes, the PCs can then Track him (DC 40). They need to succeed twice in a row or critically succeed once, and can try again on a failure. On a critical failure, the PCs must wait at least 24 hours before Scouting Duneshadow again."
+			]
+		},
+		{
+			"name": "Approach Duneshadow",
+			"source": "AoA5",
+			"page": 36,
+			"traits": [
+				"concentrate",
+				"exploration",
+				"move"
+			],
+			"entries": [
+				"Once the PCs have Tracked Duneshadow, they begin intermittently sighting him atop distant hills, hear his bellowing calls, or sense other signs that he's near. The camel is remarkably cunning and stealthy, able to exploit heat shimmers to hide his movements, predict hunters' next steps, and make exceptional use of the terrain. All the while, his path leads the PCs farther into the foothills of the Brazen Peaks.",
+				"An attempt to Approach Duneshadow is a slow and deliberate activity that takes 1 hour to perform, during which each PC attempts a skill check chosen from the following options: {@skill Acrobatics} or {@skill Athletics} DC 37 (to approach quickly via a shortcut), {@skill Deception} DC 38 (to trick Duneshadow into evading pursuit in the wrong direction), {@skill Nature} DC 35 (to keep Duneshadow calm and appear non-threatening), {@skill Performance} DC 34 (to intrigue Duneshadow with calming music), or {@skill Stealth} DC 36 (to approach undetected). {@skill Lore} skills can be substituted for any of these skills, reducing the DC by 2.",
+				"To reach Duneshadow, the party must successfully Approach four times. Critical successes count as two successes, and critical failures negate one success. If this reduces the total to two or fewer, Duneshadow runs off and the PCs must Scout for his location all over again."
+			]
 		}
 	]
 }

--- a/data/archetypes.json
+++ b/data/archetypes.json
@@ -33,7 +33,7 @@
 						"auto": true
 					},
 					"entries": [
-						"Over many generations, the magic of the hood was proven true, and more than that, the magic continued to grow and evolve with ever-more-ursine attributes. As the belief and power of each new wearer soaked into the hood, the artifact’s potential has continued to grow. Now, those who bond with the generational artifact will discover that the {@i Ursine Avenger Hood} continues to grow in power alongside them."
+						"Over many generations, the magic of the hood was proven true, and more than that, the magic continued to grow and evolve with ever-more-ursine attributes. As the belief and power of each new wearer soaked into the hood, the artifact's potential has continued to grow. Now, those who bond with the generational artifact will discover that the {@i Ursine Avenger Hood} continues to grow in power alongside them."
 					]
 				},
 				"{@note This archetype is a part of the {@item Ursine Avenger Hood|TV} artifact.}"

--- a/data/bestiary/creatures-aoa3.json
+++ b/data/bestiary/creatures-aoa3.json
@@ -261,7 +261,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"entries": [],
 						"generic": {
 							"tag": "ability"
 						}

--- a/data/bestiary/creatures-aoa5.json
+++ b/data/bestiary/creatures-aoa5.json
@@ -97,7 +97,7 @@
 							"sonic"
 						],
 						"entries": [
-							"The aluum enforcer emits a keening wail in a 15-foot cone that deals {@damage 9d6} sonic damage (DC 27 basic Fortitude save). A creature that fails its save is {@condition stunned|CRB|stunned 1}, or stunne."
+							"The aluum enforcer emits a keening wail in a 15-foot cone that deals {@damage 9d6} sonic damage (DC 27 basic Fortitude save). A creature that fails its save is {@condition stunned|CRB|stunned 1}, or {@condition stunned|CRB|stunned 3} on a critical failure. The aluum can't use Soul Shriek again for {@dice 1d4} rounds."
 						],
 						"name": "Soul Shriek"
 					}
@@ -129,508 +129,20 @@
 					"death effects",
 					"doomed",
 					"drained",
-					"fatigued"
+					"fatigued",
+					"magic (see below)",
+					"mental",
+					"nonlethal attacks",
+					"paralyzed",
+					"poison",
+					"sickened",
+					"unconscious"
 				],
 				"resistances": [
 					{
 						"name": "physical",
 						"amount": 10,
 						"note": "except adamantine"
-					}
-				]
-			},
-			"hasImages": true
-		},
-		{
-			"name": "Calikang",
-			"source": "AoA5",
-			"page": 84,
-			"level": 12,
-			"traits": [
-				"uncommon",
-				"ln",
-				"large",
-				"humanoid"
-			],
-			"perception": {
-				"std": 20
-			},
-			"senses": [
-				{
-					"name": "darkvision"
-				},
-				{
-					"name": "true seeing"
-				}
-			],
-			"languages": {
-				"languages": [
-					"common",
-					"jotun"
-				]
-			},
-			"skills": {
-				"athletics": {
-					"std": 25
-				},
-				"intimidation": {
-					"std": 24
-				}
-			},
-			"abilityMods": {
-				"str": 7,
-				"dex": 4,
-				"con": 5,
-				"int": -2,
-				"wis": 2,
-				"cha": 4
-			},
-			"items": [
-				"+1 striking longsword (2)"
-			],
-			"speed": {
-				"walk": 35
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "longsword",
-					"attack": 28,
-					"traits": [
-						"magical",
-						"reach <10 feet>",
-						"versatile <p>"
-					],
-					"damage": "{@damage 2d8+15} slashing",
-					"types": [
-						"slashing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "fist",
-					"attack": 25,
-					"traits": [
-						"agile",
-						"reach <10 feet>",
-						"nonlethal"
-					],
-					"damage": "{@damage 3d8+13} bludgeoning",
-					"types": [
-						"bludgeoning"
-					]
-				}
-			],
-			"spellcasting": [
-				{
-					"type": "Innate",
-					"tradition": "arcane",
-					"DC": 28,
-					"entry": {
-						"1": {
-							"spells": [
-								{
-									"name": "magic weapon",
-									"amount": "at will"
-								}
-							]
-						},
-						"6": {
-							"spells": [
-								{
-									"name": "chain lightning"
-								}
-							]
-						},
-						"constant": {}
-					}
-				}
-			],
-			"abilities": {
-				"top": [
-					{
-						"traits": [
-							"concentrate"
-						],
-						"entries": [
-							"By spending 5 minutes concentrating, the calikang can enter a state of suspended animation, freezing in place and becoming motionless but remaining aware of its surroundings. While in this state, the calikang gains a +4 status bonus to all Fortitude saves, does not age, and is immune to disease, inhaled toxins, poison, starvation, and thirst. The calikang can exit suspended animation as a free action. If it exits this state to attack, the calikang gains a +4 circumstance bonus to its initiative roll."
-						],
-						"name": "Suspended Animation"
-					}
-				],
-				"mid": [
-					{
-						"entries": [
-							"A calikang gains a circumstance bonus to its AC equal to the number of its hands that aren't wielding weapons, to a maximum of +4 (this bonus is already factored into this calikang's stats)."
-						],
-						"name": "Defensive Stance"
-					},
-					{
-						"traits": [
-							"abjuration",
-							"arcane"
-						],
-						"entries": [
-							"Whenever the calikang is hit by an electricity spell or rolls a successful save against a spell that deals energy damage, it absorbs the energy. This heals the calikang for an amount of HP equal to quadruple the spell's level, and recharges its Breath Weapon. A calikang can't absorb its own spells this way."
-						],
-						"name": "Energy Conversion"
-					}
-				],
-				"bot": [
-					{
-						"activity": {
-							"number": 2,
-							"unit": "action"
-						},
-						"traits": [
-							"acid",
-							"arcane",
-							"cold",
-							"electricity",
-							"evocation",
-							"fire",
-							"sonic"
-						],
-						"frequency": {
-							"unit": "day",
-							"number": 1
-						},
-						"entries": [
-							"The calikang breathes a blast of energy that deals {@damage 13d6} energy damage to all creatures in a 60-foot line (DC 28 basic Reflex save). The calikang can choose the damage type each time: acid, cold, electricity, fire, or sonic. Increase the die size to d8 if the calikang chooses electricity."
-						],
-						"name": "Breath Weapon"
-					},
-					{
-						"activity": {
-							"number": 2,
-							"unit": "action"
-						},
-						"entries": [
-							"The calikang makes up to six fist {@action Strike||Strikes}. Each {@action Strike} can be against a different target.",
-							"These attacks count toward its multiple attack penalty, which doesn't increase until after all the attacks are complete."
-						],
-						"name": "Sixfold Flurry"
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 35
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 23
-					},
-					"ref": {
-						"std": 22
-					},
-					"will": {
-						"std": 20
-					}
-				},
-				"hp": [
-					{
-						"hp": 235
-					}
-				],
-				"immunities": [
-					"electricity"
-				]
-			},
-			"hasImages": true
-		},
-		{
-			"name": "Cornugon",
-			"source": "AoA5",
-			"page": 87,
-			"level": 16,
-			"traits": [
-				"le",
-				"large",
-				"devil",
-				"fiend"
-			],
-			"perception": {
-				"std": 28
-			},
-			"senses": [
-				{
-					"name": "greater darkvision"
-				}
-			],
-			"languages": {
-				"languages": [
-					"celestial",
-					"common",
-					"draconic",
-					"infernal"
-				],
-				"abilities": [
-					"telepathy 100 feet"
-				]
-			},
-			"skills": {
-				"acrobatics": {
-					"std": 28
-				},
-				"athletics": {
-					"std": 32
-				},
-				"intimidation": {
-					"std": 30
-				},
-				"religion": {
-					"std": 28
-				},
-				"stealth": {
-					"std": 26
-				},
-				"warfare lore": {
-					"std": 30
-				}
-			},
-			"abilityMods": {
-				"str": 8,
-				"dex": 6,
-				"con": 7,
-				"int": 2,
-				"wis": 6,
-				"cha": 6
-			},
-			"items": [
-				"+2 greater striking unholy spiked chain"
-			],
-			"speed": {
-				"walk": 25,
-				"fly": 50
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "unholy spiked chain",
-					"attack": 34,
-					"traits": [
-						"disarm",
-						"evil",
-						"finesse",
-						"magical",
-						"reach <10 feet>",
-						"trip"
-					],
-					"effects": [
-						"stunning chain"
-					],
-					"damage": "{@damage 3d8+14} slashing plus {@damage 1d6} evil and stunning chain",
-					"types": [
-						"evil",
-						"slashing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "claw",
-					"attack": 32,
-					"traits": [
-						"agile",
-						"magical",
-						"reach <10 feet>"
-					],
-					"damage": "{@damage 3d10+14} slashing",
-					"types": [
-						"slashing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "tail",
-					"attack": 32,
-					"traits": [
-						"magical",
-						"reach <10 feet>"
-					],
-					"effects": [
-						"infernal wound"
-					],
-					"damage": "{@damage 2d10+14} slashing plus infernal wound",
-					"types": [
-						"slashing"
-					]
-				}
-			],
-			"spellcasting": [
-				{
-					"type": "Innate",
-					"tradition": "divine",
-					"DC": 36,
-					"entry": {
-						"4": {
-							"spells": [
-								{
-									"name": "dimension door",
-									"amount": "at will"
-								}
-							]
-						},
-						"5": {
-							"spells": [
-								{
-									"name": "dimension door"
-								}
-							]
-						},
-						"7": {
-							"spells": [
-								{
-									"name": "dispel magic"
-								},
-								{
-									"name": "fireball",
-									"amount": 2
-								},
-								{
-									"name": "lightning bolt",
-									"amount": 2
-								}
-							]
-						}
-					}
-				}
-			],
-			"rituals": [
-				{
-					"tradition": "divine",
-					"DC": 36,
-					"rituals": [
-						{
-							"name": "Infernal pact"
-						}
-					]
-				}
-			],
-			"abilities": {
-				"mid": [
-					{
-						"traits": [
-							"abjuration",
-							"aura",
-							"divine",
-							"evil"
-						],
-						"entries": [
-							"10 feet. A constant {@spell circle of protection} against good is centered on the horned devil. The horned devil can disable or activate this aura as a single action, which has the {@trait concentrate} trait."
-						],
-						"name": "Circle of Protection"
-					},
-					{
-						"traits": [
-							"aura",
-							"divine",
-							"enchantment"
-						],
-						"entries": [
-							"100 feet. Lower-level, allied evil creatures in the aura gain a +1 circumstance bonus to attack rolls, damage rolls, AC, saves, and skill checks."
-						],
-						"name": "Commander's Aura"
-					},
-					{
-						"traits": [
-							"aura",
-							"divine",
-							"emotion",
-							"enchantment",
-							"fear",
-							"mental"
-						],
-						"entries": [
-							"10 feet, DC 34"
-						],
-						"name": "Frightful Presence",
-						"generic": {
-							"tag": "ability"
-						}
-					},
-					{
-						"activity": {
-							"number": 1,
-							"unit": "reaction"
-						},
-						"name": "Attack of Opportunity",
-						"generic": {
-							"tag": "ability"
-						}
-					}
-				],
-				"bot": [
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"requirements": "The cornugon hit a creature with its spiked chain on its most recent action this turn",
-						"entries": [
-							"The devil pulls the creature 5 feet closer and grabs it with the spiked chain ({@action Escape} attempts use the cornugon's Athletics DC). The creature is automatically freed if the devil makes another spiked chain attack or moves away."
-						],
-						"name": "Chain of Malebolge"
-					},
-					{
-						"traits": [
-							"divine",
-							"necromancy"
-						],
-						"entries": [
-							"A cornugon's tail {@action Strike} deals {@damage 4d6} {@condition persistent damage||persistent bleed damage}. The flat check DC to stop the bleeding starts at 20, and is reduced to 15 only if someone successfully assists with the recovery. The DC to {@action Administer First Aid} to a creature with an infernal wound is increased by 10. A spellcaster or item using healing magic on an infernally {@condition wounded} creature must succeed at a DC 34 counteract check or the magic fails to heal the creature."
-						],
-						"name": "Infernal Wound"
-					},
-					{
-						"entries": [
-							"If the cornugon critically hits with its spiked chain {@action Strike}, the target must succeed at a DC 34 Fortitude save or be {@condition stunned} for 1 round ({@dice 1d4} rounds on a critical failure)."
-						],
-						"name": "Stunning Chain"
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 38
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 31
-					},
-					"ref": {
-						"std": 26
-					},
-					"will": {
-						"std": 26
-					},
-					"abilities": [
-						"+1 status to all saves vs. magic"
-					]
-				},
-				"hp": [
-					{
-						"hp": 300
-					}
-				],
-				"immunities": [
-					"fire"
-				],
-				"weaknesses": [
-					{
-						"amount": 15,
-						"name": "good"
-					}
-				],
-				"resistances": [
-					{
-						"amount": 15,
-						"name": "physical",
-						"note": "except silver"
-					},
-					{
-						"amount": 15,
-						"name": "poison"
 					}
 				]
 			},
@@ -678,6 +190,9 @@
 				},
 				"arcana": {
 					"std": 26
+				},
+				"crafting": {
+					"std": 30
 				},
 				"deception": {
 					"std": 26
@@ -777,20 +292,6 @@
 				}
 			],
 			"abilities": {
-				"top": [
-					{
-						"entries": [
-							"+30, {@skill Thievery} +26 Str +4, Dex +7, Con +7, Int +3, Wis +7"
-						],
-						"name": "Stealth"
-					},
-					{
-						"entries": [
-							"+5."
-						],
-						"name": "Cha"
-					}
-				],
 				"mid": [
 					{
 						"entries": [
@@ -844,7 +345,10 @@
 					},
 					"will": {
 						"std": 26
-					}
+					},
+					"abilities": [
+						"+1 status to all saves vs. magic"
+					]
 				},
 				"hp": [
 					{
@@ -856,6 +360,7 @@
 				],
 				"weaknesses": [
 					{
+						"amount": 10,
 						"name": "good"
 					}
 				],
@@ -864,266 +369,6 @@
 						"amount": 10,
 						"name": "physical",
 						"note": "except adamantine"
-					}
-				]
-			},
-			"hasImages": true
-		},
-		{
-			"name": "Duneshaker Solifugid",
-			"source": "AoA5",
-			"page": 89,
-			"level": 18,
-			"traits": [
-				"n",
-				"gargantuan",
-				"animal"
-			],
-			"perception": {
-				"std": 30
-			},
-			"senses": [
-				{
-					"name": "darkvision"
-				},
-				{
-					"type": "imprecise",
-					"name": "{@ability tremorsense}",
-					"range": 30
-				}
-			],
-			"skills": {
-				"acrobatics": {
-					"std": 33
-				},
-				"athletics": {
-					"std": 35
-				},
-				"stealth": {
-					"std": 33,
-					"in deserts": 37
-				}
-			},
-			"abilityMods": {
-				"str": 9,
-				"dex": 7,
-				"con": 7,
-				"int": -5,
-				"wis": 4,
-				"cha": -4
-			},
-			"speed": {
-				"walk": 50,
-				"burrow": 25,
-				"climb": 25
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "jaws",
-					"attack": 35,
-					"traits": [
-						"reach <10 feet>"
-					],
-					"damage": "{@damage 4d10+17} piercing",
-					"types": [
-						"piercing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "claw",
-					"attack": 35,
-					"traits": [
-						"agile",
-						"reach <20 feet>"
-					],
-					"damage": "{@damage 3d10+17} slashing",
-					"types": [
-						"slashing"
-					]
-				}
-			],
-			"abilities": {
-				"bot": [
-					{
-						"entries": [
-							"The first time per turn the duneshaker solifugid moves adjacent to a Large or smaller creature, that creature must succeed at a DC 39 {@skill Acrobatics} check or fall {@condition prone}."
-						],
-						"name": "Earth Shaker"
-					},
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"entries": [
-							"As giant solifugid (see above)."
-						],
-						"name": "Pounce"
-					},
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"traits": [
-							"claw"
-						],
-						"name": "Rend",
-						"generic": {
-							"tag": "ability"
-						}
-					},
-					{
-						"activity": {
-							"number": 2,
-							"unit": "action"
-						},
-						"traits": [
-							"poison"
-						],
-						"entries": [
-							"The duneshaker solifugid spews toxic barbs at all creatures in a 30-foot cone. Each creature within the cone takes {@damage 10d6} poison damage (DC 39 basic Fortitude save). A creature that fails is {@condition blinded} for {@dice 1d6} rounds (or permanently on a critical failure). The duneshaker solifugid can't use Venom Spray again for {@dice 1d4} rounds."
-						],
-						"name": "Venom Spray"
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 42
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 31
-					},
-					"ref": {
-						"std": 33
-					},
-					"will": {
-						"std": 28
-					}
-				},
-				"hp": [
-					{
-						"hp": 340
-					}
-				]
-			},
-			"hasImages": true
-		},
-		{
-			"name": "Giant Solifugid",
-			"source": "AoA5",
-			"page": 89,
-			"level": 1,
-			"traits": [
-				"n",
-				"medium",
-				"animal"
-			],
-			"perception": {
-				"std": 6
-			},
-			"senses": [
-				{
-					"name": "darkvision"
-				}
-			],
-			"skills": {
-				"acrobatics": {
-					"std": 8
-				},
-				"athletics": {
-					"std": 6
-				},
-				"stealth": {
-					"std": 6,
-					"in deserts": 10
-				}
-			},
-			"abilityMods": {
-				"str": 1,
-				"dex": 3,
-				"con": 3,
-				"int": -5,
-				"wis": 1,
-				"cha": -4
-			},
-			"speed": {
-				"walk": 35,
-				"climb": 25
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "jaws",
-					"attack": 8,
-					"damage": "{@damage 1d10+1} piercing",
-					"types": [
-						"piercing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "claw",
-					"attack": 8,
-					"traits": [
-						"agile",
-						"reach <10 feet>"
-					],
-					"damage": "{@damage 1d8+1} slashing",
-					"types": [
-						"slashing"
-					]
-				}
-			],
-			"abilities": {
-				"bot": [
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"entries": [
-							"The giant solifugid {@action Stride||Strides} and makes a {@action Strike} at the end of that movement. If the giant solifugid began this action {@condition hidden}, it remains {@condition hidden} until after this ability's {@action Strike}."
-						],
-						"name": "Pounce"
-					},
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"traits": [
-							"claw"
-						],
-						"name": "Rend",
-						"generic": {
-							"tag": "ability"
-						}
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 16
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 6
-					},
-					"ref": {
-						"std": 8
-					},
-					"will": {
-						"std": 4
-					}
-				},
-				"hp": [
-					{
-						"hp": 20
 					}
 				]
 			},
@@ -1310,7 +555,7 @@
 							"mental"
 						],
 						"entries": [
-							"A creature that fails to save against an immortal ichor's {@spell charm} spell becomes {@condition stupefied|CRB|stupefied 1}. The {@condition stupefied} value reduces by 1 every 24 hours. The first time each day a creature {@condition stupefied} by the ichor's charm fails to save against another casting of the ichor's charm, the value of the condition increases by {@dice 1d4}. If the {@condition stupefied} condition ever equals the creature's Wisdom score, it becomes {@condition controlled} by the ichor permanently; if it dies, it rises the next round as a zombie (of the GM's choice) under the ichor's control. If the ichor is killed, these zombies are destroyed."
+							"A creature that fails to save against an immortal ichor's {@spell charm} spell becomes {@condition stupefied|CRB|stupefied 1}. The {@condition stupefied} value reduces by 1 every 24 hours. The first time each day a creature {@condition stupefied} by the ichor's {@spell charm} fails to save against another casting of the ichor's {@spell charm}, the value of the condition increases by {@dice 1d4}. If the {@condition stupefied} condition ever equals the creature's Wisdom score, it becomes {@condition controlled} by the ichor permanently; if it dies, it rises the next round as a zombie (of the GM's choice) under the ichor's control. If the ichor is killed, these zombies are destroyed."
 						],
 						"name": "Corrupt Ally"
 					},
@@ -1366,6 +611,14 @@
 						]
 					}
 				],
+				"immunities": [
+					"acid",
+					"critical hits",
+					"mental",
+					"precision",
+					"unconscious",
+					"visual"
+				],
 				"resistances": [
 					{
 						"amount": 15,
@@ -1386,6 +639,7 @@
 				"large",
 				"beast"
 			],
+			"description": "Female {@creature lamia matriarch}",
 			"perception": {
 				"std": 29
 			},
@@ -1401,6 +655,9 @@
 				"crafting": {
 					"std": 31,
 					"for poison": 35
+				},
+				"deception": {
+					"std": 32
 				},
 				"intimidation": {
 					"std": 30
@@ -1420,6 +677,12 @@
 				"wis": 3,
 				"cha": 6
 			},
+			"items": [
+				"+2 corrosive greater striking dagger",
+				"{@item nightmare salt|TV|nightmare salt poison} (2)",
+				"{@item oblivion essence|AoA5|oblivion essence poison}",
+				"{@item weeping midnight|AoA5|weeping midnight poison} (3)"
+			],
 			"speed": {
 				"walk": 40,
 				"climb": 40,
@@ -1509,14 +772,19 @@
 							"number": 1,
 							"unit": "action"
 						},
+						"traits": [
+							"concentrate",
+							"occult",
+							"polymorph",
+							"transmutation"
+						],
 						"entries": [
-							"As lamia matriarch."
+							"The lamia matriarch can take on the appearance of a Medium humanoid. This doesn't change their Speed or their attack and damage modifiers with their {@action Strike||Strikes}, but it does prevent them from using their cursed touch. Each lamia matriarch has a fixed humanoid form\u2014they cannot adopt a different appearance each time they use this ability, and the appearance resembles that of their upper torso when in their true form."
 						],
 						"name": "Change Shape",
 						"generic": {
 							"tag": "ability"
-						},
-						"entries_as_xyz": "Ability not found: '{@action Change Shape|LOAG} As lamia matriarch.' in Ishti, p.47"
+						}
 					},
 					{
 						"activity": {
@@ -1524,21 +792,25 @@
 							"unit": "action"
 						},
 						"entries": [
-							"As lamia matriarch, but 2 actions and using her dagger."
+							"Ishti makes a dagger attack against each enemy within reach. Each attack counts toward her multiple attack penalty, but the penalty does not increase until after all the attacks. The first enemy she damages is subject to matriarch's caress."
 						],
-						"name": "Quick Dervish Strike",
-						"entries_as_xyz": "Ability not found: 'Quick Dervish {@action Strike} As lamia matriarch, but 2 actions and using her dagger.' in Ishti, p.47"
+						"name": "Quick Dervish Strike"
 					},
 					{
 						"activity": {
 							"number": 2,
 							"unit": "action"
 						},
-						"entries": [
-							"As lamia matriarch, but DC 40."
+						"traits": [
+							"curse",
+							"enchantment",
+							"mental",
+							"occult"
 						],
-						"name": "Matriarch's Caress",
-						"entries_as_xyz": "Ability not found: 'Matriarch's Caress As lamia matriarch, but DC 40.' in Ishti, p.47"
+						"entries": [
+							"Ishti touches a creature, who must succeed at a DC 40 Will save or become {@condition stupefied 1} (or {@condition stupefied 2} on a critical failure). If the target fails additional saves against this ability, the condition value increases by 1 (or 2 if it critically fails; to a maximum of {@condition stupefied 4}). This condition value decreases by 1 every 24 hours."
+						],
+						"name": "Matriarch's Caress"
 					},
 					{
 						"activity": {
@@ -1576,263 +848,16 @@
 					}
 				],
 				"immunities": [
-					"poison",
-					"controlled"
+					"controlled",
+					"poison"
+				],
+				"resistances": [
+					{
+						"amount": 15,
+						"name": "mental"
+					}
 				]
 			}
-		},
-		{
-			"name": "Nalfeshnee",
-			"source": "AoA5",
-			"page": 86,
-			"level": 14,
-			"traits": [
-				"ce",
-				"huge",
-				"demon",
-				"fiend"
-			],
-			"perception": {
-				"std": 25
-			},
-			"senses": [
-				{
-					"name": "darkvision"
-				},
-				{
-					"name": "true seeing"
-				}
-			],
-			"languages": {
-				"languages": [
-					"abyssal",
-					"celestial",
-					"draconic"
-				],
-				"abilities": [
-					"telepathy 100 feet"
-				]
-			},
-			"skills": {
-				"arcana": {
-					"std": 25
-				},
-				"athletics": {
-					"std": 28
-				},
-				"deception": {
-					"std": 26
-				},
-				"diplomacy": {
-					"std": 24
-				},
-				"intimidation": {
-					"std": 28
-				},
-				"religion": {
-					"std": 25
-				},
-				"abyss lore": {
-					"std": 25
-				}
-			},
-			"abilityMods": {
-				"str": 8,
-				"dex": 2,
-				"con": 8,
-				"int": 5,
-				"wis": 5,
-				"cha": 4
-			},
-			"speed": {
-				"walk": 30,
-				"fly": 40
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "jaws",
-					"attack": 28,
-					"traits": [
-						"magical",
-						"reach <15 feet>"
-					],
-					"damage": "{@damage 3d12+14} piercing",
-					"types": [
-						"piercing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "claw",
-					"attack": 28,
-					"traits": [
-						"agile",
-						"magical",
-						"reach <15 feet>"
-					],
-					"damage": "{@damage 3d8+14} slashing",
-					"types": [
-						"slashing"
-					]
-				}
-			],
-			"spellcasting": [
-				{
-					"type": "Innate",
-					"tradition": "divine",
-					"DC": 34,
-					"entry": {
-						"4": {
-							"spells": [
-								{
-									"name": "circle of protection"
-								},
-								{
-									"name": "dimension door",
-									"amount": "at will"
-								}
-							]
-						},
-						"5": {
-							"spells": [
-								{
-									"name": "dimension door"
-								},
-								{
-									"name": "illusory object",
-									"amount": "at will"
-								}
-							]
-						},
-						"6": {
-							"spells": [
-								{
-									"name": "dispel magic",
-									"amount": "at will"
-								},
-								{
-									"name": "divine wrath",
-									"amount": "at will"
-								}
-							]
-						},
-						"constant": {
-							"6": {
-								"spells": [
-									{
-										"name": "true seeing"
-									}
-								]
-							}
-						}
-					}
-				}
-			],
-			"rituals": [
-				{
-					"tradition": "divine",
-					"DC": 34,
-					"rituals": [
-						{
-							"name": "Abyssal pact"
-						}
-					]
-				}
-			],
-			"abilities": {
-				"mid": [
-					{
-						"entries": [
-							"A nalfeshnee's greed is such that losing possessions causes it harm. If an item is stolen from a nalfeshnee, the demon takes {@damage 3d6} mental damage."
-						],
-						"name": "Forfeiture Aversion"
-					},
-					{
-						"activity": {
-							"number": 1,
-							"unit": "reaction"
-						},
-						"trigger": "A creature critically fails a weapon {@action Strike} against the nalfeshnee",
-						"entries": [
-							"The nalfeshnee attempts to {@action Disarm} the weapon used in the triggering {@action Strike} at a \u20132 circumstance penalty. On a success, the nalfeshnee steals the weapon."
-						],
-						"name": "Greedy Grab"
-					}
-				],
-				"bot": [
-					{
-						"activity": {
-							"number": 1,
-							"unit": "action"
-						},
-						"traits": [
-							"conjuration",
-							"divine",
-							"extradimensional"
-						],
-						"entries": [
-							"The nalfeshnee steals all unattended items glowing with its Light of Avarice into an extradimensional space. The demon can {@action Interact} to regurgitate any number of these items into its hand or onto the ground. If the demon dies, is affected by a {@trait teleportation} effect, or consumes an extradimensional space (such as a {@item bag of holding}), it vomits up all the items."
-						],
-						"name": "ClaimWealth"
-					},
-					{
-						"activity": {
-							"number": 2,
-							"unit": "action"
-						},
-						"traits": [
-							"divine",
-							"enchantment",
-							"light",
-							"mental"
-						],
-						"frequency": {
-							"unit": "hour",
-							"number": 1
-						},
-						"entries": [
-							"Beams of unholy light shoot out from the nalfeshnee toward four items within 60 feet. If someone is holding or wearing a targeted item, they can keep it from being affected with a DC 34 Reflex save. For 1 minute, all affected items glow in nauseating colors. Any non-demon is {@condition sickened|CRB|sickened 2} and {@condition slowed|CRB|slowed 1} as long as it holds, wears, or touches a glowing item. Recovering from this sickness requires a DC 29 Will save instead of a Fortitude save. Ending the sickness in this way ends the {@condition slowed} condition and makes the creature temporarily immune to the Light of Avarice for 24 hours. If the creature removes or drops the item, both the conditions end immediately, but the creature doesn't become immune."
-						],
-						"name": "Light of Avarice"
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 34
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 26
-					},
-					"ref": {
-						"std": 22
-					},
-					"will": {
-						"std": 23
-					},
-					"abilities": [
-						"+1 status to all saves vs. magic"
-					]
-				},
-				"hp": [
-					{
-						"hp": 360
-					}
-				],
-				"weaknesses": [
-					{
-						"amount": 15,
-						"name": "cold iron"
-					},
-					{
-						"amount": 15,
-						"name": "good"
-					}
-				]
-			},
-			"hasImages": true
 		},
 		{
 			"name": "Scarlet Triad Boss",
@@ -1892,7 +917,7 @@
 				"+2 striking shortsword",
 				"+2 resilient studded leather armor",
 				"infiltrator thieves' tools",
-				"arrow with weeping midnight poison (page 79)"
+				"arrow with {@item weeping midnight|AoA5|weeping midnight poison}"
 			],
 			"speed": {
 				"walk": 30
@@ -2028,6 +1053,14 @@
 				"wis": 4,
 				"cha": 5
 			},
+			"items": [
+				"+2 striking composite shortbow",
+				"good manacles",
+				"moderate healing potion",
+				"+1 striking sap",
+				"+2 greater striking scimitar",
+				"+2 resilient studded leather"
+			],
 			"speed": {
 				"walk": 25
 			},
@@ -2084,17 +1117,11 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"trigger": "An enemy critically fails a",
+						"trigger": "An enemy critically fails a {@action Strike} against the enforcer",
 						"entries": [
-							"{@action Strike} against the enforcer; The enforcer {@action Strike||Strikes} with their sap against that enemy if they're within reach; otherwise, the enforcer attempts an {@skill Intimidation} check."
+							"The enforcer {@action Strike||Strikes} with their sap against that enemy if they're within reach; otherwise, the enforcer attempts an {@skill Intimidation} check to {@action Demoralize} that enemy."
 						],
 						"name": "Stunning Retort"
-					},
-					{
-						"entries": [
-							"{@action Demoralize} that enemy."
-						],
-						"name": "to"
 					}
 				],
 				"bot": [
@@ -2631,8 +1658,7 @@
 				"bot": [
 					{
 						"entries": [
-							"As aluum enforcer (page 82)",
-							"Arcane Innate Spells DC 38; 9th bind soul (×3); 5th locate."
+							"Spiritbound aluum are immune to spells and magical abilities, with two exceptions. A negative spell or magical ability grants a spiritbound aluum the {@condition quickened} condition until the end of its next turn instead of its normal effects. A positive spell or ability makes a spiritbound aluum {@condition slowed|CRB|slowed 1} until the end of its next turn instead of its normal effects."
 						],
 						"name": "Aluum Antimagic"
 					},
@@ -2646,9 +1672,9 @@
 							"evocation",
 							"force"
 						],
+						"requirements": "The spiritbound aluum has bound a soul using its {@spell bind soul} innate spell",
 						"entries": [
-							"Requirements The spiritbound aluum has bound a soul using its bind soul innate spell; The spiritbound aluum transforms the captured soul's essence into raw magical energy, channeling the spirit into a beam that deals {@damage 20d6} force damage in a 30-foot line (DC 38 basic Reflex save). The remaining fragments of the captured soul are released to the Great Beyond.",
-							"The spiritbound aluum can't use Obliteration Beam again for {@dice 1d4} rounds."
+							"The spiritbound aluum transforms the captured soul's essence into raw magical energy, channeling the spirit into a beam that deals {@damage 20d6} force damage in a 30-foot line (DC 38 basic Reflex save). The remaining fragments of the captured soul are released to the Great Beyond. The spiritbound aluum can't use Obliteration Beam again for {@dice 1d4} rounds."
 						],
 						"name": "Obliteration Beam"
 					},
@@ -2659,15 +1685,13 @@
 							"necromancy"
 						],
 						"entries": [
-							"As aluum, but DC 35."
+							"A creature damaged by the spiritbound aluum's fist {@action Strike} must succeed at a DC 35 Fortitude save or become {@condition paralyzed} for 1 round. On a critical failure, the creature is {@condition paralyzed} for {@dice 1d4} minutes and falls {@condition prone}."
 						],
-						"name": "Paralyzing Force",
-						"entries_as_xyz": "Ability not found: 'Paralyzing Force As aluum, but DC 35.' in Spiritbound Aluum, p.83"
+						"name": "Paralyzing Force"
 					},
 					{
 						"entries": [
-							"When a spiritbound aluum uses its bind soul innate spell, it binds the soul into its central crystal instead of the normal material component.",
-							"The crystal can hold up to 60 souls. When encountered, a spiritbound aluum's crystal typically contains {@dice 1d6} souls."
+							"When a spiritbound aluum uses its bind soul innate spell, it binds the soul into its central crystal instead of the normal material component. The crystal can hold up to 60 souls. When encountered, a spiritbound aluum's crystal typically contains {@dice 1d6} souls."
 						],
 						"name": "Soul Binder"
 					},
@@ -2684,7 +1708,7 @@
 							"sonic"
 						],
 						"entries": [
-							"As aluum enforcer (page 82), but {@dice 16d6} damage."
+							"The spiritbound aluum emits a keening wail in a 15-foot cone that deals {@damage 16d6} sonic damage (DC 27 basic Fortitude save). A creature that fails its save is {@condition stunned|CRB|stunned 1}, or {@condition stunned|CRB|stunned 3} on a critical failure. The aluum can't use Soul Shriek again for {@dice 1d4} rounds."
 						],
 						"name": "Soul Shriek"
 					}
@@ -2711,7 +1735,26 @@
 					}
 				],
 				"immunities": [
-					"as aluum enforcer"
+					"bleed",
+					"disease",
+					"death effects",
+					"doomed",
+					"drained",
+					"fatigued",
+					"magic (see below)",
+					"mental",
+					"nonlethal attacks",
+					"paralyzed",
+					"poison",
+					"sickened",
+					"unconscious"
+				],
+				"resistances": [
+					{
+						"name": "physical",
+						"amount": 15,
+						"note": "except adamantine"
+					}
 				]
 			},
 			"hasImages": true
@@ -2779,7 +1822,7 @@
 				"cha": 6
 			},
 			"items": [
-				"demilich eye gem (2)"
+				"{@item demilich eye gem|B1} (2)"
 			],
 			"speed": {
 				"fly": 30
@@ -2866,10 +1909,9 @@
 				"top": [
 					{
 						"entries": [
-							"As demilich."
+							"Typically, a demilich is inert when encountered and doesn't take actions until its {@i contingency} reaction has been triggered (see below)."
 						],
-						"name": "Torpor",
-						"entries_as_xyz": "Ability not found: 'Torpor As demilich.' in Teyam Ishtori, p.61"
+						"name": "Torpor"
 					}
 				],
 				"mid": [
@@ -2880,32 +1922,32 @@
 							"evocation"
 						],
 						"entries": [
-							"20 feet; As demilich."
+							"20 feet. Telekinetic whirlwind activates when the demilich ends torpor. Loose debris in the area whip up into a whirling storm. This obscures vision, making any creature in the area {@condition concealed}, and causes creatures in its area (except the demilich) to treat all creatures as {@condition concealed}. Any creature other than the demilich that enters or begins its turn in the aura takes {@damage 2d12} bludgeoning damage."
 						],
-						"name": "Telekinetic Whirlwind",
-						"entries_as_xyz": "Ability not found: 'Telekinetic Whirlwind As demilich.' in Teyam Ishtori, p.61"
+						"name": "Telekinetic Whirlwind"
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
 						},
+						"note": "A demilich has one permanent 8th-level {@spell contingency} spell in effect with one of its arcane innate spells of 5th level or lower as the companion spell\u2014typically {@spell dimension door}.",
+						"trigger": "While the lich is in torpor, a creature disturbs the demilich's remains, touches its treasure, or casts a spell that would affect the demilich.",
 						"entries": [
-							"As demilich."
+							"The demilich ends torpor, rolls initiative, and gains the effect of its {@spell contingency}'s companion spell. The {@i contingency} resets after 24 hours."
 						],
-						"name": "Contingency",
-						"entries_as_xyz": "Ability not found: 'Contingency As demilich.' in Teyam Ishtori, p.61"
+						"name": "Contingency"
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "free"
 						},
+						"trigger": "The demilich's turn begins.",
 						"entries": [
-							"As demilich."
+							"The demilich casts {@spell blink}, {@spell fly}, {@spell spell turning}, or {@spell true seeing} on itself. It usually chooses {@spell spell turning} unless it already has that spell in effect."
 						],
-						"name": "Countermeasures",
-						"entries_as_xyz": "Ability not found: 'Countermeasures As demilich.' in Teyam Ishtori, p.61"
+						"name": "Countermeasures"
 					}
 				],
 				"bot": [
@@ -2914,10 +1956,9 @@
 							"arcane"
 						],
 						"entries": [
-							"As demilich."
+							"A demilich has gemstone eyes that glow when the demilich is active. Each eye contains an 8th-level spell that targets one creature (usually one eye has {@spell maze} and the other {@spell polar ray}). The demilich can {@action Activate An Item||Activate} an eye. This uses the number of spellcasting actions the spell requires, and also requires command and envision components. When the demilich casts a spell from a gemstone eye, that eye stops glowing for {@dice 1d4} rounds, during which time that eye's spell can't be used. Occasionally, one or both of the two {@item demilich eye gem|B1|demilich eye gems} can be harvested from a destroyed demilich as magic items."
 						],
-						"name": "Demilich Eye Gems",
-						"entries_as_xyz": "Ability not found: 'Demilich Eye Gems As demilich.' in Teyam Ishtori, p.61"
+						"name": "Demilich Eye Gems"
 					},
 					{
 						"activity": {
@@ -2929,36 +1970,40 @@
 							"necromancy",
 							"negative"
 						],
+						"requirements": "A soul has been trapped in one of the demilich's blight quartz gems (see Trap Soul) for 24 hours.",
 						"entries": [
-							"As demilich."
+							"The demilich consumes the soul. The soul is utterly destroyed, and the demilich regains HP equal to double the creature's level."
 						],
-						"name": "Devour Soul",
-						"entries_as_xyz": "Ability not found: 'Devour Soul As demilich.' in Teyam Ishtori, p.61"
+						"name": "Devour Soul"
 					},
 					{
 						"entries": [
-							"As demilich."
+							"A demilich can replace all material and somatic components for casting spells with verbal components, and can replace all {@action Interact} components for activating magic items with envision components."
 						],
-						"name": "Mental Magic",
-						"entries_as_xyz": "Ability not found: 'Mental Magic As demilich.' in Teyam Ishtori, p.61"
+						"name": "Mental Magic"
 					},
 					{
 						"entries": [
-							"As demilich, but 10 charges and the spells of a staff of power."
+							"Teyam Ishtori long ago absorbed the spells from a staff into gemstone nodules embedded in her skull, with larger nodules representing higher-level spells. She can cast any of the spells as though she were {@action Activate an Item||Activating} the staff, and regains 1 charge per 4 hours spent in torpor, to a maximum of 10 charges. Teyam Ishtori has the spells from a {@item staff of power}."
 						],
-						"name": "Staff Gems",
-						"entries_as_xyz": "Ability not found: 'Staff Gems As demilich, but 10 charges and the spells of a staff of power.' in Teyam Ishtori, p.61"
+						"name": "Staff Gems"
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "action"
 						},
-						"entries": [
-							"As demilich, but DC 43 Fortitude."
+						"components": [
+							"command"
 						],
-						"name": "Trap Soul",
-						"entries_as_xyz": "Ability not found: 'Trap Soul As demilich, but DC 43 Fortitude.' in Teyam Ishtori, p.61"
+						"frequency": {
+							"special": "once per day per gem"
+						},
+						"entries": [
+							"Ten blight quartz gemstones on the demilich's skull can trap the souls of the living. The {@action Activate an Item||Activated} gem casts {@spell bind soul}. This {@spell bind soul} can target and affect a {@condition dying} creature instead of a corpse. The {@condition dying} creature can attempt a DC 43 Fortitude save; if it succeeds, it doesn't die and its soul is not trapped but it's enervated 2 (or is unaffected entirely on a critical success). When the soul of a creature gets trapped, the creature's body swiftly turns to dust.",
+							"The gemstones work like the black sapphires used in {@spell bind soul}, except that they can hold creatures of up to 17th level and have a value of 200 gp apiece. The demilich can Devour a Soul it has trapped."
+						],
+						"name": "Trap Soul"
 					}
 				]
 			},
@@ -3085,11 +2130,11 @@
 				"+2 greater resilient chain mail",
 				"+2 striking returning dagger",
 				"superior manacles",
-				"oblivion essence (page 79)",
+				"{@item oblivion essence|AoA5}",
 				"+3 major striking speed scimitar",
 				"steel shield with +2 greater striking shield spikes (Hardness 5, HP 20, BT 10)",
 				"wasp trapped in amber (portal key)",
-				"weeping midnight (page 79)",
+				"{@item weeping midnight|AoA5}",
 				"winged boots"
 			],
 			"speed": {
@@ -3245,250 +2290,6 @@
 					}
 				]
 			}
-		},
-		{
-			"name": "Witchwyrd",
-			"source": "AoA5",
-			"page": 90,
-			"level": 6,
-			"traits": [
-				"uncommon",
-				"ln",
-				"medium",
-				"humanoid"
-			],
-			"perception": {
-				"std": 12
-			},
-			"senses": [
-				{
-					"name": "darkvision"
-				},
-				{
-					"name": "detect magic"
-				}
-			],
-			"languages": {
-				"languages": [
-					"common",
-					"draconic"
-				],
-				"notes": [
-					"one or more planar languages"
-				],
-				"abilities": [
-					"tongues"
-				]
-			},
-			"skills": {
-				"arcana": {
-					"std": 16
-				},
-				"deception": {
-					"std": 15
-				},
-				"diplomacy": {
-					"std": 15
-				},
-				"intimidation": {
-					"std": 15
-				},
-				"desert lore": {
-					"std": 14
-				},
-				"notes": [
-					"one or more Lore skills related to a specific plane"
-				]
-			},
-			"abilityMods": {
-				"str": 3,
-				"dex": 3,
-				"con": 1,
-				"int": 4,
-				"wis": 3,
-				"cha": 5
-			},
-			"items": [
-				"+1 ranseur"
-			],
-			"speed": {
-				"walk": 25
-			},
-			"attacks": [
-				{
-					"range": "Melee",
-					"name": "ranseur",
-					"attack": 16,
-					"traits": [
-						"disarm",
-						"magical",
-						"reach <10 feet>"
-					],
-					"damage": "{@damage 1d10+6} piercing",
-					"types": [
-						"piercing"
-					]
-				},
-				{
-					"range": "Melee",
-					"name": "fist",
-					"attack": 15,
-					"traits": [
-						"agile",
-						"nonlethal"
-					],
-					"effects": [
-						"Grab"
-					],
-					"damage": "{@damage 1d6+6} bludgeoning plus Grab",
-					"types": [
-						"bludgeoning"
-					]
-				}
-			],
-			"spellcasting": [
-				{
-					"type": "Innate",
-					"tradition": "arcane",
-					"DC": 23,
-					"attack": 15,
-					"entry": {
-						"0": {
-							"level": 3,
-							"spells": [
-								{
-									"name": "detect magic"
-								}
-							]
-						},
-						"1": {
-							"spells": [
-								{
-									"name": "floating disk",
-									"amount": "at will"
-								},
-								{
-									"name": "unseen servant",
-									"amount": "at will"
-								}
-							]
-						},
-						"2": {
-							"spells": [
-								{
-									"name": "mirror image"
-								}
-							]
-						},
-						"3": {
-							"spells": [
-								{
-									"name": "dispel magic"
-								}
-							]
-						},
-						"4": {
-							"spells": [
-								{
-									"name": "resist energy",
-									"amount": 2
-								},
-								{
-									"name": "suggestion"
-								},
-								{
-									"name": "resilient sphere"
-								}
-							]
-						},
-						"5": {
-							"spells": [
-								{
-									"name": "dimension door"
-								}
-							]
-						},
-						"constant": {
-							"5": {
-								"spells": [
-									{
-										"name": "tongues"
-									}
-								]
-							}
-						}
-					}
-				}
-			],
-			"abilities": {
-				"mid": [
-					{
-						"activity": {
-							"number": 1,
-							"unit": "reaction"
-						},
-						"traits": [
-							"arcane",
-							"evocation",
-							"force"
-						],
-						"frequency": {
-							"unit": "round",
-							"number": 1
-						},
-						"entries": [
-							"The witchwyrd uses a free hand to \"catch\" a single {@i magic missile} fired at it, as long as it is aware of the incoming {@i magic missile}. This absorbs the missile and causes that hand to glow while it holds this energy. A hand that's holding energy can't be used for any other purpose except to use Force Bolt. The energy lasts for 6 rounds or until it is released."
-						],
-						"name": "Absorb Force"
-					}
-				],
-				"bot": [
-					{
-						"activity": {
-							"number": 1,
-							"unit": "varies",
-							"entry": "{@as 1} to {@as 3}"
-						},
-						"traits": [
-							"arcane",
-							"evocation",
-							"force"
-						],
-						"entries": [
-							"The witchwyrd fires one {@i magic missile} per action spent (dealing {@dice 1d4+1} damage each). It can't spend more actions on this ability than it has free hands. If it uses a hand that has Absorbed Force, that hand hurls two missiles instead of one, expending the held energy."
-						],
-						"name": "Force Bolt"
-					}
-				]
-			},
-			"defenses": {
-				"ac": {
-					"std": 22
-				},
-				"savingThrows": {
-					"fort": {
-						"std": 13
-					},
-					"ref": {
-						"std": 13
-					},
-					"will": {
-						"std": 15
-					}
-				},
-				"hp": [
-					{
-						"hp": 110
-					}
-				],
-				"resistances": [
-					{
-						"amount": 5,
-						"name": "force"
-					}
-				]
-			},
-			"hasImages": true
 		},
 		{
 			"name": "Xotanispawn",
@@ -3668,6 +2469,12 @@
 					"chaotic",
 					"evil",
 					"fire"
+				],
+				"weaknesses": [
+					{
+						"amount": 20,
+						"name": "cold"
+					}
 				]
 			},
 			"hasImages": true

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -18175,7 +18175,7 @@
 				"cha": 5
 			},
 			"items": [
-				"demilich eye gem (2)"
+				"{@item demilich eye gem|B1} (2)"
 			],
 			"speed": {
 				"fly": 30
@@ -18262,7 +18262,7 @@
 				"top": [
 					{
 						"entries": [
-							"Typically, a demilich is inert when encountered and doesn't take actions until its contingency reaction has been triggered (see below)."
+							"Typically, a demilich is inert when encountered and doesn't take actions until its {@i contingency} reaction has been triggered (see below)."
 						],
 						"name": "Torpor"
 					}
@@ -18284,9 +18284,10 @@
 							"number": 1,
 							"unit": "reaction"
 						},
+						"note": "A demilich has one permanent 8th-level {@spell contingency} spell in effect with one of its arcane innate spells of 5th level or lower as the companion spell\u2014typically {@spell dimension door}.",
 						"trigger": "While the lich is in torpor, a creature disturbs the demilich's remains, touches its treasure, or casts a spell that would affect the demilich.",
 						"entries": [
-							"A demilich has one permanent 8th-level {@spell contingency} spell in effect with one of its arcane innate spells of 5th level or lower as the companion spell\u2014typically dimension door. The demilich ends torpor, rolls initiative, and gains the effect of its contingency's companion spell. The contingency resets after 24 hours."
+							"The demilich ends torpor, rolls initiative, and gains the effect of its {@spell contingency}'s companion spell. The {@i contingency} resets after 24 hours."
 						],
 						"name": "Contingency"
 					},
@@ -18297,7 +18298,7 @@
 						},
 						"trigger": "The demilich's turn begins.",
 						"entries": [
-							"The demilich casts blink, fly, spell turning, or true seeing on itself. It usually chooses spell turning unless it already has that spell in effect."
+							"The demilich casts {@spell blink}, {@spell fly}, {@spell spell turning}, or {@spell true seeing} on itself. It usually chooses {@spell spell turning} unless it already has that spell in effect."
 						],
 						"name": "Countermeasures"
 					}
@@ -18308,7 +18309,7 @@
 							"arcane"
 						],
 						"entries": [
-							"A demilich has gemstone eyes that glow when the demilich is active. Each eye contains an 8th-level spell that targets one creature (usually one eye has maze and the other polar ray). The demilich can Activate an eye. This uses the number of spellcasting actions the spell requires, and also requires command and envision components. When the demilich casts a spell from a gemstone eye, that eye stops glowing for {@dice 1d4} rounds, during which time that eye's spell can't be used. Occasionally, one or both of the two demilich eye gems can be harvested from a destroyed demilich as magic items (see below)."
+							"A demilich has gemstone eyes that glow when the demilich is active. Each eye contains an 8th-level spell that targets one creature (usually one eye has {@spell maze} and the other {@spell polar ray}). The demilich can {@action Activate An Item||Activate} an eye. This uses the number of spellcasting actions the spell requires, and also requires command and envision components. When the demilich casts a spell from a gemstone eye, that eye stops glowing for {@dice 1d4} rounds, during which time that eye's spell can't be used. Occasionally, one or both of the two {@item demilich eye gem|B1|demilich eye gems} can be harvested from a destroyed demilich as magic items."
 						],
 						"name": "Demilich Eye Gems"
 					},
@@ -18336,7 +18337,7 @@
 					},
 					{
 						"entries": [
-							"A demilich long ago absorbed the spells from a staff into gemstone nodules embedded in its skull, with larger nodules representing higher-level spells. It can cast any of the spells as though it were {@action Activate an Item||Activating} the staff, and regains 1 charge per 4 hours spent in torpor, to a maximum of 8 charges. A typical demilich has the spells from a greater staff of necromancy, but it could have spells from another staff of 8th level or lower instead."
+							"A demilich long ago absorbed the spells from a staff into gemstone nodules embedded in its skull, with larger nodules representing higher-level spells. It can cast any of the spells as though it were {@action Activate an Item||Activating} the staff, and regains 1 charge per 4 hours spent in torpor, to a maximum of 8 charges. A typical demilich has the spells from a {@item greater staff of necromancy}, but it could have spells from another staff of 8th level or lower instead."
 						],
 						"name": "Staff Gems"
 					},
@@ -18345,14 +18346,15 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
+						"components": [
 							"command"
 						],
 						"frequency": {
 							"special": "once per day per gem"
 						},
 						"entries": [
-							"Ten blight quartz gemstones on the demilich's skull can trap the souls of the living. The Activated gem casts bind soul. This bind soul can target and affect a {@condition dying} creature instead of a corpse. The {@condition dying} creature can attempt a DC 38 Fortitude save; if it succeeds, it doesn't die and its soul is not trapped but it's enervated 2 (or is unaffected entirely on a critical success). When the soul of a creature gets trapped, the creature's body swiftly turns to dust. The gemstones work like the black sapphires used in bind soul, except that they can hold creatures of up to 17th level and have a value of 200 gp apiece. The demilich can Devour a Soul it has trapped."
+							"Ten blight quartz gemstones on the demilich's skull can trap the souls of the living. The {@action Activate an Item||Activated} gem casts {@spell bind soul}. This {@spell bind soul} can target and affect a {@condition dying} creature instead of a corpse. The {@condition dying} creature can attempt a DC 38 Fortitude save; if it succeeds, it doesn't die and its soul is not trapped but it's enervated 2 (or is unaffected entirely on a critical success). When the soul of a creature gets trapped, the creature's body swiftly turns to dust.",
+							"The gemstones work like the black sapphires used in {@spell bind soul}, except that they can hold creatures of up to 17th level and have a value of 200 gp apiece. The demilich can Devour a Soul it has trapped."
 						],
 						"name": "Trap Soul"
 					}
@@ -18372,7 +18374,10 @@
 					},
 					"will": {
 						"std": 23
-					}
+					},
+					"abilities": [
+						"+1 status to all saves vs. positive"
+					]
 				},
 				"hp": [
 					{
@@ -42145,6 +42150,12 @@
 				],
 				"immunities": [
 					"controlled"
+				],
+				"resistances": [
+					{
+						"amount": 10,
+						"name": "mental"
+					}
 				]
 			}
 		},

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -13592,6 +13592,11 @@
 			"name": "Cornugon",
 			"source": "B2",
 			"page": 77,
+			"otherSources": {
+				"Originally": [
+					"AoA5|87"
+				]
+			},
 			"level": 16,
 			"traits": [
 				"le",
@@ -13747,6 +13752,17 @@
 					}
 				}
 			],
+			"rituals": [
+				{
+					"DC": 36,
+					"rituals": [
+						{
+							"name": "infernal pact",
+							"source": "B1"
+						}
+					]
+				}
+			],
 			"abilities": {
 				"mid": [
 					{
@@ -13757,7 +13773,7 @@
 							"evil"
 						],
 						"entries": [
-							"10 feet. A constant circle of protection against good is centered on the cornugon."
+							"10 feet. A constant {@spell circle of protection} against good is centered on the cornugon."
 						],
 						"name": "Circle of Protection"
 					},
@@ -13807,9 +13823,9 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"requirements": "The cornugon's last action was a success with a spiked chain",
+						"requirements": "The cornugon's last action was a success with a {@i spiked chain} {@action Strike}",
 						"entries": [
-							"{@action Strike}; The devil pulls the creature 5 feet closer and grabs it with the spiked chain ({@action Escape} DC 42). The creature is automatically freed if the devil makes another spiked chain attack or moves away."
+							"The devil pulls the creature 5 feet closer and grabs it with the spiked chain ({@action Escape} DC 42). The creature is automatically freed if the devil makes another {@i spiked chain} attack or moves away."
 						],
 						"name": "Chain of Malebolge"
 					},
@@ -13829,7 +13845,7 @@
 							"incapacitation"
 						],
 						"entries": [
-							"If the cornugon critically hits with its spiked chain {@action Strike}, the target must succeed at a DC 34 Fortitude save or be {@condition stunned} for 1 round ({@dice 1d4} rounds on a critical failure)."
+							"If the cornugon critically hits with its {@i spiked chain} {@action Strike}, the target must succeed at a DC 34 Fortitude save or be {@condition stunned} for 1 round ({@dice 1d4} rounds on a critical failure)."
 						],
 						"name": "Stunning Chain"
 					}
@@ -13849,7 +13865,10 @@
 					},
 					"will": {
 						"std": 26
-					}
+					},
+					"abilities": [
+						"+1 status to all saves vs. magic"
+					]
 				},
 				"hp": [
 					{
@@ -16641,6 +16660,11 @@
 			"name": "Duneshaker Solifugid",
 			"source": "B2",
 			"page": 246,
+			"otherSources": {
+				"Originally": [
+					"AoA5|89"
+				]
+			},
 			"level": 18,
 			"traits": [
 				"n",
@@ -16735,7 +16759,7 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
+						"entries": [
 							"claw"
 						],
 						"name": "Rend",
@@ -22637,6 +22661,11 @@
 			"name": "Giant Solifugid",
 			"source": "B2",
 			"page": 246,
+			"otherSources": {
+				"Originally": [
+					"AoA5|89"
+				]
+			},
 			"level": 1,
 			"traits": [
 				"n",
@@ -22717,7 +22746,7 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
+						"entries": [
 							"claw"
 						],
 						"name": "Rend",
@@ -36153,6 +36182,11 @@
 			"name": "Nalfeshnee",
 			"source": "B2",
 			"page": 68,
+			"otherSources": {
+				"Originally": [
+					"AoA5|86"
+				]
+			},
 			"level": 14,
 			"traits": [
 				"ce",
@@ -36282,8 +36316,27 @@
 								}
 							]
 						},
-						"constant": {}
+						"constant": {
+							"6": {
+								"spells": [
+									{
+										"name": "true seeing"
+									}
+								]
+							}
+						}
 					}
+				}
+			],
+			"rituals": [
+				{
+					"DC": 34,
+					"rituals": [
+						{
+							"name": "Abyssal pact",
+							"source": "B1"
+						}
+					]
 				}
 			],
 			"abilities": {
@@ -36318,7 +36371,7 @@
 							"extradimensional"
 						],
 						"entries": [
-							"The nalfeshnee steals all unattended items glowing with its Light of Avarice into an extradimensional space. The demon can {@action Interact} to regurgitate any number of these items into their hand or onto the ground. If the demon dies, is affected by a {@trait teleportation} effect, or consumes an extradimensional space (such as a bag of holding), they vomit up all the items."
+							"The nalfeshnee steals all unattended items glowing with its Light of Avarice into an extradimensional space. The demon can {@action Interact} to regurgitate any number of these items into their hand or onto the ground. If the demon dies, is affected by a {@trait teleportation} effect, or consumes an extradimensional space (such as a {@item bag of holding (generic)}), they vomit up all the items."
 						],
 						"name": "Claim Wealth"
 					},
@@ -36358,7 +36411,10 @@
 					},
 					"will": {
 						"std": 23
-					}
+					},
+					"abilities": [
+						"+1 status to all saves vs. magic"
+					]
 				},
 				"hp": [
 					{
@@ -42837,9 +42893,7 @@
 							"divine",
 							"necromancy"
 						],
-						"trigger": [
-							"A living creature within 30 feet of the ravener dies;"
-						],
+						"trigger": "A living creature within 30 feet of the ravener dies",
 						"entries": [
 							"The ravener tears the creature's soul from its body with their maw and gulps it down. The dying creature must attempt a DC 44 Fortitude save.",
 							{
@@ -58408,6 +58462,11 @@
 			"name": "Witchwyrd",
 			"source": "B2",
 			"page": 294,
+			"otherSources": {
+				"Originally": [
+					"AoA5|90"
+				]
+			},
 			"level": 6,
 			"traits": [
 				"uncommon",
@@ -58586,7 +58645,7 @@
 							"evocation",
 							"force"
 						],
-						"trigger": "A {@i magic missile} is fired at the witchwyrd, and the witchwyrd is aware of it and has a free hand",
+						"trigger": "A {@spell magic missile} is fired at the witchwyrd, and the witchwyrd is aware of it and has a free hand",
 						"frequency": {
 							"unit": "round",
 							"number": 1
@@ -58610,7 +58669,7 @@
 							"force"
 						],
 						"entries": [
-							"The witchwyrd fires one magic missile per action spent (dealing {@damage 1d4+1} force damage each). They can't spend more actions on this ability than they have free hands. If they use a hand that has Absorbed Force, that hand hurls two missiles instead of one, expending the held energy."
+							"The witchwyrd fires one {@spell magic missile} per action spent (dealing {@damage 1d4+1} force damage each). They can't spend more actions on this ability than they have free hands. If they use a hand that has Absorbed Force, that hand hurls two missiles instead of one, expending the held energy."
 						],
 						"name": "Force Bolt"
 					}

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -9469,6 +9469,9 @@
 			"otherSources": {
 				"Expanded": [
 					"LOIL|323"
+				],
+				"Originally": [
+					"AoA5|84"
 				]
 			},
 			"traits": [
@@ -9567,7 +9570,15 @@
 								}
 							]
 						},
-						"constant": {}
+						"constant": {
+							"6": {
+								"spells": [
+									{
+										"name": "true seeing"
+									}
+								]
+							}
+						}
 					}
 				}
 			],
@@ -9645,7 +9656,10 @@
 					},
 					"will": {
 						"std": 20
-					}
+					},
+					"abilities": [
+						"+1 status to all saves vs. magic"
+					]
 				},
 				"hp": [
 					{

--- a/data/companionsfamiliars.json
+++ b/data/companionsfamiliars.json
@@ -597,7 +597,7 @@
 					"The camel {@action Stride||Strides} twice with a +5-foot circumstance bonus to Speed, ignoring {@quickref difficult terrain||3|terrain} caused by rubble, sand, and uneven ground made of earth and stone."
 				]
 			},
-			"special": "mount; your camel ignores the harmful effects of mild, severe, and extreme cold or heat, selected when you gain the companion."
+			"special": "mount; your camel ignores the harmful effects of mild, severe, and extreme cold or heat, selected when you gain the companion"
 		},
 		{
 			"name": "Capybara",
@@ -1095,8 +1095,7 @@
 				"entries": [
 					"The {@action Strike}'s target takes {@damage 1d6} {@condition persistent damage||persistent bleed damage} and takes a \u201310-foot status penalty to its Speed until it removes the bleed damage. If the hyena is a {@quickref specialized animal companion||0|Specialized Animal Companions}, the {@condition persistent damage||persistent bleed damage} increases to {@damage 2d6}."
 				]
-			},
-			"special": "mount"
+			}
 		},
 		{
 			"name": "Monitor Lizard",
@@ -1676,6 +1675,10 @@
 				"name": "Feast on the Fallen",
 				"source": "AoA5",
 				"page": 80,
+				"traits": [
+					"healing",
+					"manipulate"
+				],
 				"frequency": {
 					"unit": "hour",
 					"number": 1

--- a/data/feats/feats-aoa5.json
+++ b/data/feats/feats-aoa5.json
@@ -108,8 +108,7 @@
 				"alchemist"
 			],
 			"entries": [
-				"Through a combination of careful manipulation and precise breath control, you can deploy inhaled toxins precisely.",
-				"When you activate an inhaled poison, you can cause it to fill a 20-foot line that's 5 feet tall rather than a 10-foot cube. You gain a +3 status bonus to saving throws against inhaled poisons that you activate."
+				"Through a combination of careful manipulation and precise breath control, you can deploy inhaled toxins precisely. When you activate an inhaled poison, you can cause it to fill a 20-foot line that's 5 feet tall rather than a 10-foot cube. You gain a +3 status bonus to saving throws against inhaled poisons that you activate."
 			]
 		},
 		{
@@ -152,7 +151,7 @@
 			"prerequisites": "member of the Zephyr Guard",
 			"access": "You are from Katapesh.",
 			"entries": [
-				"As a Zephyr Guard, you're always vigilant against crime and threats to the city's safety. You gain a +1 circumstance bonus to {@skill Perception} checks against attempts to {@action Palm an Object}, {@action Steal}, or {@action Conceal an Object} (including you're Seeking {@condition concealed} objects). You become trained in {@skill Society} and {@skill Lore||Katapesh Lore}; if you were already trained, you become an expert instead."
+				"As a Zephyr Guard, you're always vigilant against crime and threats to the city's safety. You gain a +1 circumstance bonus to {@skill Perception} checks against attempts to {@action Palm an Object}, {@action Steal}, or {@action Conceal an Object} (including you're {@action Seek||Seeking} {@condition concealed} objects). You become trained in {@skill Society} and {@skill Lore||Katapesh Lore}; if you were already trained, you become an expert instead."
 			],
 			"special": [
 				"You can't select another dedication feat until you have gained two other feats from the Zephyr Guard archetype."

--- a/data/feats/feats-av3.json
+++ b/data/feats/feats-av3.json
@@ -6,7 +6,9 @@
 			"page": 77,
 			"level": 2,
 			"featType": {
-				"archetype": ["Drow Shootist"]
+				"archetype": [
+					"Drow Shootist"
+				]
 			},
 			"traits": [
 				"uncommon",
@@ -47,7 +49,9 @@
 			"page": 77,
 			"level": 8,
 			"featType": {
-				"archetype": ["Drow Shootist"]
+				"archetype": [
+					"Drow Shootist"
+				]
 			},
 			"traits": [
 				"archetype"
@@ -67,7 +71,9 @@
 			},
 			"level": 6,
 			"featType": {
-				"archetype": ["Drow Shootist"]
+				"archetype": [
+					"Drow Shootist"
+				]
 			},
 			"traits": [
 				"archetype",
@@ -92,7 +98,9 @@
 			"page": 77,
 			"level": 4,
 			"featType": {
-				"archetype": ["Drow Shootist"]
+				"archetype": [
+					"Drow Shootist"
+				]
 			},
 			"traits": [
 				"archetype"

--- a/data/feats/feats-tv.json
+++ b/data/feats/feats-tv.json
@@ -222,9 +222,10 @@
 		{
 			"name": "First Frost",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 2,
@@ -239,9 +240,10 @@
 		{
 			"name": "Snowcaster",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 4,
@@ -255,9 +257,10 @@
 		{
 			"name": "Snow Step",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 6,
@@ -271,9 +274,10 @@
 		{
 			"name": "Frozen Breadth",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 8,
@@ -287,9 +291,10 @@
 		{
 			"name": "Winter's Embrace",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 10,
@@ -304,9 +309,10 @@
 		{
 			"name": "Expert Snowcasting",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 12,
@@ -320,9 +326,10 @@
 		{
 			"name": "Winter's Kiss",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 14,
@@ -336,9 +343,10 @@
 		{
 			"name": "Greater Snow Step",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 16,
@@ -352,9 +360,10 @@
 		{
 			"name": "Master Snowcasting",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 18,
@@ -368,9 +377,10 @@
 		{
 			"name": "Icy Apotheosis",
 			"source": "TV",
-
 			"featType": {
-				"archetype": ["Gelid Shard"]
+				"archetype": [
+					"Gelid Shard"
+				]
 			},
 			"page": 185,
 			"level": 20,

--- a/data/hazards.json
+++ b/data/hazards.json
@@ -3936,8 +3936,7 @@
 					"types": [
 						"acid",
 						"piercing"
-					],
-					"noMAP": true
+					]
 				}
 			]
 		},
@@ -5805,7 +5804,7 @@
 			],
 			"disable": {
 				"entries": [
-					"{@skill Occultism} DC 36 (master) or {@skill Religion} DC 36 (master) to exorcise the spirits."
+					"{@skill Occultism} DC 36 (master) or {@skill Religion} DC 36 (master) to exorcise the spirits"
 				]
 			},
 			"actions": [
@@ -7609,14 +7608,36 @@
 					"{@skill Occultism} DC 38 (master) or {@skill Religion} DC 38 (master) to calm the restless energies and suppress the haunt for 1 hour; a critical success deactivates the haunt permanently."
 				]
 			},
+			"defenses": {
+				"ac": {
+					"std": 20
+				},
+				"savingThrows": {
+					"fort": {
+						"std": 13
+					},
+					"ref": {
+						"std": 5
+					}
+				},
+				"hardness": {
+					"Painting ": 15
+				},
+				"hp": {
+					"Painting ": 30,
+					"notes": {
+						"Painting ": "per square (6 squares must be destroyed to disable the haunt)"
+					}
+				},
+				"immunities": [
+					"critical hits",
+					"object immunities",
+					"precision damage"
+				]
+			},
 			"actions": [
 				{
-					"entries": [
-						"20; Fort +13, Ref +5 Painting Hardness 15; Painting HP 30 per square (6 squares must be destroyed to disable the haunt); Immunities critical hits, object immunities, precision damage."
-					],
-					"name": "Painting AC"
-				},
-				{
+					"name": "Lifelike Scintillation",
 					"activity": {
 						"number": 1,
 						"unit": "reaction"
@@ -7628,13 +7649,14 @@
 					"trigger": "A living creature examines the mural or enters the room",
 					"entries": [
 						"The haunt activates and rolls initiative."
-					],
-					"name": "Lifelike Scintillation"
+					]
 				}
 			],
 			"routine": [
-				"(2 actions) The haunt lures creatures into area A2 using Captivate. Any actions it hasn't used to Captivate are used to drain a living creature in the room with Live a Thousand Lives.",
+				"(2 actions) The haunt lures creatures into area {@b A2} using Captivate. Any actions it hasn't used to Captivate are used to drain a living creature in the room with Live a Thousand Lives.",
 				{
+					"name": "Captivate",
+					"type": "ability",
 					"activity": {
 						"number": 1,
 						"unit": "action"
@@ -7651,15 +7673,50 @@
 						{
 							"type": "successDegree",
 							"entries": {
-								"Success": "The target becomes {@condition fatigued}.",
-								"Failure": "The target becomes {@condition drained|CRB|drained 1} (or its {@condition drained} value increases by 1, to a maximum of {@condition drained|CRB|drained 3}), and it is {@condition paralyzed} until the end of its next turn.",
-								"Critical Failure": "As failure, but the target also becomes {@condition doomed|CRB|doomed 1} (or its {@condition doomed} value increases by 1).",
-								"Critical Success": "The target is unaffected."
+								"Success": [
+									"The target is unaffected."
+								],
+								"Failure": [
+									"The target must spend all its actions on its next turn moving into the room, and is then {@condition paralyzed} until the end of its next turn."
+								],
+								"Critical Failure": [
+									"As failure, and the target is also {@condition stupefied||stupefied 2} for 1 minute."
+								]
 							}
 						}
-					],
+					]
+				},
+				{
+					"name": "Live a Thousand Lives",
 					"type": "ability",
-					"name": "Captivate"
+					"activity": {
+						"number": 1,
+						"unit": "action"
+					},
+					"traits": [
+						"mental",
+						"occult"
+					],
+					"entries": [
+						"The haunt causes a living creature in the room to experience a full elven life, weathering every wound, misfortune, loss, and consequence of aging centuries in a matter of seconds. The target must attempt a DC 38 Fortitude save.",
+						{
+							"type": "successDegree",
+							"entries": {
+								"Critical Success": [
+									"The target is unaffected."
+								],
+								"Success": [
+									"The target becomes {@condition fatigued}."
+								],
+								"Failure": [
+									"The target becomes {@condition drained||drained 1} (or its {@condition drained} value increases by 1, to a maximum of {@condition drained||drained 3}), and it is {@condition paralyzed} until the end of its next turn."
+								],
+								"Critical Failure": [
+									"As failure, but the target also becomes {@condition doomed||doomed 1} (or its {@condition doomed} value increases by 1)."
+								]
+							}
+						}
+					]
 				}
 			],
 			"reset": [
@@ -10450,7 +10507,7 @@
 			],
 			"disable": {
 				"entries": [
-					"{@skill Thievery} DC 40 (master) to disable the wards or dispel magic (9th level; counteract DC 38) to counteract the ward."
+					"{@skill Thievery} DC 40 (master) to disable the wards or dispel magic (9th level; counteract DC 38) to counteract the ward"
 				]
 			},
 			"actions": [
@@ -10829,7 +10886,7 @@
 			],
 			"disable": {
 				"entries": [
-					"{@skill Arcana} (DC 41) to suppress the magic or {@skill Thievery} (DC 41) to scratch out the ward."
+					"{@skill Arcana} (DC 41) to suppress the magic or {@skill Thievery} (DC 41) to scratch out the ward"
 				]
 			},
 			"actions": [
@@ -12606,7 +12663,7 @@
 			],
 			"disable": {
 				"entries": [
-					"{@skill Thievery} DC 43 (master) to disable the wards or dispel magic (9th level; counteract DC 38) to counteract the ward."
+					"{@skill Thievery} DC 43 (master) to disable the wards or {@spell dispel magic} (9th level; counteract DC 38) to counteract the ward."
 				]
 			},
 			"actions": [

--- a/data/items/items-aoa5.json
+++ b/data/items/items-aoa5.json
@@ -16,7 +16,7 @@
 			"bulk": "\u2013",
 			"category": "Worn",
 			"entries": [
-				"This ornate pendant of brass is adorned with a vibrant blue gemstone. An aluum charm grants control over a particular aluum and lesser influence over other such constructs. As long as you wear an aluum's linked aluum charm, that aluum follows your verbal commands, including somewhat nuanced orders like \"subdue this target\" or \"strike anyone wearing a blue robe.\"",
+				"This ornate pendant of brass is adorned with a vibrant blue gemstone. An {@i aluum charm} grants control over a particular aluum and lesser influence over other such constructs. As long as you wear an aluum's linked {@i aluum charm}, that aluum follows your verbal commands, including somewhat nuanced orders like \"subdue this target\" or \"strike anyone wearing a blue robe.\"",
 				{
 					"type": "ability",
 					"activity": {
@@ -31,7 +31,7 @@
 						"number": 1
 					},
 					"entries": [
-						"The charm grants you control over an aluum you can see within 60 feet, with a level equal to or lower than the charm. This has the effect of dominate and allows a DC 28 Will save. If the aluum is currently under the control of someone wearing its linked charm, it gets a result on its saving throw one degree higher than what it rolled. You can control only one aluum at a time using this activation, and controlling a new aluum ends the effect for one you had previously affected."
+						"The charm grants you control over an aluum you can see within 60 feet, with a level equal to or lower than the charm. This has the effect of {@spell dominate} and allows a DC 28 Will save. If the aluum is currently under the control of someone wearing its linked charm, it gets a result on its saving throw one degree higher than what it rolled. You can control only one aluum at a time using this activation, and controlling a new aluum ends the effect for one you had previously affected."
 					]
 				}
 			]
@@ -145,110 +145,6 @@
 							"stage": 3,
 							"entry": "{@damage 8d6} mental damage, {@condition fatigued}, attack nearby creatures as if {@condition confused}",
 							"duration": "1 round"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Gorgon's Breath",
-			"source": "AoA5",
-			"page": 78,
-			"type": "Item",
-			"level": 13,
-			"traits": [
-				"uncommon",
-				"alchemical",
-				"consumable",
-				"inhaled",
-				"poison"
-			],
-			"price": {
-				"coin": "gp",
-				"amount": 475
-			},
-			"usage": "held in 1 hand",
-			"bulk": "L",
-			"activate": {
-				"activity": {
-					"number": 1,
-					"unit": "action"
-				},
-				"components": [
-					"{@action Interact}"
-				]
-			},
-			"category": "Poison",
-			"entries": [
-				"Gorgon's breath is a fine powder that can easily enter living creatures' bloodstreams through their lungs before binding to mucous membranes and causing any nearby soft tissues to harden.",
-				{
-					"type": "affliction",
-					"DC": 32,
-					"savingThrow": "Fortitude",
-					"onset": "1 round",
-					"maxDuration": "6 rounds",
-					"stages": [
-						{
-							"stage": 1,
-							"entry": "{@condition slowed|CRB|slowed 1}",
-							"duration": "1 round"
-						},
-						{
-							"stage": 2,
-							"entry": "{@damage 4d6} bludgeoning damage and {@condition slowed|CRB|slowed 1}",
-							"duration": "1 round"
-						},
-						{
-							"stage": 3,
-							"entry": "{@condition petrified} ;",
-							"duration": "1 round"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Grinning Pugwampi",
-			"source": "AoA5",
-			"page": 77,
-			"type": "Item",
-			"level": 14,
-			"traits": [
-				"uncommon",
-				"consumable",
-				"enchantment",
-				"magical",
-				"misfortune",
-				"talisman"
-			],
-			"price": {
-				"coin": "gp",
-				"amount": 700
-			},
-			"usage": "affixed to weapon",
-			"bulk": "\u2013",
-			"category": "Talisman",
-			"entries": [
-				"This bone statuette of a sneering gremlin crumbles to dust when activated, imparting a fraction of its subject's infamous misfortune unto those you strike.",
-				{
-					"type": "ability",
-					"activity": {
-						"number": 1,
-						"unit": "free"
-					},
-					"components": [
-						"envision"
-					],
-					"trigger": "You damage a {@condition flat-footed} creature with the affixed weapon",
-					"entries": [
-						"The damaged creature must attempt a DC 33 Will save.",
-						{
-							"type": "successDegree",
-							"entries": {
-								"Critical Success": "The creature is unaffected.",
-								"Success": "The creature must roll twice and take the worse result on the next check it attempts.",
-								"Failure": "The creature must roll twice and take the worse result on all checks until the end of its next turn."
-							}
 						}
 					]
 				}
@@ -387,8 +283,7 @@
 			"bulk": 1,
 			"category": "Held",
 			"entries": [
-				"This round shield is often fashioned to resemble the religious symbol of its dual-natured namesake.",
-				"A Nethysian bulwark is a high-grade cold iron shield (Hardness 10, HP 40, BT 20) that defends the wielder and can explode with retributive force when struck.",
+				"This round shield is often fashioned to resemble the religious symbol of its dual-natured namesake. A {@i Nethysian bulwark} is a high-grade cold iron shield (Hardness 10, HP 40, BT 20) that defends the wielder and can explode with retributive force when struck.",
 				{
 					"type": "ability",
 					"activity": {
@@ -398,66 +293,9 @@
 					"components": [
 						"envision"
 					],
-					"trigger": "The shield becomes {@condition broken} when performing a",
+					"trigger": "The shield becomes {@condition broken} when performing a {@feat Shield Block}",
 					"entries": [
 						"The shield explodes in a burst of bright light and shadowy tendrils, releasing a 15-foot cone of force that must include the attacker if possible. The cone deals {@damage 6d8} force damage to all creatures in the area (DC 34 basic Reflex save)."
-					]
-				}
-			]
-		},
-		{
-			"name": "Nightmare Salt",
-			"source": "AoA5",
-			"page": 79,
-			"type": "Item",
-			"level": 20,
-			"traits": [
-				"rare",
-				"alchemical",
-				"consumable",
-				"ingested",
-				"poison"
-			],
-			"price": {
-				"coin": "gp",
-				"amount": 14000
-			},
-			"usage": "held in 2 hands",
-			"bulk": "L",
-			"activate": {
-				"activity": {
-					"number": 3,
-					"unit": "action"
-				},
-				"components": [
-					"{@action Interact}"
-				]
-			},
-			"category": "Poison",
-			"entries": [
-				"This potent poison consists of crystals whose flavor and appearance mimics edible salt but whose effects are deadly: victims experience periods of waking nightmares that overload the senses and eventually result in death through a combination of shock and exhaustion.",
-				{
-					"type": "affliction",
-					"DC": 43,
-					"savingThrow": "Fortitude",
-					"onset": "1 hour",
-					"maxDuration": "5 days",
-					"stages": [
-						{
-							"stage": 1,
-							"entry": "{@condition frightened|CRB|frightened 2} once every {@dice 1d4} hours, plus {@condition fatigued}",
-							"duration": "1 day"
-						},
-						{
-							"stage": 2,
-							"entry": "{@condition confused} for 1 minute once every {@dice 1d4} hours, plus {@condition frightened|CRB|frightened 3} and {@condition fatigued}",
-							"duration": "1 day"
-						},
-						{
-							"stage": 3,
-							"entry": "{@condition frightened|CRB|frightened 3}, plus {@condition confused} for {@dice 1d4} minutes, once every hour, plus {@condition fatigued} ;",
-							"duration": "1 day"
-						}
 					]
 				}
 			]

--- a/data/items/items-tv.json
+++ b/data/items/items-tv.json
@@ -23085,6 +23085,11 @@
 			"name": "Grinning Pugwampi",
 			"source": "TV",
 			"page": 94,
+			"otherSources": {
+				"Originally": [
+					"AoA5|77"
+				]
+			},
 			"type": "Item",
 			"level": 14,
 			"traits": [
@@ -28325,6 +28330,11 @@
 			"name": "Gorgon's Breath",
 			"source": "TV",
 			"page": 69,
+			"otherSources": {
+				"Originally": [
+					"AoA5|78"
+				]
+			},
 			"type": "Item",
 			"level": 13,
 			"traits": [
@@ -28624,6 +28634,11 @@
 			"name": "Nightmare Salt",
 			"source": "TV",
 			"page": 70,
+			"otherSources": {
+				"Originally": [
+					"AoA5|79"
+				]
+			},
 			"type": "Item",
 			"level": 20,
 			"traits": [

--- a/js/render.js
+++ b/js/render.js
@@ -3907,6 +3907,9 @@ Renderer.action = {
 		if (it.trigger != null) {
 			renderStack.push(`<p class="pf2-stat pf2-stat__section"><strong>Trigger&nbsp;</strong>${renderer.render(it.trigger)}</p>`);
 		}
+		if (it.overcome != null) {
+			renderStack.push(`<p class="pf2-stat pf2-stat__section"><strong>Overcome&nbsp;</strong>${renderer.render(it.overcome)}</p>`);
+		}
 		if (it.requirements != null) {
 			renderStack.push(`<p class="pf2-stat pf2-stat__section"><strong>Requirements&nbsp;</strong>${renderer.render(it.requirements)}</p>`);
 		}
@@ -4117,11 +4120,11 @@ Renderer.companion = {
 		${Renderer.utils.getTraitsDiv(companion.traits)}
 		${companion.access ? `<p class="pf2-stat pf2-stat__section"><strong>Access&nbsp;</strong>${renderer.render(companion.access)}</p>` : ""}
 		${(companion.traits && companion.traits.length) || companion.access ? Renderer.utils.getDividerDiv() : ""}
-		<p class="pf2-stat pf2-stat__section"><strong>Size&nbsp;</strong>${companion.size}</p>
+		<p class="pf2-stat pf2-stat__section"><strong>Size&nbsp;</strong>${companion.size.map(s => s.toTitleCase()).join(" or ")}</p>
 		${Renderer.creature.getAttacks(companion)}
 		${Renderer.creature.getAbilityMods(companion.abilityMods)}
 		<p class="pf2-stat pf2-stat__section"><strong>Hit Points&nbsp;</strong>${companion.hp}</p>
-		<p class="pf2-stat pf2-stat__section"><strong>Skill&nbsp;</strong>${renderer.render(`{@skill ${companion.skill}}`)}</p>
+		<p class="pf2-stat pf2-stat__section"><strong>Skill&nbsp;</strong>${renderer.render(`{@skill ${companion.skill.toTitleCase()}}`)}</p>
 		${Renderer.companionfamiliar.getRenderedSenses(companion)}
 		${Renderer.creature.getSpeed(companion)}
 		${companion.special ? `<p class="pf2-stat pf2-stat__section"><strong>Special&nbsp;</strong>${renderer.render(companion.special)}</p>` : ""}
@@ -4558,6 +4561,7 @@ Renderer.creature = {
 		const $ele = $$`<p class="pf2-stat pf2-stat__section ${buttonClass} ${opts.isRenderingGeneric ? "hidden" : ""}"><strong>${abilityName}</strong>
 					${ability.activity ? renderer.render(Parser.timeToFullEntry(ability.activity)) : ""}
 					${isRenderButton ? Renderer.creature.getAbilityTextButton(buttonClass, opts.isRenderingGeneric) : ""}
+					${ability.components && ability.components.length ? `${ability.components.map(t => renderer.render(t)).join(", ")} ` : ""}
 					${ability.traits && ability.traits.length ? `(${ability.traits.map(t => renderer.render(`{@trait ${t.toLowerCase()}}`)).join(", ")}) ` : ""}
 					${ability.note ? renderer.render_addTerm(ability.note) : ""}
 					${ability.frequency ? `<strong>Frequency&nbsp;</strong>${renderer.render_addTerm(Parser.freqToFullEntry(ability.frequency))}` : ""}

--- a/test/schema-template/actions.json
+++ b/test/schema-template/actions.json
@@ -147,6 +147,9 @@
 					"cost": {
 						"type": "string"
 					},
+					"overcome": {
+						"type": "string"
+					},
 					"info": {
 						"type": "array",
 						"items": {


### PR DESCRIPTION
* General typo fixes
* schema
  * add `overcome` property for actions.
* renderer
  * render `overcome` properties for actions
  * render `components` in creature abilities
* Add missing AoA5 actions & remove AoA5 content that has been reprinted in later core books & add corresponding Originally links