### PR TITLE
Improve beginner box creature & hazard rendering

### DIFF
--- a/data/bestiary/creatures-bb.json
+++ b/data/bestiary/creatures-bb.json
@@ -53,6 +53,7 @@
 			"source": "BB",
 			"page": 57,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -159,6 +160,7 @@
 			"source": "BB",
 			"page": 57,
 			"level": 5,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -266,6 +268,7 @@
 			"source": "BB",
 			"page": 58,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -369,6 +372,7 @@
 			"source": "BB",
 			"page": 47,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"medium",
@@ -499,6 +503,7 @@
 			"source": "BB",
 			"page": 59,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -636,6 +641,7 @@
 			"source": "BB",
 			"page": 59,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -730,6 +736,7 @@
 			"source": "BB",
 			"page": 60,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -859,6 +866,7 @@
 			"source": "BB",
 			"page": 60,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"medium",
@@ -1043,6 +1051,7 @@
 			"source": "BB",
 			"page": 61,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -1197,6 +1206,7 @@
 			"source": "BB",
 			"page": 61,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -1280,6 +1290,7 @@
 					"type": "Prepared",
 					"tradition": "divine",
 					"DC": 21,
+					"note": "The drow priestess can cast these cleric spells",
 					"entry": {
 						"0": {
 							"level": 2,
@@ -1391,6 +1402,7 @@
 			"source": "BB",
 			"page": 62,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -1532,6 +1544,7 @@
 			"source": "BB",
 			"page": 62,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -1646,6 +1659,7 @@
 			"source": "BB",
 			"page": 63,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"small",
@@ -1757,6 +1771,7 @@
 			"source": "BB",
 			"page": 63,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"small",
@@ -1864,6 +1879,7 @@
 			"source": "BB",
 			"page": 64,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"small",
@@ -1958,6 +1974,7 @@
 			"source": "BB",
 			"page": 64,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -2089,6 +2106,7 @@
 			"source": "BB",
 			"page": 65,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -2235,6 +2253,7 @@
 			"source": "BB",
 			"page": 65,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -2379,6 +2398,7 @@
 			"source": "BB",
 			"page": 66,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"small",
@@ -2494,6 +2514,7 @@
 			"source": "BB",
 			"page": 66,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"small",
@@ -2551,6 +2572,7 @@
 					"tradition": "arcane",
 					"DC": 16,
 					"attack": 6,
+					"note": "The goblin igniter can cast these wizard spells",
 					"entry": {
 						"0": {
 							"level": 1,
@@ -2619,6 +2641,7 @@
 			"source": "BB",
 			"page": 67,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"small",
@@ -2734,6 +2757,7 @@
 			"source": "BB",
 			"page": 67,
 			"level": 0,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"tiny",
@@ -2862,6 +2886,7 @@
 			"source": "BB",
 			"page": 68,
 			"level": 5,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -2990,6 +3015,7 @@
 			"source": "BB",
 			"page": 68,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"medium",
@@ -3109,6 +3135,7 @@
 			"source": "BB",
 			"page": 69,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"medium",
@@ -3227,6 +3254,7 @@
 			"source": "BB",
 			"page": 69,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"small",
@@ -3305,6 +3333,7 @@
 					"tradition": "arcane",
 					"DC": 20,
 					"attack": 12,
+					"note": "The dragon mage can cast these wizard spells",
 					"entry": {
 						"0": {
 							"level": 1,
@@ -3392,6 +3421,7 @@
 			"source": "BB",
 			"page": 70,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"small",
@@ -3518,6 +3548,7 @@
 			"source": "BB",
 			"page": 70,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"small",
@@ -3654,6 +3685,7 @@
 			"source": "BB",
 			"page": 71,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"small",
@@ -3768,6 +3800,7 @@
 			"source": "BB",
 			"page": 71,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -3877,6 +3910,7 @@
 			"source": "BB",
 			"page": 72,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"large",
@@ -3969,6 +4003,7 @@
 			"source": "BB",
 			"page": 72,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -4072,6 +4107,7 @@
 			"source": "BB",
 			"page": 73,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -4213,6 +4249,7 @@
 			"source": "BB",
 			"page": 73,
 			"level": 0,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -4335,6 +4372,7 @@
 			"source": "BB",
 			"page": 74,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -4473,6 +4511,7 @@
 			"source": "BB",
 			"page": 74,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"large",
@@ -4605,6 +4644,7 @@
 			"source": "BB",
 			"page": 75,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"small",
@@ -4685,6 +4725,7 @@
 			"source": "BB",
 			"page": 75,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -4816,6 +4857,7 @@
 			"source": "BB",
 			"page": 76,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"large",
@@ -4949,6 +4991,7 @@
 			"source": "BB",
 			"page": 76,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"large",
@@ -5092,6 +5135,7 @@
 			"source": "BB",
 			"page": 77,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -5212,6 +5256,7 @@
 			"source": "BB",
 			"page": 77,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"tiny",
@@ -5323,6 +5368,7 @@
 			"source": "BB",
 			"page": 78,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -5444,6 +5490,7 @@
 			"source": "BB",
 			"page": 78,
 			"level": 5,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"large",
@@ -5569,6 +5616,7 @@
 			"source": "BB",
 			"page": 79,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"medium",
@@ -5699,6 +5747,7 @@
 			"source": "BB",
 			"page": 79,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"le",
 				"medium",
@@ -5808,6 +5857,7 @@
 			"source": "BB",
 			"page": 80,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"medium",
@@ -5908,6 +5958,7 @@
 			"source": "BB",
 			"page": 80,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -6046,6 +6097,7 @@
 			"source": "BB",
 			"page": 81,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -6165,6 +6217,7 @@
 			"source": "BB",
 			"page": 81,
 			"level": -1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"medium",

--- a/data/bestiary/creatures-tio.json
+++ b/data/bestiary/creatures-tio.json
@@ -225,6 +225,7 @@
 			"page": 11,
 			"hasImages": true,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"n",
 				"large",
@@ -372,6 +373,7 @@
 			"source": "TiO",
 			"page": 36,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"unique",
 				"le",
@@ -464,6 +466,7 @@
 					"type": "Prepared",
 					"DC": 21,
 					"attack": 13,
+					"note": "Hargrit can cast these cleric spells",
 					"entry": {
 						"0": {
 							"level": 2,
@@ -613,6 +616,7 @@
 			"source": "TiO",
 			"page": 33,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"unique",
 				"le",
@@ -756,6 +760,7 @@
 			"source": "TiO",
 			"page": 61,
 			"level": 6,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"uncommon",
 				"ce",
@@ -973,6 +978,7 @@
 			"source": "TiO",
 			"page": 35,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"unique",
 				"ne",
@@ -1049,6 +1055,7 @@
 					"tradition": "arcane",
 					"DC": 21,
 					"attack": 13,
+					"note": "Morgrym can cast these wizard spells",
 					"entry": {
 						"0": {
 							"level": 2,
@@ -1188,6 +1195,7 @@
 			"source": "TiO",
 			"page": 37,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"unique",
 				"ne",
@@ -1329,6 +1337,7 @@
 			"page": 40,
 			"hasImages": true,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ce",
 				"medium",
@@ -1453,6 +1462,7 @@
 			"source": "TiO",
 			"page": 62,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"uncommon",
 				"cg",
@@ -1635,6 +1645,7 @@
 			"source": "TiO",
 			"page": 63,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"ne",
 				"small",

--- a/data/hazards.json
+++ b/data/hazards.json
@@ -6111,13 +6111,14 @@
 			"source": "TiO",
 			"page": 14,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"mechanical",
 				"trap"
 			],
 			"stealth": {
 				"dc": 19,
-				"notes": "{@skill Perception} check (or 0 after the hazard is triggered)"
+				"notes": "(or 0 after the hazard is triggered)"
 			},
 			"description": [
 				"A section of splintery and rotten floorboards drop a creature 6 feet onto uneven rocks and piercing shards of wood."
@@ -10580,6 +10581,7 @@
 			"source": "TiO",
 			"page": 28,
 			"level": 5,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"complex",
 				"magical",
@@ -10587,7 +10589,7 @@
 			],
 			"stealth": {
 				"dc": 22,
-				"notes": "{@skill Perception} check to spot the magical energies reverberating in the pillars"
+				"notes": "to spot the magical energies reverberating in the pillars"
 			},
 			"description": [
 				"Starknife symbols on the six pillars glow and shoot across the room."
@@ -11150,6 +11152,7 @@
 			"source": "TiO",
 			"page": 41,
 			"level": 6,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"complex",
 				"magical",
@@ -11157,7 +11160,7 @@
 			],
 			"stealth": {
 				"dc": 22,
-				"notes": "{@skill Perception} to detect the subtle magical aura of the land"
+				"notes": "to detect the subtle magical aura of the land"
 			},
 			"description": [
 				"What seems like an innocent stretch of land assaults trespassers with terrible illusions."
@@ -14319,14 +14322,14 @@
 			"source": "TiO",
 			"page": 44,
 			"level": 5,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"complex",
 				"mechanical",
 				"trap"
 			],
 			"stealth": {
-				"dc": 23,
-				"notes": "{@skill Perception}."
+				"dc": 23
 			},
 			"description": [
 				"Nozzles {@condition hidden} in the ceiling of the four corridors leading to the intersection spray jets of flame along their lengths when the trap is triggered."
@@ -15925,14 +15928,14 @@
 			"source": "TiO",
 			"page": 31,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"uncommon",
 				"mechanical",
 				"trap"
 			],
 			"stealth": {
-				"dc": 15,
-				"notes": "{@skill Perception} check"
+				"dc": 15
 			},
 			"description": [
 				"A ceramic urn containing a coiled viper tips and shatters when a tripwire is pulled."
@@ -16501,13 +16504,13 @@
 			"source": "TiO",
 			"page": 17,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [
 				"mechanical",
 				"trap"
 			],
 			"stealth": {
-				"dc": 22,
-				"notes": "{@skill Perception} check"
+				"dc": 22
 			},
 			"description": [
 				"Discreet webbing at throat level snags a creature that walks into it."
@@ -16566,7 +16569,7 @@
 					"range": "Melee",
 					"name": "noose",
 					"attack": 13,
-					"effects": [
+					"traits": [
 						"deadly <d10>"
 					],
 					"damage": "{@damage 3d6} bludgeoning and the target gains the {@condition grabbed} condition is and pulled off the ground ({@action Escape} DC 22).",
@@ -18195,10 +18198,10 @@
 			"source": "BB",
 			"page": 12,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"stealth": {
-				"dc": 20,
-				"notes": "{@skill Perception} check"
+				"dc": 20
 			},
 			"disable": {
 				"entries": [
@@ -18234,10 +18237,10 @@
 			"source": "BB",
 			"page": 14,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"stealth": {
-				"dc": 20,
-				"notes": "{@skill Perception} check"
+				"dc": 20
 			},
 			"disable": {
 				"entries": [
@@ -18276,10 +18279,11 @@
 			"source": "BB",
 			"page": 21,
 			"level": 3,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"stealth": {
-				"bonus": 10,
-				"notes": "; DC 20 {@skill Perception} check to notice."
+				"dc": 20,
+				"bonus": 10
 			},
 			"disable": {
 				"entries": [
@@ -18342,13 +18346,14 @@
 			"source": "BB",
 			"page": 49,
 			"level": 0,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"description": [
 				"A wooden trapdoor covers a 10-foot square pit that's 20 feet deep."
 			],
 			"stealth": {
 				"dc": 18,
-				"notes": "{@skill Perception} check (or DC 0 if the trapdoor is disabled or {@condition broken})."
+				"notes": "(or DC 0 if the trapdoor is disabled or {@condition broken})."
 			},
 			"disable": {
 				"entries": [
@@ -18399,13 +18404,13 @@
 			"source": "BB",
 			"page": 49,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"description": [
 				"A spring-loaded, poisoned spine is hidden near the keyhole of a lock. Disabling or breaking the trap doesn't disable or break the lock."
 			],
 			"stealth": {
-				"dc": 17,
-				"notes": "{@skill Perception} check"
+				"dc": 17
 			},
 			"disable": {
 				"entries": [
@@ -18459,13 +18464,13 @@
 			"source": "BB",
 			"page": 49,
 			"level": 1,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"description": [
 				"Pressure-sensitive panels in the floor connect to a stone slab hidden in a hallway's ceiling."
 			],
 			"stealth": {
-				"dc": 17,
-				"notes": "{@skill Perception} check"
+				"dc": 17
 			},
 			"disable": {
 				"entries": [
@@ -18520,10 +18525,10 @@
 			"source": "BB",
 			"page": 49,
 			"level": 2,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"stealth": {
-				"dc": 20,
-				"notes": "{@skill Perception} check"
+				"dc": 20
 			},
 			"description": [
 				"A wall socket loaded with a spear connects to a floor tile in one 5-foot square."
@@ -18580,10 +18585,10 @@
 			"source": "BB",
 			"page": 49,
 			"level": 4,
+			"beginnerBoxLayout": true,
 			"traits": [],
 			"stealth": {
-				"dc": 23,
-				"notes": "{@skill Perception} check"
+				"dc": 23
 			},
 			"description": [
 				"Two blades, each hidden in a 15-foot-long ceiling groove, are both connected to a trip wire."

--- a/test/schema-template/bestiary.json
+++ b/test/schema-template/bestiary.json
@@ -37,6 +37,9 @@
 					"isNpc": {
 						"const": true
 					},
+					"usesBBLayout": {
+						"const": true
+					},
 					"_copy": {
 						"type": "object",
 						"properties": {

--- a/test/schema-template/hazards.json
+++ b/test/schema-template/hazards.json
@@ -31,6 +31,9 @@
 						"type": "integer",
 						"minimum": -1
 					},
+					"usesBBLayout": {
+						"const": true
+					},
 					"traits": {
 						"type": "array",
 						"items": {


### PR DESCRIPTION
Add a new hazard & creature property `beginnerBoxLayout` and adjust hazard & creature rendering when that property is set to better match the layout used in BB/TiO.

**hazard example (before/after)**

<img width="200" alt="Screenshot 2023-05-17 at 16 20 11" src="https://github.com/Pf2eToolsOrg/Pf2eTools/assets/3801202/8c8afbbe-cdb5-40dd-afc2-8a93b1ff41f6">
<img width="200" alt="Screenshot 2023-05-17 at 16 19 52" src="https://github.com/Pf2eToolsOrg/Pf2eTools/assets/3801202/95a5b1f2-16bc-40c0-823a-43b1d0e624e8">

**creature example (before/after)**

<img width="200" alt="Screenshot 2023-05-17 at 16 20 35" src="https://github.com/Pf2eToolsOrg/Pf2eTools/assets/3801202/3fc0149a-281f-40ac-98b7-462c8392f1be">
<img width="200" alt="Screenshot 2023-05-17 at 16 21 00" src="https://github.com/Pf2eToolsOrg/Pf2eTools/assets/3801202/f5ebe4e8-023f-4077-841e-b2ce002c56a5">


