### PR TITLE
Adding adventure link functionality

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -1999,7 +1999,7 @@ function Renderer () {
 						// path: page,
 						// hash,
 						// hashPreEncoded: true,
-						path: UrlUtil.getCurrentPage(),
+						path: `${page}#${hash}`,
 					},
 					text: displayText,
 				};


### PR DESCRIPTION
Using the `{@adventure}` tag would not link to the adventure if it existed. Changed the path of the generated hyperlink to use the `page` and `hash` variables already created but unused.