### PR TITLE
Fix Magnifying Glass of Elucidation description

### DIFF
--- a/data/items/items-lotgb.json
+++ b/data/items/items-lotgb.json
@@ -4591,7 +4591,7 @@
 			"category": "Held",
 			"entries": [
 				"These well-aged wooden magnifying glasses are engraved with a variety of runes. Each is imbued with a specific language.",
-				"When you use a magnifying glass to examine writing of its imbued language, it translates the writing into a language Urban Garden Wares you understand. For example, an elf who speaks only Elven using a magnifying glass of elucidation imbued with Dwarven would see Dwarven writing as Elven when {@condition observed} through the magnifying glass. The magnifying glass only provides direct translations and doesn't automatically allow you to understand codes or extremely esoteric passages\u2014you still need to attempt a skill check to {@action Decipher Writing}.",
+				"When you use a magnifying glass to examine writing of its imbued language, it translates the writing into a language you understand. For example, an elf who speaks only Elven using a magnifying glass of elucidation imbued with Dwarven would see Dwarven writing as Elven when observed through the magnifying glass. The magnifying glass only provides direct translations and doesn't automatically allow you to understand codes or extremely esoteric passages\u2014you still need to attempt a skill check to {@action Decipher Writing}.",
 				{
 					"type": "ability",
 					"activity": {


### PR DESCRIPTION
* Remove mid-sentence "Urban Garden Wares"

* Remove link to observed condition as that pertains to enemies rather than writing