### PR TITLE
Added entry for the Summon trait from Player Core 1.

### DIFF
--- a/data/traits.json
+++ b/data/traits.json
@@ -5755,12 +5755,82 @@
 			]
 		},
 		{
+			"name": "Summon",
+			"source": "PC1",
+			"page": 360,
+			"categories": [
+				"Spell"
+			],
+			"entries": [
+				"Spells with the summon trait can conjure creatures, typically ones with a particular trait. Such creatures can be found in Monster Core or similar books. Unless noted otherwise, the creature must be common, it gains the {@trait summoned} trait (page 301), and it must appear in an unoccupied space in range large enough to contain it. The highest level of creature the spell can summon depends on the rank of the spell, as listed below. The spell can still summon a creature of a lower level if you so choose. These rules apply on to spells that have the summon trait; other spells that call or conjure items or beings but that don't have the trait, like {@spell summon instrument|pc1}, work as explained in the spell.",
+				{
+					"type": "table",
+					"source": "PC1",
+					"page": 360,
+					"labelRowIdx": [
+						0
+					],
+					"colStyles": [
+						"text-center",
+						"text-center"
+					],
+					"rows": [
+						[
+							"Spell Rank",
+							"Maximum Creature Level"
+						],
+						[
+							"1st",
+							"\u22121"
+						],
+						[
+							"2nd",
+							"1"
+						],
+						[
+							"3rd",
+							"2"
+						],
+						[
+							"4th",
+							"3"
+						],
+						[
+							"5th",
+							"5"
+						],
+						[
+							"6th",
+							"7"
+						],
+						[
+							"7th",
+							"9"
+						],
+						[
+							"8th",
+							"11"
+						],
+						[
+							"9th",
+							"13"
+						],
+						[
+							"10th",
+							"15"
+						]
+					]
+				}
+			]
+		},
+		{
 			"name": "Summoned",
 			"source": "CRB",
 			"page": 637,
 			"otherSources": {
 				"Reprinted": [
-					"SoM|254"
+					"SoM|254",
+					"PC1|301"
 				]
 			},
 			"categories": [


### PR DESCRIPTION
Spells like [Summon Fiend](https://pf2etools.com/spells.html#summon%20fiend_pc1) from Player Core have the `Summon` trait but hovering over that leads to a console error since the trait doesn't exist. So, this PR adds that trait from PC1.

 Also, the `Summoned` trait was reprinted in PC1 so I've added a reference to that as well.