### PR TITLE
add Elemental Instinct Barbarian Subclass

### DIFF
--- a/data/class/class-barbarian.json
+++ b/data/class/class-barbarian.json
@@ -160,6 +160,18 @@
 					]
 				},
 				{
+					"name": "Elemental",
+					"shortName": "Elemental",
+					"type": "Instinct",
+					"source": "RoE",
+					"page": 54,
+					"subclassFeatures": [
+						"Instinct|Barbarian|CRB|Elemental|RoE|1",
+						"Weapon Specialization|Barbarian|CRB|Elemental|RoE|7",
+						"Raging Resistance|Barbarian|CRB|Elemental|RoE|9"
+					]
+				},
+				{
 					"name": "Fury",
 					"shortName": "Fury",
 					"type": "Instinct",
@@ -902,6 +914,127 @@
 					"name": "Raging Resistance",
 					"entries": [
 						"You resist piercing damage and the damage type of your dragon's breath weapon."
+					]
+				}
+			]
+		},		
+		{
+			"name": "Instinct",
+			"source": "RoE",
+			"page": 54,
+			"className": "Barbarian",
+			"classSource": "CRB",
+			"subclassShortName": "Elemental",
+			"subclassSource": "RoE",
+			"level": 1,
+			"entries": [
+				{
+					"type": "pf2-h3",
+					"name": "Elemental Instinct",
+					"entries": [
+						"This instinct option for barbarians allows you to channel elemental forces, bonding with a single element and its associated plane. Perhaps your ancestors were elemental conjurers or blessed by an elemental lord. Select an element from {@table Elemental Instincts|RoE|Table 3\u20135: Elemental Instincts} to be your instinct's element. If your element offers multiple damage types, choose one of those type when you select your element.",
+ 					{
+							"type": "table",
+							"name": "Elemental Instincts",
+							"id": "3-5",
+							"source": "RoE",
+							"page": 54,
+							"colSizes": [
+								2,
+								2,
+								3
+							],
+							"rows": [
+								[
+									"Element",
+									"Trait",
+									"Damage"
+								],
+								[
+									"Air",
+									"{@trait Air}",
+									"Electricity or slashing"
+								],
+								[
+									"Earth",
+									"{@trait Earth}",
+									"Bludgeoning or piercing"
+								],
+								[
+									"Fire",
+									"{@trait Fire}",
+									"Fire"
+								],
+								[
+									"Metal",
+									"{@trait Metal}",
+									"Piercing or slashing"
+								],
+								[
+									"Water",
+									"{@trait Water}",
+									"Bludgeoning or cold"
+								],
+								[
+									"Wood",
+									"{@trait Wood}",
+									"Bludgeoning or piercing"
+								]
+							]
+						}
+					]
+				},
+				{
+					"type": "pf2-h4",
+					"name": "Anathema",
+					"entries": [
+						"Disrespecting an elemental creature is anathema to your instinct; defending yourself against one is not. Purposefully despoiling the elemental plane associated with your element is anathema to your instinct, though this doesn't prevent you from responsibly altering that plane."
+					]
+				},
+				{
+					"type": "pf2-h4",
+					"name": "Elemental Rage (Instinct Ability)",
+					"entries": [
+						"While raging, you're cloaked in a vortex of elemental matter; you become {@condition concealed} against ranged attacks. You can't use this concealment to {@action Hide} or {@action Sneak}. While raging, you increase the additional damage from {@action Rage} from 2 to 4 and change its damage type to the one you selected for your element.",
+						"If you have any {@class Kineticist|roe} {@trait impulses} with the same element type as the one you chose for your instinct, such as ones gained by taking the Kineticist Dedication multiclass feat, they gain the {@trait rage} trait."
+					]
+				}
+			]
+		},
+		{
+			"name": "Weapon Specialization",
+			"source": "RoE",
+			"page": 54,
+			"className": "Barbarian",
+			"classSource": "CRB",
+			"subclassShortName": "Elemental",
+			"subclassSource": "RoE",
+			"level": 7,
+			"entries": [
+				{
+					"type": "pf2-h4",
+					"name": "Specialization Ability",
+					"entries": [
+						"When you use elemental rage, you increase the damage from {@action Rage} from 4 to 6. If you have greater weapon specialization, instead increase the damage from {@action Rage} when using elemental rage from 6 to 12."
+					]
+				}
+			]
+		},
+		{
+			"name": "Raging Resistance",
+			"source": "RoE",
+			"page": 54,
+			"className": "Barbarian",
+			"classSource": "CRB",
+			"subclassShortName": "Elemental",
+			"subclassSource": "RoE",
+			"level": 9,
+			"entries": [
+				{
+					"type": "pf2-h4",
+					"name": "Raging Resistance",
+					"entries": [
+						"You resist the damage dealt by attacks and abilities of elemental creatures of your chosen element, as well as creatures made of your element, regardless of the damage type. You also resist damage dealt by attacks, spells, and abilities with your elemental trait."
 					]
 				}
 			]

--- a/data/class/class-barbarian.json
+++ b/data/class/class-barbarian.json
@@ -953,7 +953,7 @@
 					"name": "Elemental Rage (Instinct Ability)",
 					"entries": [
 						"While raging, you're cloaked in a vortex of elemental matter; you become {@condition concealed} against ranged attacks. You can't use this concealment to {@action Hide} or {@action Sneak}. While raging, you increase the additional damage from {@action Rage} from 2 to 4 and change its damage type to the one you selected for your element.",
-						"If you have any {@class Kineticist|roe} {@trait impulses} with the same element type as the one you chose for your instinct, such as ones gained by taking the Kineticist Dedication multiclass feat, they gain the {@trait rage} trait."
+						"If you have any {@class Kineticist|RoE} {@trait Impulse} with the same element type as the one you chose for your instinct, such as ones gained by taking the {@feat Kineticist Dedication|RoE} multiclass feat, they gain the {@trait rage} trait."
 					]
 				}
 			]

--- a/data/class/class-barbarian.json
+++ b/data/class/class-barbarian.json
@@ -932,55 +932,12 @@
 					"type": "pf2-h3",
 					"name": "Elemental Instinct",
 					"entries": [
-						"This instinct option for barbarians allows you to channel elemental forces, bonding with a single element and its associated plane. Perhaps your ancestors were elemental conjurers or blessed by an elemental lord. Select an element from {@table Elemental Instincts|RoE|Table 3\u20135: Elemental Instincts} to be your instinct's element. If your element offers multiple damage types, choose one of those type when you select your element.",
- 					{
-							"type": "table",
+						"This instinct option for barbarians allows you to channel elemental forces, bonding with a single element and its associated plane. Perhaps your ancestors were elemental conjurers or blessed by an elemental lord. Select an element from the {@table Elemental Instincts|RoE|Elemental Instincts} table to be your instinct's element. If your element offers multiple damage types, choose one of those type when you select your element.",
+						{
+							"type": "data",
+							"tag": "table",
 							"name": "Elemental Instincts",
-							"id": "3-5",
-							"source": "RoE",
-							"page": 54,
-							"colSizes": [
-								2,
-								2,
-								3
-							],
-							"rows": [
-								[
-									"Element",
-									"Trait",
-									"Damage"
-								],
-								[
-									"Air",
-									"{@trait Air}",
-									"Electricity or slashing"
-								],
-								[
-									"Earth",
-									"{@trait Earth}",
-									"Bludgeoning or piercing"
-								],
-								[
-									"Fire",
-									"{@trait Fire}",
-									"Fire"
-								],
-								[
-									"Metal",
-									"{@trait Metal}",
-									"Piercing or slashing"
-								],
-								[
-									"Water",
-									"{@trait Water}",
-									"Bludgeoning or cold"
-								],
-								[
-									"Wood",
-									"{@trait Wood}",
-									"Bludgeoning or piercing"
-								]
-							]
+							"source": "RoE"
 						}
 					]
 				},

--- a/data/class/class-barbarian.json
+++ b/data/class/class-barbarian.json
@@ -917,7 +917,7 @@
 					]
 				}
 			]
-		},		
+		},
 		{
 			"name": "Instinct",
 			"source": "RoE",

--- a/data/feats/feats-roe.json
+++ b/data/feats/feats-roe.json
@@ -3495,7 +3495,7 @@
 			"traits": [
 				"barbarian"
 			],
-			"prerequisites": "elemental instinct",
+			"prerequisites": "{@class barbarian|CRB|Elemental Instinct|Elemental|RoE}",
 			"entries": [
 				"The elemental power within you is more mutable and versatile than most. Choose a second damage type for your element. Whenever you {@action Rage}, you can choose that type instead of the damage type you would normally gain. The new damage type can be the one you did not choose when you selected the element initially if you had multiple options available for your element, or one of the following types: air cold, earth poison, fire cold, metal electricity, water acid, wood poison."
 			]
@@ -3515,7 +3515,7 @@
 				"primal",
 				"rage"
 			],
-			"prerequisites": "elemental instinct",
+			"prerequisites": "{@class barbarian|CRB|Elemental Instinct|Elemental|RoE}",
 			"requirements": "You're raging, and you haven't used this ability since you last Raged.",
 			"entries": [
 				"You unleash the energy roiling within you, exploding elemental matter in a 15-foot emanation. Each creature in the area takes {@dice 1d8} damage per level you possess, with the same type you chose for elemental rage.",

--- a/data/tables.json
+++ b/data/tables.json
@@ -9474,7 +9474,7 @@
 				]
 			]
 		},
-    {
+		{
 			"type": "table",
 			"name": "Elemental Instincts",
 			"source": "RoE",

--- a/data/tables.json
+++ b/data/tables.json
@@ -9474,6 +9474,54 @@
 				]
 			]
 		},
+    {
+			"type": "table",
+			"name": "Elemental Instincts",
+			"source": "RoE",
+			"page": 54,
+			"colSizes": [
+				2,
+				2,
+				3
+			],
+			"rows": [
+				[
+					"Element",
+					"Trait",
+					"Damage"
+				],
+				[
+					"Air",
+					"{@trait Air}",
+					"Electricity or slashing"
+				],
+				[
+					"Earth",
+					"{@trait Earth}",
+					"Bludgeoning or piercing"
+				],
+				[
+					"Fire",
+					"{@trait Fire}",
+					"Fire"
+				],
+				[
+					"Metal",
+					"{@trait Metal}",
+					"Piercing or slashing"
+				],
+				[
+					"Water",
+					"{@trait Water}",
+					"Bludgeoning or cold"
+				],
+				[
+					"Wood",
+					"{@trait Wood}",
+					"Bludgeoning or piercing"
+				]
+			]
+		},
 		{
 			"name": "Encounter Budget",
 			"id": "10-1",


### PR DESCRIPTION
I added the elemental instinct barbarian subclass.

The wording is identical to https://2e.aonprd.com/Instincts.aspx, however, I slightly changed the sentence containing the link to the table to make it grammatically correct.

## TODO
- [x] The only remaining issue is that the table containing the elemental instincts does not link correctly. `npm run serve:dev` shows the table, however, if I hover over the link, it is not shown as a popup. Can you help me with that?