### PR TITLE
Add alias entries for several BB creatures

### DIFF
--- a/data/bestiary/creatures-bb.json
+++ b/data/bestiary/creatures-bb.json
@@ -496,6 +496,9 @@
 		},
 		{
 			"name": "Cat, Leopard",
+			"alias": [
+				"Leopard"
+			],
 			"source": "BB",
 			"page": 59,
 			"level": 2,
@@ -633,6 +636,9 @@
 		},
 		{
 			"name": "Centipede, Giant",
+			"alias": [
+				"Giant Centipede"
+			],
 			"source": "BB",
 			"page": 59,
 			"level": -1,
@@ -856,6 +862,9 @@
 		},
 		{
 			"name": "Dragon, Wyrmling Green",
+			"alias": [
+				"Wyrmling Green Dragon"
+			],
 			"source": "BB",
 			"page": 60,
 			"level": 4,
@@ -1529,6 +1538,9 @@
 		},
 		{
 			"name": "Elemental, Brine Shark",
+			"alias": [
+				"Brine Shark"
+			],
 			"source": "BB",
 			"page": 62,
 			"level": 3,
@@ -1643,6 +1655,9 @@
 		},
 		{
 			"name": "Elemental, Cinder Rat",
+			"alias": [
+				"Cinder Rat"
+			],
 			"source": "BB",
 			"page": 63,
 			"level": 3,
@@ -1754,6 +1769,9 @@
 		},
 		{
 			"name": "Elemental, Sod Hound",
+			"alias": [
+				"Sod Hound"
+			],
 			"source": "BB",
 			"page": 63,
 			"level": 3,
@@ -1861,6 +1879,9 @@
 		},
 		{
 			"name": "Elemental, Zephyr Hawk",
+			"alias": [
+				"Zephyr Hawk"
+			],
 			"source": "BB",
 			"page": 64,
 			"level": 3,
@@ -1955,6 +1976,9 @@
 		},
 		{
 			"name": "Gargoyle",
+			"alias": [
+				"Gargoyle Guardian"
+			],
 			"source": "BB",
 			"page": 64,
 			"level": 4,
@@ -2731,6 +2755,9 @@
 		},
 		{
 			"name": "Gremlin, Pugwampi",
+			"alias": [
+				"Pugwampi"
+			],
 			"source": "BB",
 			"page": 67,
 			"level": 0,
@@ -3966,6 +3993,9 @@
 		},
 		{
 			"name": "Ooze, Sewer",
+			"alias": [
+				"Sewer Ooze"
+			],
 			"source": "BB",
 			"page": 72,
 			"level": 1,
@@ -4602,6 +4632,9 @@
 		},
 		{
 			"name": "Rat, Giant",
+			"alias": [
+				"Giant Rat"
+			],
 			"source": "BB",
 			"page": 75,
 			"level": -1,
@@ -4946,6 +4979,9 @@
 		},
 		{
 			"name": "Skeleton, Skeletal Giant",
+			"alias": [
+				"Skeletal Giant"
+			],
 			"source": "BB",
 			"page": 76,
 			"level": 3,
@@ -5089,6 +5125,9 @@
 		},
 		{
 			"name": "Snake, Giant Viper",
+			"alias": [
+				"Giant Viper"
+			],
 			"source": "BB",
 			"page": 77,
 			"level": 2,
@@ -5209,6 +5248,9 @@
 		},
 		{
 			"name": "Snake, Viper",
+			"alias": [
+				"Viper"
+			],
 			"source": "BB",
 			"page": 77,
 			"level": -1,
@@ -5320,6 +5362,9 @@
 		},
 		{
 			"name": "Spider, Giant",
+			"alias": [
+				"Giant Spider"
+			],
 			"source": "BB",
 			"page": 78,
 			"level": 1,

--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -27,6 +27,12 @@
 					"name": {
 						"type": "string"
 					},
+					"alias": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
 					"page": {
 						"type": "integer",
 						"exclusiveMinimum": 0


### PR DESCRIPTION
BB names some creatures as `<creature type>, <creature>` or `<creature>, Giant`.

Also add more regular Pathfinder 2 names as aliases. These are also used in TiO to reference the BB creatures.