### PR TITLE
Update book-gmg.json: remove link from heading

### DIFF
--- a/data/book/book-gmg.json
+++ b/data/book/book-gmg.json
@@ -5215,7 +5215,7 @@
 							"type": "pf2-h2",
 							"source": "GMG",
 							"page": 64,
-							"name": "{@action Strike||Strikes}",
+							"name": "Strikes",
 							"entries": [
 								"When building your creature's selection of {@action Strike||Strikes}, use the following sections to set the {@action Strike}'s attack bonus and damage. Give the attack all the normal traits if it's a weapon; for unarmed attacks or weapons you invent, give whatever traits you feel are appropriate. Note that these traits might influence the damage you give the {@action Strike}.",
 								"You might want to make sure a creature has an unarmed attack if you think it's likely to get disarmed. At 7th level and higher, PCs might have the ability to fly, which makes it more important for creatures to have decent ranged {@action Strike||Strikes} to make sure they aren't totally hopeless against flying PCs (though they could instead have fast fly Speeds or something similar)",


### PR DESCRIPTION
Cross-referencing the header is not possible w/ the link present..
(the link is present in the text immediately following)