### PR TITLE
Fix up a bunch of creature and hazard data issues

### DIFF
--- a/data/afflictions.json
+++ b/data/afflictions.json
@@ -128,7 +128,7 @@
 			]
 		},
 		{
-			"name": "Exhaustive Addiction",
+			"name": "Addictive Exhaustion",
 			"source": "LOMM",
 			"page": 65,
 			"type": "Disease",

--- a/data/backgrounds/backgrounds-sog0.json
+++ b/data/backgrounds/backgrounds-sog0.json
@@ -204,7 +204,7 @@
 				"Your home is likely located south of the Ceiba River, on the southernmost outskirts of town.",
 				"During the Reenactment Festival, you likely spent time helping to set up the feasts, assisted in running some of the events, and otherwise worked behind the scenes. You were chosen to be an abductee during the Reenactment Festival because you lost a bet, owed a favor, or otherwise got pressured or tricked into the role by a family member, friend, or coworker. Perhaps someone who was going to be one of the abductees but had to back out at the last moment, and so you ended up taking their place.",
 				"Choose two ability boosts. One must be to Charisma or Constitution, and one is a free ability boost.",
-				"You're trained in the {@skill Crafting} skill and the {@lore Lore||Farming Lore} skill. You gain the {@feat Hobnobber} feat.",
+				"You're trained in the {@skill Crafting} skill and the {@skill Lore||Farming Lore} skill. You gain the {@feat Hobnobber} feat.",
 				{
 					"type": "ability",
 					"name": "Seasonal Boon",

--- a/data/bestiary/creatures-aoe2.json
+++ b/data/bestiary/creatures-aoe2.json
@@ -937,14 +937,11 @@
 							"number": 2,
 							"unit": "action"
 						},
-						"requirements": "The excorion has at least 70",
-						"name": "Vital Transfusion"
-					},
-					{
+						"requirements": "The excorion has at least 70 Hit Points",
 						"entries": [
 							"The excorion sacrifices itself and transfers its bloody, vital energy to a willing living creature within 30 feet. The excorion is immediately destroyed, and the targeted living creature heals a number of HP equal to half the excorion's remaining HP at the time that it used this ability. The living creature is {@condition slowed|CRB|slowed 1} during its next turn as its body adjusts to the newly transfused blood and vital energy; the living creature also counts as an excorion for 1 minute for the purpose of seeing other excorions' Bloody Handprint marks."
 						],
-						"name": "Hit Points; Effect"
+						"name": "Vital Transfusion"
 					},
 					{
 						"activity": {

--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -1659,13 +1659,10 @@
 							"unit": "reaction"
 						},
 						"trigger": "The Iroran skeleton is critically hit",
-						"name": "Collapse"
-					},
-					{
 						"entries": [
-							"Iroran skeleton collapses into a pile of bones and the attack deals damage for a hit, rather than a critical hit. The skeleton can reform in a standing position as an action, but until it does, it is {@condition immobilized} and {@condition flat-footed}."
+							"The Iroran skeleton collapses into a pile of bones and the attack deals damage for a hit, rather than a critical hit. The skeleton can reform in a standing position as an action, but until it does, it is {@condition immobilized} and {@condition flat-footed}."
 						],
-						"name": "The"
+						"name": "Collapse"
 					}
 				],
 				"bot": [
@@ -1678,25 +1675,22 @@
 							"flourish"
 						],
 						"entries": [
-							"As the monk's {@action Flurry of Blows} class feature. The Iroran skeleton makes two claw {@action Strike||Strikes}.",
+							"The Iroran skeleton makes two claw {@action Strike||Strikes}.",
 							"If both hit the same creature, the damage is combined for the purpose of resistances and weaknesses. The multiple attack penalty applies to the {@action Strike||Strikes} as normal."
 						],
-						"name": "Flurry of Claws",
-						"entries_as_xyz": "Ability not found: 'Flurry of Claws As the monk's {@action Flurry of Blows} class feature.' in Iroran Skeleton, p.52"
+						"name": "Flurry of Claws"
 					},
 					{
 						"entries": [
-							"As the monk feat. The Iroran skeleton can {@action Stride} along vertical surfaces, such as walls, as long as it begins and ends its movement on a horizontal surface."
+							"The Iroran skeleton can {@action Stride} along vertical surfaces, such as walls, as long as it begins and ends its movement on a horizontal surface."
 						],
-						"name": "Wall Run",
-						"entries_as_xyz": "Ability not found: 'Wall Run As the monk feat.' in Iroran Skeleton, p.52"
+						"name": "Wall Run"
 					},
 					{
 						"entries": [
-							"As the monk feat. The Iroran skeleton can {@action Stride} across liquid surfaces. If it ends its movement on a liquid surface, it falls in as normal."
+							"The Iroran skeleton can {@action Stride} across liquid surfaces. If it ends its movement on a liquid surface, it falls in as normal."
 						],
-						"name": "Water Step",
-						"entries_as_xyz": "Ability not found: 'Water {@action Step} As the monk feat.' in Iroran Skeleton, p.52"
+						"name": "Water Step"
 					},
 					{
 						"activity": {

--- a/data/bestiary/creatures-aoe5.json
+++ b/data/bestiary/creatures-aoe5.json
@@ -3713,12 +3713,9 @@
 							"number": 1
 						},
 						"entries": [
-							"The fanged mouths at the ends of a myrucarx's tendrils twist around obstacles. The myrucarx makes two jaws {@action Strike||Strikes} against the same target, ignoring the target's cover. Both attacks count toward the myrucarx's multiple attack penalty, but the penalty doesn't increase until after both attacks are made. The myrucarx can't Grab as its next action after."
+							"The fanged mouths at the ends of a myrucarx's tendrils twist around obstacles. The myrucarx makes two jaws {@action Strike||Strikes} against the same target, ignoring the target's cover. Both attacks count toward the myrucarx's multiple attack penalty, but the penalty doesn't increase until after both attacks are made. The myrucarx can't Grab as its next action after Twisting Reach."
 						],
 						"name": "Twisting Reach"
-					},
-					{
-						"name": "Twisting Reach."
 					}
 				]
 			},

--- a/data/bestiary/creatures-aoe6.json
+++ b/data/bestiary/creatures-aoe6.json
@@ -3679,10 +3679,30 @@
 						"name": "Devastating Blast"
 					},
 					{
-						"entries": [
-							"This curse affects anyone who wears a graveknight's armor for at least 1 hour; Saving Throw {@dc 43} Will save; Onset 1 hour; Stage 1 {@condition doomed|CRB|doomed 1} and can't remove the armor (1 day); Stage 2 {@condition doomed|CRB|doomed 2}, hampered 10, and can't remove the armor (1 day); Stage 3 dies and transforms into the armor's graveknight."
+						"type": "affliction",
+						"name": "Graveknight's Curse",
+						"notes": [
+							"This curse affects anyone who wears a graveknight's armor for at least 1 hour"
 						],
-						"name": "Graveknight's Curse"
+						"DC": 43,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition doomed||doomed 1} and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
+							}
+						]
 					},
 					{
 						"activity": {
@@ -3690,15 +3710,9 @@
 							"unit": "action"
 						},
 						"entries": [
-							"The graveknight carves the sigil of Kharnas onto an adjacent {@condition immobilized} or {@condition unconscious} creature. As long as the creature bears the sigil of Kharnas, it takes a \u20132 status penalty to saving throws against the abilities of any creature that previously served Kharnas, but it can also freely pass through any hazards that can be bypassed by those bearing the sigil."
+							"The graveknight carves the sigil of Kharnas onto an adjacent {@condition immobilized} or {@condition unconscious} creature. As long as the creature bears the sigil of Kharnas, it takes a \u20132 status penalty to saving throws against the abilities of any creature that previously served Kharnas, but it can also freely pass through any hazards that can be bypassed by those bearing the sigil of Kharnas, such as Kharnas's glyphs."
 						],
 						"name": "Kharnas's Blessing"
-					},
-					{
-						"entries": [
-							"Kharnas, such as Kharnas's glyphs."
-						],
-						"name": "of"
 					},
 					{
 						"entries": [

--- a/data/bestiary/creatures-av1.json
+++ b/data/bestiary/creatures-av1.json
@@ -3855,7 +3855,7 @@
 							"number": 1
 						},
 						"entries": [
-							"Wrin attempts to read the future in the stars by spending an hour studying the night sky\u2014she can't use this ability during the day, on an overcast night, or when she can't otherwise study the stars. Although Wrin usually performs this reading for an individual person or to answer a pressing question she has, for the purposes of this campaign she reads the stars for the party as a whole. She attempts an {@skill Astrology Lore} check, using the DC appropriate for the heroes' current level (see {@table dcs by level|crb|Table 10\u20135: DCs by Level}).",
+							"Wrin attempts to read the future in the stars by spending an hour studying the night sky\u2014she can't use this ability during the day, on an overcast night, or when she can't otherwise study the stars. Although Wrin usually performs this reading for an individual person or to answer a pressing question she has, for the purposes of this campaign she reads the stars for the party as a whole. She attempts an {@skill Lore||Astrology Lore} check, using the DC appropriate for the heroes' current level (see {@table dcs by level|crb|Table 10\u20135: DCs by Level}).",
 							{
 								"type": "successDegree",
 								"entries": {

--- a/data/bestiary/creatures-av2.json
+++ b/data/bestiary/creatures-av2.json
@@ -916,14 +916,11 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"requirements": "The gibtas's last action was a",
-						"name": "Pinning Chomp"
-					},
-					{
+						"requirements": "The gibtas's last action was a Bouncing Slam and the gibtas successfully Shoved the target",
 						"entries": [
-							"Slam and the gibtas successfully Shoved the target; The gibtas attempts to {@action Trip} the target of its Bouncing Slam, then makes a jaws {@action Strike} against the target. The {@action Trip} and {@action Strike} both count against the gibtas's multiple attack penalty, but the penalty doesn't increase until after both attacks."
+							"The gibtas attempts to {@action Trip} the target of its Bouncing Slam, then makes a jaws {@action Strike} against the target. The {@action Trip} and {@action Strike} both count against the gibtas's multiple attack penalty, but the penalty doesn't increase until after both attacks."
 						],
-						"name": "Bouncing"
+						"name": "Pinning Chomp"
 					}
 				]
 			},

--- a/data/bestiary/creatures-av3.json
+++ b/data/bestiary/creatures-av3.json
@@ -848,14 +848,11 @@
 							"fire",
 							"light"
 						],
-						"requirements": "The bright walker's",
-						"name": "Light Flare"
-					},
-					{
 						"entries": [
-							"Aura is suppressed; The bright walker reignites their Light Aura with a burst of brightness that deals {@damage 5d6} fire damage ({@dc 25} basic Reflex save) to creatures within a 20-foot burst. Creatures who are {@condition dazzled} or with light blindness find this flare particularly painful; such a creature's save result is one degree of success worse than the result it rolled."
+							"The bright walker reignites their Light Aura with a burst of brightness that deals {@damage 5d6} fire damage ({@dc 25} basic Reflex save) to creatures within a 20-foot burst. Creatures who are {@condition dazzled} or with light blindness find this flare particularly painful; such a creature's save result is one degree of success worse than the result it rolled."
 						],
-						"name": "Light"
+						"requirements": "The bright walker's Light Aura is suppressed",
+						"name": "Light Flare"
 					},
 					{
 						"activity": {
@@ -4128,18 +4125,15 @@
 					},
 					{
 						"entries": [
-							"Quara isn't {@condition flat-footed} to {@condition hidden}, {@condition undetected}, or flanking creatures of 11th level or lower, or to creatures of 11th level or lower using Surprise."
+							"Quara isn't {@condition flat-footed} to {@condition hidden}, {@condition undetected}, or flanking creatures of 11th level or lower, or to creatures of 11th level or lower using Surprise Attack."
 						],
 						"name": "Deny Advantage"
 					},
 					{
-						"name": "Attack."
-					},
-					{
 						"entries": [
-							"Quara rolls a success on a Reflex saving throw, she gets a critical success instead."
+							"When Quara rolls a success on a Reflex saving throw, she gets a critical success instead."
 						],
-						"name": "Evasion When"
+						"name": "Evasion"
 					}
 				],
 				"bot": [

--- a/data/bestiary/creatures-b1.json
+++ b/data/bestiary/creatures-b1.json
@@ -6047,10 +6047,7 @@
 						"entries": [
 							"15 feet, {@damage 3d6} cold damage. The silver dragon can turn this aura on or off as a single action, which has the {@trait concentrate} trait, and can choose not to affect allies within the aura."
 						],
-						"name": "Cold Aura",
-						"generic": {
-							"tag": "ability"
-						}
+						"name": "Cold Aura"
 					},
 					{
 						"activity": {
@@ -21937,7 +21934,10 @@
 						"name": "Nature Empathy"
 					},
 					{
-						"name": "Tied to the Land"
+						"name": "Tied to the Land",
+						"entries": [
+							"The dryad queen is tied to a forest or other woodland."
+						]
 					}
 				],
 				"mid": [
@@ -22002,6 +22002,9 @@
 							"mental",
 							"primal"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Inspiration"
 					},
 					{
@@ -22017,9 +22020,6 @@
 							"As dryad, except the hamadryad can enter and exit her extradimensional domain from any tree in her domain and she can bring up to eight other creatures with her when she does so."
 						],
 						"name": "Tree Meld"
-					},
-					{
-						"name": "Octopus, Giant"
 					}
 				]
 			},
@@ -31996,8 +31996,18 @@
 				"mid": [
 					{
 						"name": "Sacrilegious Aura",
+						"traits": [
+							"abjuration",
+							"aura",
+							"divine",
+							"evil"
+						],
+						"range": {
+							"unit": "feet",
+							"number": 30
+						},
 						"entries": [
-							"30 feet. +17"
+							"When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with a +17 counteract modifier."
 						]
 					},
 					{
@@ -32024,13 +32034,34 @@
 							"evocation"
 						],
 						"entries": [
-							"{@damage 6d12} cold, {@dc 29}"
+							"The graveknight unleases a 30-foot cone of energy. Creatures in the area take {@damage 6d12} cold damage ({@dc 29} basic Reflex save). The graveknight can use this ability once every 1d4 rounds."
 						]
 					},
 					{
-						"name": "Graveknight's Curse DC",
-						"entries": [
-							"33"
+						"type": "affliction",
+						"name": "Graveknight's Curse",
+						"traits": [
+							"curse"
+						],
+						"note": "This curse affects anyone who wears a graveknight's armor for at least 1 hour.",
+						"DC": 33,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition doomed 1} and cannot remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed 2}, hampered 10, and cannot remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
+							}
 						]
 					},
 					{
@@ -32044,11 +32075,15 @@
 							"conjuration"
 						],
 						"entries": [
-							"HP 58; AC 27,"
+							"The graveknight summons a supernatural mount as per {@spell phantom steed}, heightened to a level equal to half the graveknight's level. Unlike phantom steed, the steed's AC and saving throw bonuses are all 4 lower than the graveknight's, and the steed has one-third the graveknight's Hit Points (rounded down). If the steed is destroyed, the graveknight must wait 1 hour before using this ability again.",
+							"HP 58; AC 27, Fort +17, Ref +15, Will +14."
 						]
 					},
 					{
-						"name": "Weapon Master"
+						"name": "Weapon Master",
+						"entries":  [
+							"The graveknight has access to the critical specialization effects of any weapons it wields."
+						]
 					}
 				]
 			}
@@ -49216,7 +49251,10 @@
 			"abilities": {
 				"top": [
 					{
-						"name": "Tied to the Land"
+						"name": "Tied to the Land",
+						"entries": [
+							"The queen is tied to a body of water or area with a great deal of water features."
+						]
 					},
 					{
 						"entries": [
@@ -49286,6 +49324,9 @@
 							"mental",
 							"primal"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Inspiration"
 					},
 					{
@@ -67673,6 +67714,9 @@
 							"enchantment",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Children of the Night"
 					}
 				],
@@ -67681,6 +67725,9 @@
 						"activity": {
 							"number": 1,
 							"unit": "free"
+						},
+						"generic": {
+							"tag": "ability"
 						},
 						"name": "Mist Escape"
 					}
@@ -67711,6 +67758,9 @@
 							"downtime",
 							"necromancy"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Create Spawn"
 					},
 					{
@@ -67754,6 +67804,9 @@
 							"divine",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Turn to Mist"
 					}
 				]
@@ -67999,6 +68052,9 @@
 							"enchantment",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Children of the Night"
 					}
 				],
@@ -68007,6 +68063,9 @@
 						"activity": {
 							"number": 1,
 							"unit": "free"
+						},
+						"generic": {
+							"tag": "ability"
 						},
 						"name": "Mist Escape"
 					}
@@ -68037,6 +68096,9 @@
 							"downtime",
 							"necromancy"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Create Spawn"
 					},
 					{
@@ -68108,6 +68170,9 @@
 							"divine",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Turn to Mist"
 					}
 				]
@@ -71054,6 +71119,9 @@
 							"primal",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Moon Frenzy"
 					},
 					{

--- a/data/bestiary/creatures-b2.json
+++ b/data/bestiary/creatures-b2.json
@@ -3204,10 +3204,7 @@
 						"entries": [
 							"30 feet. A swirling vortex of reflected color and light shimmers around the crystal dragon. Creatures in this aura's emanation are {@condition dazzled}. Each creature that ends its turn in the emanation must succeed at a {@dc 34} Will saving throw or be {@condition stunned 1} (or {@condition stunned 3} on a critical failure). Once a creature succeeds at this save, it is temporarily immune to the stunning effect for 1 minute. The crystal dragon can turn this aura on or off using a single action, which has the {@trait concentrate} trait, and it can choose not to affect allies."
 						],
-						"name": "Scintillating Aura",
-						"generic": {
-							"tag": "ability"
-						}
+						"name": "Scintillating Aura"
 					},
 					{
 						"activity": {
@@ -26528,7 +26525,7 @@
 							"attack"
 						],
 						"entries": [
-							"The hippopotamus tries to capsize an adjacent aquatic vessel of its size or smaller. The hippopotamus must succeed at an {@skill Athletics} check with a DC of 25 (reduced by 5 for each size smaller the vessel is than the hippo) or the pilot's {@skill Lore|Sailing Lore} DC, whichever is higher."
+							"The hippopotamus tries to capsize an adjacent aquatic vessel of its size or smaller. The hippopotamus must succeed at an {@skill Athletics} check with a DC of 25 (reduced by 5 for each size smaller the vessel is than the hippo) or the pilot's {@skill Lore||Sailing Lore} DC, whichever is higher."
 						],
 						"name": "Capsize"
 					},
@@ -30047,36 +30044,27 @@
 								]
 							}
 						],
-						"name": "Burble",
-						"generic": {
-							"tag": "ability"
-						}
+						"name": "Burble"
 					},
 					{
 						"entries": [
 							"If the jabberwock makes a jaws attack and rolls a natural 19 on the d20 roll, the attack is a critical hit. This has no effect if the 19 would be a failure."
 						],
-						"name": "Jaws That Bite",
-						"generic": {
-							"tag": "ability"
-						}
+						"name": "Jaws That Bite"
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
 						},
-						"trigger": "The jabberwock Flies or makes a wing {@action Strike};",
+						"trigger": "The jabberwock Flies or makes a wing {@action Strike}",
 						"entries": [
 							"The jabberwock's wings whiffle, creating severe winds within a 30-foot emanation. These winds move outward from the jabberwock, and they persist until the start of the jabberwock's next turn. During this time, flight of any kind in the emanation requires a successful {@dc 43} {@skill Acrobatics} check to {@action Maneuver in Flight}, and creatures flying toward the jabberwock are moving through greater difficult terrain. Creatures on the ground in the emanation must succeed at a {@dc 43} {@skill Athletics} check to approach the jabberwock."
 						],
 						"traits": [
 							"aura"
 						],
-						"name": "Whiffling",
-						"generic": {
-							"tag": "ability"
-						}
+						"name": "Whiffling"
 					}
 				]
 			},
@@ -56818,10 +56806,16 @@
 							"enchantment",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Children of the Night"
 					},
 					{
-						"name": "Swift Tracker"
+						"name": "Swift Tracker",
+						"entries": [
+							"The vrykolakas moves at full Speed while {@action Track||Tracking}."
+						]
 					}
 				],
 				"mid": [
@@ -56837,7 +56831,10 @@
 						"name": "Pestilential Aura"
 					},
 					{
-						"name": "Vrykolakas Vulnerabilities"
+						"name": "Vrykolakas Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
 						"activity": {
@@ -56880,6 +56877,9 @@
 							"downtime",
 							"necromancy"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Create Spawn"
 					},
 					{
@@ -57077,10 +57077,16 @@
 							"enchantment",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Children of the Night"
 					},
 					{
-						"name": "Swift Tracker"
+						"name": "Swift Tracker",
+						"entries": [
+							"The vrykolakas moves at full Speed while {@action Track||Tracking}."
+						]
 					}
 				],
 				"mid": [
@@ -57096,7 +57102,10 @@
 						"name": "Pestilential Aura"
 					},
 					{
-						"name": "Vrykolakas Vulnerabilities"
+						"name": "Vrykolakas Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
 						"activity": {
@@ -57237,7 +57246,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Vrykolakas Vulnerabilities"
+						"name": "Vrykolakas Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
 						"activity": {
@@ -57961,6 +57973,9 @@
 							"primal",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Moon Frenzy"
 					}
 				]
@@ -58145,6 +58160,9 @@
 							"primal",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Moon Frenzy"
 					},
 					{

--- a/data/bestiary/creatures-b3.json
+++ b/data/bestiary/creatures-b3.json
@@ -10157,9 +10157,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
@@ -10430,14 +10427,11 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"trigger": "A creature attempts to leave the chouchinobake's",
-						"name": "Shadowbind"
-					},
-					{
+						"trigger": "A creature attempts to leave the chouchinobake's Lifewick Candle aura during a move action",
 						"entries": [
-							"Candle aura during a move action; The chouchin-obake attempts to bind the creature using their own shadow. The triggering creature must succeed at a {@dc 26} Reflex save or become {@condition immobilized} until its next turn."
+							"The chouchin-obake attempts to bind the creature using their own shadow. The triggering creature must succeed at a {@dc 26} Reflex save or become {@condition immobilized} until its next turn."
 						],
-						"name": "Lifewick"
+						"name": "Shadowbind"
 					}
 				],
 				"bot": [
@@ -10825,7 +10819,8 @@
 				"mid": [
 					{
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Troop Defenses"
 					}
@@ -10847,7 +10842,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -13609,9 +13605,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
@@ -15898,9 +15891,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Shield Block",
 						"generic": {
 							"tag": "ability"
@@ -16744,9 +16734,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
@@ -24765,9 +24752,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -24786,6 +24774,10 @@
 						"activity": {
 							"number": 1,
 							"unit": "action"
+						},
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -24934,14 +24926,11 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"requirements": "The hellwasp swarm is controlling a corpse with",
-						"name": "Abandon Corpse"
-					},
-					{
+						"requirements": "The hellwasp swarm is controlling a corpse with Infest Corpse",
 						"entries": [
 							"The hellwasp swarm leaves its host corpse, which dies instantly and becomes a normal corpse in all respects. The hellwasp swarm expands out from that space to its normal size."
 						],
-						"name": "Infest Corpse; Effect"
+						"name": "Abandon Corpse"
 					},
 					{
 						"activity": {
@@ -25784,7 +25773,7 @@
 				"top": [
 					{
 						"entries": [
-							"As lampad queen, except the hesperid queen is tied to an isolated region such as an island or island chain, a remote coast, or a secluded valley. Their counteract modifier is +37 and their counteract level is 10."
+							"A hesperid queen is intrinsically tied to a specific underground region, usually an isolated region such as an island or island chain, a remote coast, or a secluded valley. As long as the queen is healthy, the environment is exceptionally resilient, allowing the hesperid queen to automatically attempt to counteract spells and rituals that would harm the environment, such as blight, with a +37 counteract modifier and a counteract level of 10. When the hesperid queen becomes physically or psychologically unhealthy, however, their warded region eventually becomes twisted or unhealthy as well. In that case, restoring the hesperid queen swiftly heals the entire region."
 						],
 						"name": "Tied to the Land"
 					}
@@ -37543,9 +37532,10 @@
 						}
 					},
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -37572,7 +37562,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -38046,7 +38037,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Nosferatu Vulnerabilities"
+						"name": "Nosferatu Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					}
 				],
 				"bot": [
@@ -38079,6 +38073,9 @@
 							"divine",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Command Thrall"
 					},
 					{
@@ -38250,7 +38247,10 @@
 						"name": "Air of Sickness"
 					},
 					{
-						"name": "Nosferatu Vulnerabilities"
+						"name": "Nosferatu Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					}
 				],
 				"bot": [
@@ -38280,6 +38280,9 @@
 							"divine",
 							"mental"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Command Thrall"
 					},
 					{
@@ -38458,12 +38461,18 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Mindbound"
+						"name": "Mindbound",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
+						},
+						"generic": {
+							"tag": "ability"
 						},
 						"name": "Mortal Shield"
 					},
@@ -38471,6 +38480,9 @@
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
+						},
+						"generic": {
+							"tag": "ability"
 						},
 						"name": "Rally"
 					}
@@ -40028,7 +40040,7 @@
 							"occult"
 						],
 						"entries": [
-							"The owb inflicts a curse on one creature taking {@condition persistent damage||persistent cold damage} damage||persistent cold damage} from their burning cold Strike, stealing the victim's vibrancy. The creature must attempt a {@dc 23} Fortitude save. On a failure, the creature gains light blindness and its coloration turns to washed out shades of gray, along with all equipment it carries, wields, or wears. These effects have an unlimited duration. Regardless of the result of its save, the creature is temporarily immune for 1 minute.",
+							"The owb inflicts a curse on one creature taking {@condition persistent damage||persistent cold damage} from their burning cold Strike, stealing the victim's vibrancy. The creature must attempt a {@dc 23} Fortitude save. On a failure, the creature gains light blindness and its coloration turns to washed out shades of gray, along with all equipment it carries, wields, or wears. These effects have an unlimited duration. Regardless of the result of its save, the creature is temporarily immune for 1 minute.",
 							"If the owb uses this ability on a caligni, the curse can't be removed short of {@spell wish} or similar powerful magic."
 						],
 						"name": "Curse of Darkness"
@@ -42175,9 +42187,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
@@ -43748,9 +43757,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -43761,7 +43771,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -45317,10 +45328,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
-						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
 						}
@@ -46779,9 +46786,10 @@
 				],
 				"mid": [
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -46813,7 +46821,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -47728,9 +47737,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Shield Block",
 						"generic": {
 							"tag": "ability"
@@ -48049,9 +48055,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -48087,7 +48094,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -51558,18 +51566,16 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Shield Block",
 						"generic": {
 							"tag": "ability"
 						}
 					},
 					{
-						"traits": [
-							"page 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -51580,7 +51586,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						},
 						"name": "Form Up"
 					},
@@ -51732,9 +51739,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Shield Block",
 						"generic": {
 							"tag": "ability"
@@ -53392,9 +53396,6 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Throw Rock",
 						"generic": {
 							"tag": "ability"
@@ -55321,9 +55322,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 306"
-						],
 						"name": "Shield Block",
 						"generic": {
 							"tag": "ability"
@@ -57401,6 +57399,9 @@
 							"primal",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Moon Frenzy"
 					}
 				]
@@ -57614,6 +57615,9 @@
 							"primal",
 							"transmutation"
 						],
+						"generic": {
+							"tag": "ability"
+						},
 						"name": "Moon Frenzy"
 					},
 					{

--- a/data/bestiary/creatures-botd.json
+++ b/data/bestiary/creatures-botd.json
@@ -1193,9 +1193,6 @@
 				"bot": [
 					{
 						"name": "Grab",
-						"traits": [
-							"page 212"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -3072,9 +3069,6 @@
 				"bot": [
 					{
 						"name": "Grab",
-						"traits": [
-							"page 212"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -6214,7 +6208,8 @@
 							"The ghost is typically bound to a vessel, even one damaged beyond repair. They can't venture more than 120 feet away from the ship or site of its wreckage."
 						],
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"name": "Site Bound"
 						}
 					}
 				],
@@ -7089,13 +7084,7 @@
 							"necromancy"
 						],
 						"entries": [
-							"When a graveknight is destroyed, their armor rebuilds their body over the course of {@dice 1d10} days\u2014or more quickly if the armor is worn by a living host (Graveknight Armor, Bestiary 191). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating their armor (such as with disintegrate), transporting it to the Positive"
-						]
-					},
-					{
-						"name": "Energy",
-						"entries": [
-							"Plane, or throwing it into the heart of a volcano."
+							"When a graveknight is destroyed, their armor rebuilds their body over the course of {@dice 1d10} days\u2014or more quickly if the armor is worn by a living host (Graveknight Armor, Bestiary 191). If the body is destroyed before then, the process restarts. A graveknight can only be permanently destroyed by obliterating their armor (such as with disintegrate), transporting it to the Positive Energy Plane, or throwing it into the heart of a volcano"
 						]
 					},
 					{
@@ -7116,9 +7105,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 212"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -7141,43 +7127,60 @@
 						]
 					},
 					{
-						"name": "Exemplar of Violence[two-actions]",
+						"name": "Exemplar of Violence",
 						"traits": [
 							"visual"
 						],
+						"activity": {
+							"number": 2,
+							"unit": "action"
+						},
 						"frequency": {
 							"number": 1,
 							"unit": "round"
 						},
 						"entries": [
-							"The graveknight attempts a {@action Strike} as their armor flashes with sinister power that spurs allies to violence. After the {@action Strike}, allies who can see the graveknight can use a reaction to {@action Step} or {@action Stride}, but they must end this movement in a space adjacent to an enemy. One ally of the graveknight's choice can instead use a reaction to {@action Strike}.",
+							"The graveknight attempts a {@action Strike} as their armor flashes with sinister power that spurs allies to violence. After the {@action Strike}, allies who can see the graveknight can use a reaction to {@action Step} or {@action Stride}, but they must end this movement in a space adjacent to an enemy. One ally of the graveknight's choice can instead use a reaction to {@action Strike}."
+						]
+					},
+					{
+						"type": "affliction",
+						"name": "Graveknight's Curse",
+						"notes": [
+							"This curse affects anyone who wears a graveknight's armor for at least 1 hour"
+						],
+						"DC": 39,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
 							{
-								"type": "affliction",
-								"name": "Graveknight's Curse This curse affects anyone who",
-								"notes": [
-									"The graveknight summons a supernatural mount as per phantom steed, heightened to 7th level. The steed has AC 34,"
-								],
-								"DC": 39,
-								"savingThrow": "Will",
-								"onset": "1 hour",
-								"stages": [
-									{
-										"stage": 1,
-										"entry": "{@condition doomed||doomed 1} and can't remove the armor",
-										"duration": "1 day"
-									},
-									{
-										"stage": 2,
-										"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
-										"duration": "1 day"
-									},
-									{
-										"stage": 3,
-										"entry": "dies and transforms into the armor's graveknight Phantom {@action Mount} {@as 3}",
-										"duration": "arcane, conjuration"
-									}
-								]
+								"stage": 1,
+								"entry": "{@condition doomed||doomed 1} and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
 							}
+						]
+					},
+					{
+						"name": "Phantom Mount",
+						"traits": [
+							"arcane",
+							"conjuration"
+						],
+						"activity": {
+							"unit": "action",
+							"number": 3
+						},
+						"entries": [
+							"The graveknight summons a supernatural mount as per {@spell phantom steed}, heightened to 7th level. The steed has AC 34, Fort +23, Ref +20, Will +20, and 85 Hit Points. If the steed is destroyed, the graveknight must wait 1 hour before using this ability again."
 						]
 					},
 					{
@@ -7207,11 +7210,7 @@
 					},
 					"will": {
 						"std": 20
-					},
-					"abilities": [
-						"and 85 Hit Points. If the steed is destroyed",
-						"the graveknight must wait 1 hour before using this ability again."
-					]
+					}
 				},
 				"hp": [
 					{
@@ -7620,9 +7619,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 212"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -7633,9 +7629,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 213"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -8356,9 +8349,10 @@
 					},
 					{
 						"name": "Troop Defenses",
-						"traits": [
-							"page 214"
-						]
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						}
 					}
 				],
 				"bot": [
@@ -8368,10 +8362,10 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"entries": [
-							"The troop chooses one of the squares it currently occupies and redistributes its squares to any configuration in which all squares are contiguous and within 15 feet of the chosen square.",
-							"The troop can't share its space with other creatures."
-						]
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						}
 					},
 					{
 						"name": "Frightful Battle Cry",
@@ -8522,7 +8516,10 @@
 					"common",
 					"draconic",
 					"dwarven",
-					"infernal"
+					"infernal",
+					"jotun",
+					"necril",
+					"undercommon"
 				]
 			},
 			"skills": {
@@ -8535,6 +8532,21 @@
 				"crafting": {
 					"std": 29,
 					"note": "can craft magic items"
+				},
+				"deception": {
+					"std": 27
+				},
+				"intimidation": {
+					"std": 27
+				},
+				"religion": {
+					"std": 25
+				},
+				"stealth": {
+					"std": 27
+				},
+				"thievery": {
+					"std": 27
 				}
 			},
 			"abilityMods": {
@@ -8718,17 +8730,6 @@
 				}
 			],
 			"abilities": {
-				"top": [
-					{
-						"name": "Jotun, Necril, Undercommon"
-					},
-					{
-						"name": "Deception+27,",
-						"entries": [
-							"{@skill Intimidation} +27, {@skill Religion} +25, {@skill Stealth} +27, {@skill Thievery} +27"
-						]
-					}
-				],
 				"mid": [
 					{
 						"name": "Rejuvenation",
@@ -10554,10 +10555,11 @@
 							"necromancy"
 						],
 						"entries": [
-							"This affliction can't be reduced below stage 1, nor can damage from it be healed, until successfully treated with remove curse or a similar effect. The affliction can then be removed as normal for a disease. A creature killed by cold rot turns to ice crystals and can't be resurrected except by a 7th-level resurrect ritual or similar magic; Saving",
+							"This affliction can't be reduced below stage 1, nor can damage from it be healed, until successfully treated with remove curse or a similar effect. The affliction can then be removed as normal for a disease. A creature killed by cold rot turns to ice crystals and can't be resurrected except by a 7th-level resurrect ritual or similar magic",
 							{
 								"type": "affliction",
-								"name": "Throw {@dc 24} Fortitude;",
+								"savingThrow": "Fortitude",
+								"DC": 24,
 								"stages": [
 									{
 										"stage": 1,
@@ -11730,9 +11732,6 @@
 						"components": [
 							"scythe claw"
 						],
-						"traits": [
-							"page 213"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -12644,7 +12643,10 @@
 				],
 				"bot": [
 					{
-						"name": "Blight Mastery"
+						"name": "Blight Mastery",
+						"entries": [
+							"Any of the siabrae's spells or effects that would normally be restricted to affecting animal can also affect undead animals. Furthermore, any animals the siabrae takes the form of or summons appear to be diseased, malnourished, or even dead and rotting. (This doesn't affect their statistics.)"
+						]
 					},
 					{
 						"name": "Steady Spellcasting",
@@ -14636,10 +14638,16 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Jiang-Shi Vulnerabilities"
+						"name": "Jiang-Shi Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
-						"name": "Warped Fulu"
+						"name": "Warped Fulu",
+						"generic": {
+							"tag": "ability"
+						}
 					}
 				],
 				"bot": [
@@ -14812,10 +14820,16 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Jiang-Shi Vulnerabilities"
+						"name": "Jiang-Shi Vulnerabilities",
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
-						"name": "Warped Fulu"
+						"name": "Warped Fulu",
+						"generic": {
+							"tag": "ability"
+						}
 					}
 				],
 				"bot": [
@@ -15022,11 +15036,8 @@
 					{
 						"name": "Anticipatory Attack",
 						"entries": [
-							"The vetalarana emergent uses consumed memories to anticipate their prey's movements. The vetalarana emergent's {@action Strike||Strikes} deal an additional {@damage 1d8} precision damage to creatures {@condition stupefied} due to the vetalarana's"
+							"The vetalarana emergent uses consumed memories to anticipate their prey's movements. The vetalarana emergent's {@action Strike||Strikes} deal an additional {@damage 1d8} precision damage to creatures {@condition stupefied} due to the vetalarana's Drain Thoughts."
 						]
-					},
-					{
-						"name": "Drain Thoughts."
 					},
 					{
 						"name": "Drain Thoughts",
@@ -15354,7 +15365,10 @@
 							"necromancy",
 							"occult",
 							"possession"
-						]
+						],
+						"generic": {
+							"tag": "ability"
+						}
 					},
 					{
 						"name": "Drain Thoughts",
@@ -16220,9 +16234,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 212"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -16249,9 +16260,6 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"page 213"
-						],
 						"generic": {
 							"tag": "ability"
 						}
@@ -17257,9 +17265,6 @@
 				"bot": [
 					{
 						"name": "Improved Grab",
-						"traits": [
-							"page 213"
-						],
 						"generic": {
 							"tag": "ability"
 						}

--- a/data/bestiary/creatures-ec1.json
+++ b/data/bestiary/creatures-ec1.json
@@ -1489,27 +1489,51 @@
 			"abilities": {
 				"bot": [
 					{
+						"type": "affliction",
+						"name": "Flea Fever",
 						"traits": [
 							"disease"
 						],
-						"entries": [
-							"As giant flea, except {@dc 19}."
+						"DC": 18,
+						"savingThrow": "Fortitude",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition drained|CRB|drained 1}",
+								"duration": "{@dice 1d4} hours"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition drained|CRB|drained 1} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition drained|CRB|drained 2} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition drained|CRB|drained 3} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "dead"
+							}
 						],
-						"name": "Flea Fever"
+						"note": "Drain from flea fever can't be reduced or recovered from naturally until the disease is cured."
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "action"
 						},
-						"requirements": "The flea swarm's last action was",
-						"name": "Suck Blood"
-					},
-					{
+						"requirements": "The flea swarm's last action was Swarming Bites, and it dealt damage to at least one enemy",
 						"entries": [
-							"Bites, and it dealt damage to at least one enemy; The flea swarm drinks the creatures' blood. Each victim becomes {@condition drained|CRB|drained 1} and the swarm regains 3 HP for each victim {@condition drained}."
+							"The flea swarm drinks the creatures' blood. Each victim becomes {@condition drained|CRB|drained 1} and the swarm regains 3 HP for each victim {@condition drained}."
 						],
-						"name": "Swarming"
+						"name": "Suck Blood"
 					},
 					{
 						"activity": {
@@ -1627,13 +1651,40 @@
 						"name": "Suck Blood"
 					},
 					{
+						"type": "affliction",
+						"name": "Flea Fever",
 						"traits": [
 							"disease"
 						],
-						"entries": [
-							"Drain from flea fever can't be reduced or recovered from naturally until the disease is cured. Saving Throw {@dc 18} Fortitude; Stage 1 {@condition drained|CRB|drained 1} ({@dice 1d4} hours), Stage 2 {@condition drained|CRB|drained 1} and {@condition sickened|CRB|sickened 1} (1 day), Stage 3 {@condition drained|CRB|drained 2} and {@condition sickened|CRB|sickened 1} (1 day), Stage 4."
+						"DC": 18,
+						"savingThrow": "Fortitude",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition drained|CRB|drained 1}",
+								"duration": "{@dice 1d4} hours"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition drained|CRB|drained 1} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "{@condition drained|CRB|drained 2} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 4,
+								"entry": "{@condition drained|CRB|drained 3} and {@condition sickened|CRB|sickened 1}",
+								"duration": "1 day"
+							},
+							{
+								"stage": 5,
+								"entry": "dead"
+							}
 						],
-						"name": "Flea Fever"
+						"note": "Drain from flea fever can't be reduced or recovered from naturally until the disease is cured."
 					}
 				]
 			},
@@ -3696,14 +3747,11 @@
 							"number": 1,
 							"unit": "reaction"
 						},
-						"trigger": "A creature adjacent to both Violet and",
-						"name": "Protect"
-					},
-					{
+						"trigger": "A creature adjacent to both Violet and Two-Punch hits Pruana with a melee attack",
 						"entries": [
-							"Two-Punch hits Pruana with a melee attack; Violet shields Pruana from the worst of the blow, taking half the damage from the attack and Pruana takes the remainder."
+							"Violet shields Pruana from the worst of the blow, taking half the damage from the attack and Pruana takes the remainder."
 						],
-						"name": "Pruana"
+						"name": "Protect"
 					}
 				],
 				"bot": [

--- a/data/bestiary/creatures-ec2.json
+++ b/data/bestiary/creatures-ec2.json
@@ -1872,7 +1872,7 @@
 					{
 						"name": "Sneak Attack",
 						"entries": [
-							"A babau deals an additional {@damage 1d6} precision damage to {@condition flat‐footed} creatures."
+							"A babau deals an additional {@damage 1d6} precision damage to {@condition flat-footed} creatures."
 						],
 						"generic": {
 							"tag": "ability"

--- a/data/bestiary/creatures-ec3.json
+++ b/data/bestiary/creatures-ec3.json
@@ -1419,15 +1419,12 @@
 							"evil",
 							"necromancy"
 						],
-						"requirements": "The herecite is in a cabal of three or more members, two of which are within 60 feet and have used",
-						"name": "Assault the Soul"
-					},
-					{
+						"requirements": "The herecite is in a cabal of three or more members, two of which are within 60 feet and have used Cabal Communion within the last round",
 						"entries": [
-							"Communion within the last round; The herecite casts bind soul, spirit blast, or spiritual epidemic ({@dc 31})",
+							"The herecite casts {@spell bind soul}, {@spell spirit blast}, or {@spell spiritual epidemic} ({@dc 31})",
 							"Once a herecite has used this ability (whether or not it was successful), the cabal must wait 24 hours before one of its members can use Assault the Soul again."
 						],
-						"name": "Cabal"
+						"name": "Assault the Soul"
 					},
 					{
 						"activity": {

--- a/data/bestiary/creatures-ec5.json
+++ b/data/bestiary/creatures-ec5.json
@@ -180,12 +180,9 @@
 						},
 						"trigger": "The ammut Grabs a creature",
 						"entries": [
-							"The ammut uses."
+							"The ammut uses Swallow Whole."
 						],
 						"name": "Fast Swallow"
-					},
-					{
-						"name": "Swallow Whole."
 					},
 					{
 						"activity": {
@@ -3027,11 +3024,17 @@
 			"abilities": {
 				"mid": [
 					{
-						"entries": [
-							"30 feet. As graveknight, but with a +24 counteract modifier."
+						"traits": [
+							"abjuration",
+							"aura",
+							"divine",
+							"evil"
 						],
-						"name": "Sacrilegious Aura",
-						"entries_as_xyz": "Ability not found: 'Sacrilegious Aura As graveknight, but with a +24 counteract modifier.' in Shraen Graveknight, p.52"
+						"entries": [
+							"30 feet.",
+							"When a creature in the aura uses a positive spell or ability, the graveknight automatically attempts to counteract it, with a +24 counteract modifier."
+						],
+						"name": "Sacrilegious Aura"
 					},
 					{
 						"activity": {
@@ -3046,6 +3049,7 @@
 				],
 				"bot": [
 					{
+						"name": "Devastating Blast",
 						"activity": {
 							"number": 2,
 							"unit": "action"
@@ -3056,17 +3060,34 @@
 							"evocation"
 						],
 						"entries": [
-							"As graveknight, but {@damage 8d12} cold and {@dc 36}."
-						],
-						"name": "Devastating Blast",
-						"entries_as_xyz": "Ability not found: 'Devastating Blast As graveknight, but {@damage 8d12} cold and {@dc 36}.' in Shraen Graveknight, p.52"
+							"The graveknight unleashes a 30-foot cone of lightning. Creatures in the area take {@damage 8d12} cold damage ({@dc 36} basic Reflex save). The graveknight can use this ability once every {@dice 1d4} rounds."
+						]
 					},
 					{
-						"entries": [
-							"As graveknight, but {@dc 36}."
-						],
+						"type": "affliction",
 						"name": "Graveknight's Curse",
-						"entries_as_xyz": "Ability not found: 'Graveknight's Curse As graveknight, but {@dc 36}.' in Shraen Graveknight, p.52"
+						"notes": [
+							"This curse affects anyone who wears a graveknight's armor for at least 1 hour"
+						],
+						"DC": 36,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition doomed||doomed 1} and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
+							}
+						]
 					},
 					{
 						"activity": {
@@ -3089,18 +3110,16 @@
 						"name": "Quick Draw"
 					},
 					{
-						"entries": [
-							"As graveknight."
-						],
 						"name": "Ruinous Weapons",
-						"entries_as_xyz": "Ability not found: 'Ruinous Weapons As graveknight.' in Shraen Graveknight, p.52"
+						"entries": [
+							"Any weapon or unarmed attack the graveknight uses gains the effects of the +1 greater striking and greater shock weapon runes."
+						]
 					},
 					{
-						"entries": [
-							"As graveknight."
-						],
 						"name": "Weapon Master",
-						"entries_as_xyz": "Ability not found: 'Weapon Master As graveknight.' in Shraen Graveknight, p.52"
+						"entries": [
+							"The graveknight has access to the critical specialization effects of any weapons they wield."
+						]
 					}
 				]
 			},
@@ -4335,12 +4354,9 @@
 							"concentrate"
 						],
 						"entries": [
-							"The deepmouth warps part of a scalescribed creature's flesh into a mouthed tentacle, then wills it to lash out. The deepmouth makes a jaws {@action Strike} that originates from any living scalescribed creature within 120 feet; this {@action Strike} also has reach <15 feet> and deals an additional {@damage 2d8} negative damage. If the {@action Strike} originates from a creature other than the deepmouth, that creature triggers reactions as though it had made."
+							"The deepmouth warps part of a scalescribed creature's flesh into a mouthed tentacle, then wills it to lash out. The deepmouth makes a jaws {@action Strike} that originates from any living scalescribed creature within 120 feet; this {@action Strike} also has reach <15 feet> and deals an additional {@damage 2d8} negative damage. If the {@action Strike} originates from a creature other than the deepmouth, that creature triggers reactions as though it had made the Strike."
 						],
 						"name": "Devourer's Dictum"
-					},
-					{
-						"name": "the Strike."
 					},
 					{
 						"traits": [
@@ -4645,10 +4661,9 @@
 							"mental"
 						],
 						"entries": [
-							"As vampire, but hunting spiders or spider swarms only."
+							"The vampire's presence brings forth creatures of the night to do the master's bidding. Zinogyvaz can only bring forth hunting spiders and spider swarms. The vampire can give telepathic orders to these creatures as long as they are within 100 feet, but they can't communicate back."
 						],
-						"name": "Children of the Night",
-						"entries_as_xyz": "Ability not found: 'Children of the Night As vampire, but hunting spiders or spider swarms only.' in Zinogyvaz, p.35"
+						"name": "Children of the Night"
 					}
 				],
 				"mid": [
@@ -4658,10 +4673,9 @@
 							"unit": "free"
 						},
 						"entries": [
-							"As vampire."
+							"The vampire is reduced to 0 HP. Effect The vampire uses Turn to Mist. It can take move actions to move toward its coffin even though it's at 0 HP. While at 0 HP in this form, the vampire is unaffected by further damage. It automatically returns to its corporeal form, unconscious, if it reaches its coffin or after 2 hours, whichever comes first."
 						],
-						"name": "Mist Escape",
-						"entries_as_xyz": "Ability not found: 'Mist {@action Escape} As vampire.' in Zinogyvaz, p.35"
+						"name": "Mist Escape"
 					}
 				],
 				"bot": [
@@ -4677,13 +4691,12 @@
 							"transmutation"
 						],
 						"entries": [
-							"As vampire, but hunting spider or spider swarm only, and Zinogyvaz keeps her fangs and web {@action Strike||Strikes} in either form."
+							"The vampire transforms into one of its animal forms or back into its normal form. Use the options in the aerial form and animal form spells as guidelines. Zinogyvaz can turn into a hunting spider or spider swarm only, and she keeps her fangs and web Strikes in either form."
 						],
 						"name": "Change Shape",
 						"generic": {
 							"tag": "ability"
-						},
-						"entries_as_xyz": "Ability not found: '{@action Change Shape|LOAG} As vampire, but hunting spider or spider swarm only, and Zinogyvaz keeps her fangs and web {@action Strike||Strikes} in either form.' in Zinogyvaz, p.35"
+						}
 					},
 					{
 						"traits": [
@@ -4692,10 +4705,9 @@
 							"necromancy"
 						],
 						"entries": [
-							"As vampire."
+							"If a creature dies after being reduced to 0 HP by Drink Blood, the vampire can turn this victim into a vampire by donating some of its own blood to the victim and burying the victim in earth for 3 nights. If the new vampire is lower level than its creator, it is under the creator's control. If a vampire controls too many spawn at once (as determined by the GM), strong-willed spawn can free themselves by succeeding at a Will saving throw against the vampire's Will DC."
 						],
-						"name": "Create Spawn",
-						"entries_as_xyz": "Ability not found: 'Create Spawn As vampire.' in Zinogyvaz, p.35"
+						"name": "Create Spawn"
 					},
 					{
 						"activity": {
@@ -4706,11 +4718,13 @@
 							"divine",
 							"necromancy"
 						],
+						"requirements": "A {@condition grabbed}, {@condition paralyzed}, {@condition restrained}, {@condition unconscious}, or willing creature is within the vampire's reach.",
 						"entries": [
-							"As vampire. When Drinking Blood, Zinogyvaz regains 24 Hit Points and may inject the victim with vampire drider venom."
+							"The vampire sinks its fangs into that creature to drink its blood. This requires an {@skill Athletics} check against the victim's Fortitude DC if the victim is grabbed and is automatic for any of the other conditions. The victim is drained 1 and Zinogyvaz regains 24 Hit Points, gaining any excess HP as temporary Hit Points. Drinking Blood from a creature that's already drained doesn't restore any HP to the vampire but increases the victim's drain value by 1. A vampire can also consume blood that's been emptied into a vessel for sustenance, but it gains no HP from doing so.",
+							" A victim's drained condition decreases by 1 per week. A blood transfusion, which requires a {@dc 20} {@skill Medicine} check and sufficient blood or a blood donor, reduces the drain by 1 after 10 minutes.",
+							"When Drinking Blood, Zinogyvaz may inject the victim with vampire drider venom."
 						],
-						"name": "Drink Blood",
-						"entries_as_xyz": "Ability not found: 'Drink Blood As vampire.' in Zinogyvaz, p.35"
+						"name": "Drink Blood"
 					},
 					{
 						"activity": {
@@ -4723,10 +4737,9 @@
 							"transmutation"
 						],
 						"entries": [
-							"As vampire."
+							"The vampire turns into a cloud of vapor, as the {@spell gaseous form} spell, or back to its normal form. The vampire loses fast healing while in gaseous form. The vampire can remain in this form indefinitely."
 						],
-						"name": "Turn to Mist",
-						"entries_as_xyz": "Ability not found: 'Turn to Mist As vampire.' in Zinogyvaz, p.35"
+						"name": "Turn to Mist"
 					},
 					{
 						"type": "affliction",

--- a/data/bestiary/creatures-ec6.json
+++ b/data/bestiary/creatures-ec6.json
@@ -2038,6 +2038,23 @@
 					"DC": 45,
 					"attack": 37,
 					"entry": {
+						"0": {
+							"level": 10,
+							"spells": [
+								{
+									"name": "divine lance"
+								},
+								{
+									"name": "message"
+								},
+								{
+									"name": "read aura"
+								},
+								{
+									"name": "shield"
+								}
+							]
+						},
 						"6": {
 							"spells": [
 								{
@@ -2100,8 +2117,37 @@
 									"name": "weapon of judgment"
 								}
 							]
+						},
+						"constant": {
+							"4": {
+								"spells": [
+									{
+										"name": "air walk"
+									},
+									{
+										"name": "freedom of movement"
+									}
+								]
+							}
 						}
 					}
+				}
+			],
+			"rituals": [
+				{
+					"tradition": "divine",
+					"DC": 45,
+					"rituals": [
+						{
+							"name": "abyssal pact"
+						},
+						{
+							"name": "atone"
+						},
+						{
+							"name": "commune"
+						}
+					]
 				}
 			],
 			"abilities": {
@@ -2129,29 +2175,17 @@
 					{
 						"entries": [
 							"Sarvel begins combat with two tentacles. Each tentacle has 66 HP and is immune to area damage.",
-							"A creature can attempt to sever one."
+							"A creature can attempt to sever one of Sarvel's tentacles by specifically targeting it and dealing damage equal to the tentacle's Hit Points. A tentacle not completely severed returns to full HP at the end of any creature's turn. For each tentacle he has, Sarvel gains an extra reaction at the start of his turn that can be used only for an {@action Attack of Opportunity}. If he has no tentacles, he can no longer make tentacle {@action Strike||Strikes}, Writhe Independently, or Constrict."
 						],
 						"name": "Touch of Zevgavizeb"
-					},
-					{
-						"entries": [
-							"Sarvel's tentacles by specifically targeting it and dealing damage equal to the tentacle's Hit Points. A tentacle not completely severed returns to full HP at the end of any creature's turn. For each tentacle he has, Sarvel gains an extra reaction at the start of his turn that can be used only for an {@action Attack of Opportunity}. If he has no tentacles, he can no longer make tentacle {@action Strike||Strikes}, Writhe."
-						],
-						"name": "of"
-					},
-					{
-						"name": "Independently, or Constrict."
 					},
 					{
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
 						},
-						"traits": [
-							"tentacle"
-						],
 						"entries": [
-							"only."
+							"tentacle only"
 						],
 						"name": "Attack of Opportunity",
 						"generic": {
@@ -2160,15 +2194,6 @@
 					}
 				],
 				"bot": [
-					{
-						"traits": [
-							"10th"
-						],
-						"entries": [
-							"divine lance, message, read aura, shield; Constant (4th) air walk, freedom of movement Rituals {@dc 45}; Abyssal pact, atone, commune."
-						],
-						"name": "Cantrips"
-					},
 					{
 						"activity": {
 							"number": 1,

--- a/data/bestiary/creatures-fop.json
+++ b/data/bestiary/creatures-fop.json
@@ -1331,13 +1331,10 @@
 							"unit": "reaction"
 						},
 						"trigger": "An adjacent foe moves away.",
-						"name": "No Escape"
-					},
-					{
 						"entries": [
-							"Nar may move up to his speed but must end his move as close to the triggering creature as possible without entering the triggering creature's square."
+							"Lord Nar may move up to his speed but must end his move as close to the triggering creature as possible without entering the triggering creature's square."
 						],
-						"name": "Lord"
+						"name": "No Escape"
 					},
 					{
 						"activity": {

--- a/data/bestiary/creatures-frp1.json
+++ b/data/bestiary/creatures-frp1.json
@@ -2428,9 +2428,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"traits": [
-							"pathfinder bestiary 3 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -2440,9 +2441,10 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"bestiary 3 305"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Form Up"
 					},
 					{
@@ -4471,12 +4473,9 @@
 						},
 						"trigger": "A creature succeeds at an attempt to {@action Grapple} the muckish creep",
 						"entries": [
-							"The muckish creep attempts an {@skill Athletics} check."
+							"The muckish creep attempts an {@skill Athletics} check to {@action Escape}."
 						],
 						"name": "Elude Grasp"
-					},
-					{
-						"name": "to Escape."
 					}
 				],
 				"bot": [
@@ -5127,9 +5126,10 @@
 			"abilities": {
 				"mid": [
 					{
-						"traits": [
-							"pathfinder bestiary 3 306"
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -5139,13 +5139,21 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"traits": [
-							"pathfinder bestiary 3 305"
-						],
-						"entries": [
-							"Aim as One {@as 2} The terra-cotta squadron launches a ranged attack in the form of a 10-foot burst within 100 feet that deals {@dice 3d8+13} damage ({@dc 33} basic Reflex save). When the garrison is reduced to 8 or fewer squares, this area decreases to a 5-foot burst."
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Form Up"
+					},
+					{
+						"name": "Aim as One",
+						"activity": {
+							"number": 2,
+							"unit": "action"
+						},
+						"entries": [
+							"The terra-cotta squadron launches a ranged attack in the form of a 10-foot burst within 100 feet that deals {@dice 3d8+13} damage ({@dc 33} basic Reflex save). When the garrison is reduced to 8 or fewer squares, this area decreases to a 5-foot burst."
+						]
 					},
 					{
 						"activity": {
@@ -6879,7 +6887,10 @@
 							"incapacitation",
 							"mental"
 						],
-						"requirements": "As poltergeist, but {@dc 33}.",
+						"requirements": "The poltergeist must be {@condition invisible}.",
+						"entries": [
+							"The poltergeist becomes visible, appearing as a skeletal, ghostlike humanoid. Each creature within 30 feet must attempt a {@dc 33} Will save, becoming {@condition frightened|CRB|frightened 2} on a failure. On a critical failure, it's also {@condition fleeing} for as long as it's {@condition frightened}. On a success, the creature is temporarily immune for 1 minute. At the start of its next turn, the poltergeist becomes {@condition invisible} again."
+						],
 						"name": "Frighten"
 					},
 					{

--- a/data/bestiary/creatures-frp2.json
+++ b/data/bestiary/creatures-frp2.json
@@ -124,12 +124,9 @@
 							"unit": "action"
 						},
 						"entries": [
-							"Akila {@action Stride||Strides}, then {@action Strike||Strikes}. If she was {@condition hidden} at the start of this action, she remains {@condition hidden} until after."
+							"Akila {@action Stride||Strides}, then {@action Strike||Strikes}. If she was {@condition hidden} at the start of this action, she remains {@condition hidden} until after the Strike."
 						],
 						"name": "Pounce"
-					},
-					{
-						"name": "the Strike."
 					},
 					{
 						"activity": {
@@ -1822,15 +1819,12 @@
 							"unit": "reaction"
 						},
 						"entries": [
-							"Huldrin gets 1 extra reaction each turn that she can use only to make an."
+							"Huldrin gets 1 extra reaction each turn that she can use only to make an Attack of Opportunity."
 						],
 						"name": "Attack of Opportunity",
 						"generic": {
 							"tag": "ability"
 						}
-					},
-					{
-						"name": "Attack of Opportunity."
 					},
 					{
 						"activity": {

--- a/data/bestiary/creatures-frp3.json
+++ b/data/bestiary/creatures-frp3.json
@@ -1282,9 +1282,10 @@
 						}
 					},
 					{
-						"entries": [
-							"Bestiary 3 306."
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -1309,9 +1310,10 @@
 							"number": 1,
 							"unit": "action"
 						},
-						"entries": [
-							"Bestiary 3 305."
-						],
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Form Up"
 					},
 					{

--- a/data/bestiary/creatures-gw1.json
+++ b/data/bestiary/creatures-gw1.json
@@ -415,10 +415,9 @@
 					"aklo",
 					"common",
 					"draconic",
-					"d'ziriak"
-				],
-				"notes": [
-					"Shadowtongue,"
+					"d'ziriak",
+					"shadowtongue",
+					"sylvan"
 				]
 			},
 			"skills": {
@@ -574,31 +573,34 @@
 							]
 						}
 					}
+				},
+				{
+					"tradition": "Transmutation School Spell",
+					"type": "Focus",
+					"fp": 1,
+					"entry": {
+						"1": {
+							"spells": [
+								{
+									"name": "physical boost"
+								}
+							]
+						}
+					}
 				}
 			],
 			"abilities": {
-				"top": [
-					{
-						"name": "Sylvan"
-					}
-				],
 				"mid": [
 					{
-						"name": "Shadow Blending When the Looksee",
+						"name": "Shadow Blending",
 						"entries": [
-							"Man is {@condition concealed} as a result of dim light, the flat check to target him has a DC of 7, not 5."
+							"When the Looksee Man is {@condition concealed} as a result of dim light, the flat check to target him has a DC of 7, not 5."
 						]
 					},
 					{
 						"name": "Stalk Goggles Specialist",
 						"entries": [
 							"As long as he wears his greater stalk goggles, the Looksee Man can't be flanked by creatures of 4th level or lower."
-						]
-					},
-					{
-						"name": "Transmutation School Spell 1 Focus Point;",
-						"entries": [
-							"1st physical boost (Core Rulebook 407)"
 						]
 					},
 					{
@@ -614,13 +616,7 @@
 						],
 						"requirements": "The Looksee Man is in dim light",
 						"entries": [
-							"The Looksee"
-						]
-					},
-					{
-						"name": "Man Strides.",
-						"entries": [
-							"He has a +10-foot status bonus to his"
+							"The Looksee Man Strides. He has a +10-foot status bonus to his Speed during this Stride. The DC from shadow blending increases to 11 during this Stride, and the Looksee Man remains concealed by dim light until the end of the movement, even if he leaves dim light during the Stride."
 						]
 					}
 				]

--- a/data/bestiary/creatures-loil.json
+++ b/data/bestiary/creatures-loil.json
@@ -1917,20 +1917,18 @@
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
-						}
+						},
+						"trigger": "A creature critically hits the mutant with a melee unarmed Strike or a non-reach melee Strike",
+						"entries": [
+							"The mutant makes a maw Strike against the triggering creature."
+						]
 					}
 				],
 				"bot": [
 					{
-						"name": "Pack Attack A Mana",
+						"name": "Pack Attack",
 						"entries": [
-							"Wastes mutant gnoll hulk deals {@damage 1d4} extra damage to any creature who's within reach of at least two of the"
-						]
-					},
-					{
-						"name": "Mana",
-						"entries": [
-							"Wastes mutant gnoll hulk's allies."
+							"A Mana Wastes mutant gnoll hulk deals {@damage 1d4} extra damage to any creature who's within reach of at least two of the Mana Wastes mutant gnoll hulk's allies."
 						]
 					},
 					{

--- a/data/bestiary/creatures-lomm.json
+++ b/data/bestiary/creatures-lomm.json
@@ -733,7 +733,7 @@
 					{
 						"name": "Paralytic Secretion",
 						"entries": [
-							"Desert's Howl's saliva is a potent paralytic substance that drains the energy from prey. A creature hit by its spit {@action Strike} must succeed at a {@dc 41} Fortitude save or become {@condition drained <2>} as well as {@condition paralyzed} for 1 round. If the target was already drained, it instead increases the condition's value by 1, to a maximum of drained 4."
+							"Desert's Howl's saliva is a potent paralytic substance that drains the energy from prey. A creature hit by its spit {@action Strike} must succeed at a {@dc 41} Fortitude save or become {@condition drained 2} as well as {@condition paralyzed} for 1 round. If the target was already drained, it instead increases the condition's value by 1, to a maximum of drained 4."
 						]
 					},
 					{
@@ -974,7 +974,7 @@
 					{
 						"name": "Paralytic Secretion",
 						"entries": [
-							"The howling spawn's saliva is a potent paralytic substance that drains the energy from prey. A creature hit by its spit {@action Strike} must succeed at a {@dc 30} Fortitude save or become {@condition drained <1>} as well as {@condition paralyzed} for 1 round. If the target was already drained, it instead increases the condition's value by 1, to a maximum of drained 4."
+							"The howling spawn's saliva is a potent paralytic substance that drains the energy from prey. A creature hit by its spit {@action Strike} must succeed at a {@dc 30} Fortitude save or become {@condition drained 1} as well as {@condition paralyzed} for 1 round. If the target was already drained, it instead increases the condition's value by 1, to a maximum of drained 4."
 						]
 					},
 					{
@@ -3446,13 +3446,9 @@
 							"disease"
 						],
 						"generic": {
-							"tag": "ability",
-							"name": "Addictive Exhaustion",
+							"tag": "affliction",
 							"source": "LOMM"
-						},
-						"entries": [
-							"{@dc 32}"
-						]
+						}
 					},
 					{
 						"name": "Infectious Spores",
@@ -3481,7 +3477,7 @@
 							"number": 1
 						},
 						"entries": [
-							"Kuworsys stands on its two hind limbs, bringing its other four limbs to bear on its foes. Kuworsys stays Reared Back until it uses a single action to return to its normal stance. While Kuworsys is Reared Back, it is {@condition clmusy||clumsy 1} but can use its Pinion and Yank abilities."
+							"Kuworsys stands on its two hind limbs, bringing its other four limbs to bear on its foes. Kuworsys stays Reared Back until it uses a single action to return to its normal stance. While Kuworsys is Reared Back, it is {@condition clumsy||clumsy 1} but can use its Pinion and Yank abilities."
 						]
 					},
 					{

--- a/data/bestiary/creatures-ngd.json
+++ b/data/bestiary/creatures-ngd.json
@@ -2386,9 +2386,26 @@
 							"concentrate",
 							"move"
 						],
-						"requirements": "The chakanaj is Bonded with a Host; Effect the chakanaj removes itself from its host, peeling off the host's body and enters an adjacent space. Skip Between {@as 1} (conjuration, divine, teleportation) The chakanaj sahkil moves from the Material Plane to the Ethereal Plane or vice versa, with the effects of ethereal jaunt except the effect has an unlimited duration and can be Dismissed. A summoned sahkil can't use Skip Between."
-					}
-				]
+						"entries": [
+							"The chakanaj removes itself from its host, peeling off the host's body and enters an adjacent space."
+						],
+						"requirements": "The chakanaj is Bonded with a Host"
+					},
+					{
+						"name": "Skip Between",
+						"activity": {
+							"number": 1,
+							"unit": "action"
+						},
+						"traits": [
+							"conjuration",
+							"divine",
+							"teleportation"
+						],
+						"entries": [
+							"The chakanaj sahkil moves from the Material Plane to the Ethereal Plane or vice versa, with the effects of ethereal jaunt except the effect has an unlimited duration and can be Dismissed. A summoned sahkil can't use Skip Between."
+						]
+					}]
 			},
 			"defenses": {
 				"ac": {

--- a/data/bestiary/creatures-ooa1.json
+++ b/data/bestiary/creatures-ooa1.json
@@ -2562,11 +2562,8 @@
 							"unit": "action"
 						},
 						"entries": [
-							"Nixbrix flees the scene. He moves four times, each time using one of the following actions:"
+							"Nixbrix flees the scene. He moves four times, each time using one of the following actions: {@action Climb}, {@action Leap}, {@action Stand}, {@action Step}, or {@action Stride}."
 						]
-					},
-					{
-						"name": "Climb, Leap, Stand, Step, or Stride."
 					},
 					{
 						"name": "Really Big Gun",
@@ -2616,7 +2613,10 @@
 					"dwarven",
 					"elven",
 					"gnoll",
-					"gnomish,"
+					"gnomish",
+					"ignan",
+					"kelish",
+					"osiriani"
 				]
 			},
 			"skills": {
@@ -2718,9 +2718,6 @@
 			],
 			"abilities": {
 				"top": [
-					{
-						"name": "Ignan, Kelish, Osiriani"
-					},
 					{
 						"name": "Infused",
 						"entries": [

--- a/data/bestiary/creatures-ooa3.json
+++ b/data/bestiary/creatures-ooa3.json
@@ -679,7 +679,8 @@
 					{
 						"name": "Troop Defenses",
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						}
 					}
 				],
@@ -691,7 +692,8 @@
 							"unit": "action"
 						},
 						"generic": {
-							"tag": "ability"
+							"tag": "ability",
+							"source": "B3"
 						}
 					},
 					{

--- a/data/bestiary/creatures-sog1.json
+++ b/data/bestiary/creatures-sog1.json
@@ -3257,7 +3257,7 @@
 					{
 						"name": "You Know, They Say...",
 						"entries": [
-							"Old Matsuki can use {@skill lore||Willowshore Lore} in place of {@skill Arcana}, {@skill Medicine}, {@skill Occultism}, or {@skill Religion} to attempt {@action Recall Knowledge} checks with a \u20132 penalty. He has the effects of the {@feat Dubious Knowledge} feat for {@action Recall Knowledge checks attempted in this way."
+							"Old Matsuki can use {@skill lore||Willowshore Lore} in place of {@skill Arcana}, {@skill Medicine}, {@skill Occultism}, or {@skill Religion} to attempt {@action Recall Knowledge} checks with a \u20132 penalty. He has the effects of the {@feat Dubious Knowledge} feat for {@action Recall Knowledge} checks attempted in this way."
 						]
 					}
 				],

--- a/data/bestiary/creatures-sot3.json
+++ b/data/bestiary/creatures-sot3.json
@@ -893,34 +893,54 @@
 							"evocation"
 						],
 						"entries": [
-							"Bharlen unleashes crackling lightning in a 30-foot cone. Creatures in the area take {@damage 6d12} electricity damage ({@dc 30} basic Reflex save). Bharlen can use this ability once every {@dice 1d4} rounds.",
+							"Bharlen unleashes crackling lightning in a 30-foot cone. Creatures in the area take {@damage 6d12} electricity damage ({@dc 30} basic Reflex save). Bharlen can use this ability once every {@dice 1d4} rounds."
+						]
+					},
+					{
+						"name": "Sodden Strike",
+						"activity": {
+							"number": 2,
+							"unit": "action"
+						},
+						"traits": [
+							"conjuration",
+							"divine",
+							"water"
+						],
+						"entries": [
+							"Bharlen calls to the endless storm to lend murderous power to her blows. She makes a {@action Strike}; on a hit, seawater appears in the target's lungs and the target is {@condition sickened||sickened 1} ({@condition sickened||sickened 3} on a critical hit)."
+						]
+					},
+					{
+						"type": "affliction",
+						"name": "Graveknight's Curse",
+						"notes": [
+							"This curse affects anyone who wears a graveknight's armor for at least 1 hour"
+						],
+						"DC": 40,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
 							{
-								"type": "affliction",
-								"name": "Graveknight's Curse This curse affects anyone who wears a",
-								"notes": [
-									"Bharlen calls to the endless storm to lend murderous power to her blows. She makes a {@action Strike}; on a hit, seawater appears in the target's lungs and the target is {@condition sickened||sickened 1} ({@condition sickened||sickened 3} on a critical hit)."
-								],
-								"DC": 40,
-								"savingThrow": "Will",
-								"onset": "1 hour",
-								"stages": [
-									{
-										"stage": 1,
-										"entry": "{@condition doomed||doomed 1} and cannot remove the armor",
-										"duration": "1 day"
-									},
-									{
-										"stage": 2,
-										"entry": "{@condition doomed||doomed 2}, hampered 10, and cannot remove the armor",
-										"duration": "1 day"
-									},
-									{
-										"stage": 3,
-										"entry": "dies and transforms into the armor's graveknight. Ruinous Weapons Any weapons Bharlen wields gain the effects of the +1 striking and shock runes. Sodden {@action Strike} {@as 2}",
-										"duration": "conjuration, divine, water"
-									}
-								]
+								"stage": 1,
+								"entry": "{@condition doomed||doomed 1} and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
 							}
+						]
+					},
+					{
+						"name": "Ruinous Weapons",
+						"entries": [
+							"Any weapon or unarmed attack Bharlen uses gains the effects of the +1 greater striking and greater shock weapon runes."
 						]
 					},
 					{

--- a/data/bestiary/creatures-sot4.json
+++ b/data/bestiary/creatures-sot4.json
@@ -745,7 +745,8 @@
 					"common",
 					"draconic",
 					"requian",
-					"sphinx"
+					"sphinx",
+					"sylvan"
 				],
 				"abilities": [
 					"{@spell speak with animals}",
@@ -918,12 +919,6 @@
 			"abilities": {
 				"top": [
 					{
-						"name": "Requian, Sphinx, Sylvan;",
-						"entries": [
-							"speak with animals, speak with plants; telepathy 300 feet"
-						]
-					},
-					{
 						"name": "Fungus Sight",
 						"traits": [
 							"divination",
@@ -961,30 +956,21 @@
 							"transmutation"
 						],
 						"entries": [
-							"60 feet.",
-							"Dimari-Diji's natural power enhances primal spellcasting around him. All creatures within the emanation can alter a primal spell as if they had just used Reach Spell or Widen"
-						]
-					},
-					{
-						"name": "Spell",
-						"activity": {
-							"unit": "varies",
-							"entry": "Core Rulebook 210"
-						},
-						"components": [
-							"when they {@action Cast a Spell||Cast the Spell}."
+							"60 feet. Dimari-Diji's natural power enhances primal spellcasting around him. All creatures within the emanation can alter a primal spell as if they had just used {@feat Reach Spell (Sorcerer)||Reach Spell} or {@feat Widen Spell (Sorcerer)||Widen Spell} when they {@action Cast a Spell||Cast the Spell}."
 						]
 					}
 				],
 				"bot": [
 					{
-						"name": "Memories of Ages"
-					},
-					{
 						"name": "Forest Growth",
 						"entries": [
-							"Once per month, Dimari-Diji can spend 1 hour to sprout a new forest. He causes the forest to sprout in a 50-foot burst within 300 feet. The forest instantly springs to life, and is composed of fungi, plants, and trees most appropriate to the area he selected. The forest grows to the height, density, and liveliness of a forest that has grown for 10 years.",
-							"The forest doesn't feature any animals or other creatures, but animals within 1 mile are aware of the new forest and might make the forest their new habitat as appropriate. Memories of Ages Dimari-Diji's mental blasts cloud the minds of his foes, making it difficult for them to focus on combat. A creature that takes damage from Dimari-Diji's mental blast is {@condition dazzled} for 1 round. If the attack was a critical hit, the creature is {@condition dazzled} for 1 minute instead."
+							"Once per month, Dimari-Diji can spend 1 hour to sprout a new forest. He causes the forest to sprout in a 50-foot burst within 300 feet. The forest instantly springs to life, and is composed of fungi, plants, and trees most appropriate to the area he selected. The forest grows to the height, density, and liveliness of a forest that has grown for 10 years. The forest doesn't feature any animals or other creatures, but animals within 1 mile are aware of the new forest and might make the forest their new habitat as appropriate."
+						]
+					},
+					{
+						"name": "Memories of Ages",
+						"entries": [
+							"Dimari-Diji's mental blasts cloud the minds of his foes, making it difficult for them to focus on combat. A creature that takes damage from Dimari-Diji's mental blast is {@condition dazzled} for 1 round. If the attack was a critical hit, the creature is {@condition dazzled} for 1 minute instead."
 						]
 					},
 					{
@@ -1727,6 +1713,10 @@
 						]
 					},
 					{
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -1736,6 +1726,10 @@
 						"activity": {
 							"number": 1,
 							"unit": "action"
+						},
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
 						}
 					},
 					{
@@ -2148,7 +2142,14 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Graveknight's Shield"
+						"name": "Graveknight's Shield",
+						"traits": [
+							"arcane",
+							"necromancy"
+						],
+						"entries": [
+							"The graveknight's curse extends to their shield, or the graveknight's armor uses a portion of itself to produce a shield. The graveknight has a shield that uses the statistics of a {@item sturdy shield} of a level no higher than the graveknight's level – 1. The shield is quasi-independent of the graveknight and automatically protects the graveknight from harm. When the shield is raised, it automatically uses {@action Shield Block} to reduce the damage of the first attack against the graveknight each round without the graveknight needing to spend their reaction to do so. The shield automatically rejuvenates with the rest of the graveknight and must be destroyed in the same manner as the graveknight's armor."
+						]
 					},
 					{
 						"name": "Attack of Opportunity",
@@ -2324,6 +2325,40 @@
 					"DC": 33,
 					"attack": 25,
 					"entry": {
+						"0": {
+							"level": 7,
+							"spells": [
+								{
+									"name": "chill touch"
+								},
+								{
+									"name": "daze"
+								},
+								{
+									"name": "light"
+								},
+								{
+									"name": "shield"
+								}
+							]
+						},
+						"4": {
+							"spells": [
+								{
+									"name": "fireball"
+								}
+							]
+						},
+						"5": {
+							"spells": [
+								{
+									"name": "cone of cold"
+								},
+								{
+									"name": "flame strike"
+								}
+							]
+						},
 						"6": {
 							"spells": [
 								{
@@ -2364,25 +2399,29 @@
 						"activity": {
 							"number": 1,
 							"unit": "reaction"
-						}
+						},
+						"traits": [
+							"arcane",
+							"transmutation"
+						],
+						"trigger": "A creature attempts to move away from the graveknight",
+						"entries": [
+							"The graveknight's armor animates and attempts to Grab the triggering creature. It makes an {@skill Athletics} check to {@action Grapple} using the graveknight's Athletics modifier – 2. The armor can continue to Grapple the creature normally. Since the armor is grappling the creature, the graveknight doesn't need a free hand to do so."
+						]
 					}
 				],
 				"bot": [
-					{
-						"name": "SoM;",
-						"entries": [
-							"5th cone of cold, flame strike; 4th fireball; Cantrips (7th) chill touch, daze, light, shield"
-						]
-					},
 					{
 						"name": "Channel Magic",
 						"activity": {
 							"number": 2,
 							"unit": "action"
-						}
+						},
+						"entries": [
+							"The graveknight redirects magical energies through its armor, allowing it to deliver magic through an attack. The graveknight Casts a Spell that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell don't occur immediately but are imbued into an attack instead. The graveknight then makes a melee Strike with a weapon or unarmed attack. The spell is coupled with the attack, using the attack roll result to determine the effects of both the Strike and the spell. This counts as two attacks for the graveknight's multiple attack penalty but doesn't apply the penalty until after it's completed Channeling Magic. The graveknight can't use Channel Magic again for 1d4 rounds."
+						]
 					},
 					{
-						"name": "Devastating Blast",
 						"activity": {
 							"number": 2,
 							"unit": "action"
@@ -2393,20 +2432,42 @@
 							"fire"
 						],
 						"entries": [
-							"{@damage 8d12} fire, {@dc 36}; as graveknight"
-						]
+							"The graveknight unleashes a 30-foot cone of energy.",
+							"Creatures in the area take {@damage 8d12} fire damage ({@dc 36} basic Reflex save). The graveknight can't use this ability again for {@dice 1d4} rounds."
+						],
+						"name": "Devastating Blast"
 					},
 					{
+						"type": "affliction",
 						"name": "Graveknight's Curse",
-						"entries": [
-							"{@dc 36}; as graveknight."
+						"notes": [
+							"This curse affects anyone who wears a graveknight's armor for at least 1 hour"
+						],
+						"DC": 43,
+						"savingThrow": "Will",
+						"onset": "1 hour",
+						"stages": [
+							{
+								"stage": 1,
+								"entry": "{@condition doomed||doomed 1} and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 2,
+								"entry": "{@condition doomed||doomed 2}, hampered 10, and can't remove the armor",
+								"duration": "1 day"
+							},
+							{
+								"stage": 3,
+								"entry": "dies and transforms into the armor's graveknight"
+							}
 						]
 					},
 					{
-						"name": "Weapon Master",
 						"entries": [
-							"As graveknight."
-						]
+							"The graveknight has access to the critical specialization effects of any weapons it wields."
+						],
+						"name": "Weapon Master"
 					}
 				]
 			},
@@ -2582,12 +2643,9 @@
 						"frequency": {
 							"number": 1,
 							"unit": "round"
-						}
-					},
-					{
-						"name": "The Jackal",
+						},
 						"entries": [
-							"Guard swings their weapon with a sweeping spin. They attempt separate {@skill Athletics} checks to {@action Trip} any number of creatures within their reach. Each attempt counts toward the Jackal Guard's multiple attack penalty, but the multiple attack penalty doesn't increase until after they make all the attacks."
+							"The Jackal Guard swings their weapon with a sweeping spin. They attempt separate {@skill Athletics} checks to {@action Trip} any number of creatures within their reach. Each attempt counts toward the Jackal Guard's multiple attack penalty, but the multiple attack penalty doesn't increase until after they make all the attacks."
 						]
 					},
 					{
@@ -2601,13 +2659,7 @@
 							"unit": "round"
 						},
 						"entries": [
-							"The"
-						]
-					},
-					{
-						"name": "Jackal",
-						"entries": [
-							"Guard uses their spear to jump over or around a creature and create an opening. The Jackal Guard Strides up to half their Speed. This movement doesn't trigger reactions. During this movement, they can move through the space of one creature, and when the Jackal Guard moves through a creature's space in this way, that creature becomes flatfooted until the end of the Jackal Guard's turn. If the Jackal Guard ends their movement within melee reach of at least one enemy, they can make a melee {@action Strike} against that enemy."
+							"The Jackal Guard uses their spear to jump over or around a creature and create an opening. The Jackal Guard Strides up to half their Speed. This movement doesn't trigger reactions. During this movement, they can move through the space of one creature, and when the Jackal Guard moves through a creature's space in this way, that creature becomes flatfooted until the end of the Jackal Guard's turn. If the Jackal Guard ends their movement within melee reach of at least one enemy, they can make a melee {@action Strike} against that enemy."
 						]
 					}
 				]
@@ -2615,9 +2667,7 @@
 			"defenses": {
 				"ac": {
 					"std": 29,
-					"abilities": [
-						"31 with shield raised);"
-					]
+					"with shield raised": 31
 				},
 				"savingThrows": {
 					"fort": {
@@ -4211,6 +4261,10 @@
 						}
 					},
 					{
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -4230,6 +4284,10 @@
 						"activity": {
 							"number": 1,
 							"unit": "action"
+						},
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
 						}
 					},
 					{
@@ -4416,6 +4474,10 @@
 			"abilities": {
 				"mid": [
 					{
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
+						},
 						"name": "Troop Defenses"
 					}
 				],
@@ -4425,6 +4487,10 @@
 						"activity": {
 							"number": 1,
 							"unit": "action"
+						},
+						"generic": {
+							"tag": "ability",
+							"source": "B3"
 						}
 					},
 					{

--- a/data/bestiary/creatures-sot5.json
+++ b/data/bestiary/creatures-sot5.json
@@ -769,12 +769,6 @@
 				],
 				"bot": [
 					{
-						"name": "Red Star",
-						"traits": [
-							"page 77"
-						]
-					},
-					{
 						"name": "Project Calm",
 						"activity": {
 							"number": 3,
@@ -3175,7 +3169,7 @@
 				{
 					"rituals": [
 						{
-							"name": "rite of the"
+							"name": "rite of the red star"
 						}
 					]
 				}
@@ -3195,12 +3189,6 @@
 				],
 				"bot": [
 					{
-						"name": "Red Star",
-						"traits": [
-							"see page 77"
-						]
-					},
-					{
 						"name": "Iobane Vision",
 						"traits": [
 							"fortune"
@@ -3217,18 +3205,10 @@
 						},
 						"frequency": {
 							"special": "Until recharged"
-						}
-					},
-					{
-						"name": "Warder-Chief Mpondo Casts a",
+						},
 						"entries": [
-							"Spell that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell do not occur immediately but are imbued into the attack instead. Mpondo makes a melee {@action Strike}. The spell is coupled with the attack, using the attack roll result to determine the effects of both the {@action Strike} and the spell. This counts as two attacks for Mpondo's multiple attack penalty, but don't apply the penalty until after he has completed the {@action Spellstrike|SoM}."
-						]
-					},
-					{
-						"name": "After",
-						"entries": [
-							"Mpondo uses {@action Spellstrike|SoM}, he can't do so again until he recharges his {@action Spellstrike|SoM} as a single action, which has the {@trait concentrate} trait. Mpondo also recharges his {@action Spellstrike|SoM} when he casts a conflux spell."
+							"Warder-Chief Mpondo {@action Casts a Spell} that takes 1 or 2 actions to cast and requires a spell attack roll. The effects of the spell do not occur immediately but are imbued into the attack instead. Mpondo makes a melee {@action Strike}. The spell is coupled with the attack, using the attack roll result to determine the effects of both the {@action Strike} and the spell. This counts as two attacks for Mpondo's multiple attack penalty, but don't apply the penalty until after he has completed the {@action Spellstrike|SoM}.",
+							"After Mpondo uses {@action Spellstrike|SoM}, he can't do so again until he recharges his {@action Spellstrike|SoM} as a single action, which has the {@trait concentrate} trait. Mpondo also recharges his {@action Spellstrike|SoM} when he casts a conflux spell."
 						]
 					}
 				]

--- a/data/bestiary/creatures-sot6.json
+++ b/data/bestiary/creatures-sot6.json
@@ -4191,15 +4191,15 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Shadow's Displeasure As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Shadow's Displeasure",
+						"entries": [
+							"When Anchor Root has fewer than 150 Hit Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. She looks pained and confused, and she becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, she falls {@condition unconscious}."
 						]
 					},
 					{
-						"name": "Vesicated Shadow As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Vesicated Shadow",
+						"entries": [
+							"Anchor Root's shadow has become corrupted via the power of the Vesicant Egg. Her shredded shadow grants him some control over acid and shadows. She gains a +4 status bonus to resist {@trait acid} and {@trait shadow} effects."
 						]
 					}
 				],
@@ -4217,13 +4217,25 @@
 							"shadow"
 						],
 						"entries": [
-							"As"
-						]
-					},
-					{
-						"name": "Unshadowed Okoro",
-						"traits": [
-							"page 19"
+							"Okoro can create immense blisters on a creature's shadow, which immediately burst, dealing {@damage 20d6} acid damage. He targets a creature within 60 feet that is casting a shadow, which must attempt a {@dc 37} Will save.",
+							"Okoro can't use Rupture Shadow again for {@dice 1d4} rounds.",
+							{
+								"type": "successDegree",
+								"entries": {
+									"Critical Success": [
+										"The target is unaffected and becomes temporarily immune for 1 day."
+									],
+									"Success": [
+										"The target takes half damage. The bursting shadow deals 5 acid {@trait splash} damage to all creatures within 5 feet of the target."
+									],
+									"Failure": [
+										"The target takes full damage, and the bursting shadow deals 10 acid {@trait splash} damage."
+									],
+									"Critical Failure": [
+										"The target takes double damage, the bursting shadow deals 20 acid {@trait splash} damage, and the target also takes {@damage 4d6} {@condition persistent damage||persistent acid damage}."
+									]
+								}
+							}
 						]
 					}
 				]
@@ -4526,15 +4538,15 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Shadow's Displeasure As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Shadow's Displeasure",
+						"entries": [
+							"When Haibram has fewer than 150 Hit Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. He looks pained and confused, and he becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, he falls {@condition unconscious}."
 						]
 					},
 					{
-						"name": "Vesicated Shadow As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Vesicated Shadow",
+						"entries": [
+							"Haibram's shadow has become corrupted via the power of the Vesicant Egg. His shredded shadow grants him some control over acid and shadows. He gains a +4 status bonus to resist {@trait acid} and {@trait shadow} effects."
 						]
 					}
 				],
@@ -4552,13 +4564,25 @@
 							"shadow"
 						],
 						"entries": [
-							"As"
-						]
-					},
-					{
-						"name": "Unshadowed Okoro",
-						"traits": [
-							"page 19"
+							"Haibram can create immense blisters on a creature's shadow, which immediately burst, dealing {@damage 20d6} acid damage. He targets a creature within 60 feet that is casting a shadow, which must attempt a {@dc 37} Will save.",
+							"Haibram can't use Rupture Shadow again for {@dice 1d4} rounds.",
+							{
+								"type": "successDegree",
+								"entries": {
+									"Critical Success": [
+										"The target is unaffected and becomes temporarily immune for 1 day."
+									],
+									"Success": [
+										"The target takes half damage. The bursting shadow deals 5 acid {@trait splash} damage to all creatures within 5 feet of the target."
+									],
+									"Failure": [
+										"The target takes full damage, and the bursting shadow deals 10 acid {@trait splash} damage."
+									],
+									"Critical Failure": [
+										"The target takes double damage, the bursting shadow deals 20 acid {@trait splash} damage, and the target also takes {@damage 4d6} {@condition persistent damage||persistent acid damage}."
+									]
+								}
+							}
 						]
 					},
 					{
@@ -4640,7 +4664,12 @@
 			"languages": {
 				"languages": [
 					"common",
-					"draconic,"
+					"draconic",
+					"gnoll",
+					"iruxi",
+					"necril",
+					"orc",
+					"sylvan"
 				]
 			},
 			"skills": {
@@ -4876,22 +4905,17 @@
 				}
 			],
 			"abilities": {
-				"top": [
-					{
-						"name": "Gnoll, Iruxi, Necril, Orc, Sylvan"
-					}
-				],
 				"mid": [
 					{
-						"name": "Shadow's Displeasure As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Shadow's Displeasure",
+						"entries": [
+							"When Koride has fewer than 150 Hit Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. She looks pained and confused, and she becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, she falls {@condition unconscious}."
 						]
 					},
 					{
-						"name": "Vesicated Shadow As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Vesicated Shadow",
+						"entries": [
+							"Koride's shadow has become corrupted via the power of the Vesicant Egg. Her shredded shadow grants him some control over acid and shadows. She gains a +4 status bonus to resist {@trait acid} and {@trait shadow} effects."
 						]
 					}
 				],
@@ -4909,13 +4933,25 @@
 							"shadow"
 						],
 						"entries": [
-							"As"
-						]
-					},
-					{
-						"name": "Unshadowed Okoro",
-						"traits": [
-							"page 18"
+							"Koride can create immense blisters on a creature's shadow, which immediately burst, dealing {@damage 20d6} acid damage. She targets a creature within 60 feet that is casting a shadow, which must attempt a {@dc 37} Will save.",
+							"Koride can't use Rupture Shadow again for {@dice 1d4} rounds.",
+							{
+								"type": "successDegree",
+								"entries": {
+									"Critical Success": [
+										"The target is unaffected and becomes temporarily immune for 1 day."
+									],
+									"Success": [
+										"The target takes half damage. The bursting shadow deals 5 acid {@trait splash} damage to all creatures within 5 feet of the target."
+									],
+									"Failure": [
+										"The target takes full damage, and the bursting shadow deals 10 acid {@trait splash} damage."
+									],
+									"Critical Failure": [
+										"The target takes double damage, the bursting shadow deals 20 acid {@trait splash} damage, and the target also takes {@damage 4d6} {@condition persistent damage||persistent acid damage}."
+									]
+								}
+							}
 						]
 					}
 				]
@@ -5227,21 +5263,21 @@
 			"abilities": {
 				"mid": [
 					{
-						"name": "Shadow's Displeasure As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Shadow's Displeasure",
+						"entries": [
+							"When Mariama has fewer than 150 Hit Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. She looks pained and confused, and she becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, she falls {@condition unconscious}."
 						]
 					},
 					{
-						"name": "Vesicated Shadow As Unshadowed Okoro",
-						"traits": [
-							"page 18"
+						"name": "Vesicated Shadow",
+						"entries": [
+							"Mariama's shadow has become corrupted via the power of the Vesicant Egg. Her shredded shadow grants him some control over acid and shadows. She gains a +4 status bonus to resist {@trait acid} and {@trait shadow} effects."
 						]
 					},
 					{
 						"name": "Weird Astrology",
 						"entries": [
-							"Perhaps because of Mariama's quirky nature, she has received all the effects of the astrological evaluator. When she gains any of the {@condition clumsy}, {@condition drained}, {@condition enfeebled}, or {@condition stupefied} conditions, she reduces the value by 1. This means her Shadow's Displeasure doesn't affect her until she has fewer than 50 Hit Points, when she falls {@condition unconscious}."
+							"Perhaps because of Mariama's quirky nature, she has received all the effects of the astrological evaluator. When she gains any of the {@condition clumsy||clumsy 1}, {@condition drained}, {@condition enfeebled}, or {@condition stupefied} conditions, she reduces the value by 1. This means her Shadow's Displeasure doesn't affect her until she has fewer than 50 Hit Points, when she falls {@condition unconscious}."
 						]
 					}
 				],
@@ -5295,13 +5331,25 @@
 							"shadow"
 						],
 						"entries": [
-							"As"
-						]
-					},
-					{
-						"name": "Unshadowed Okoro",
-						"traits": [
-							"page 19"
+							"Mariama can create immense blisters on a creature's shadow, which immediately burst, dealing {@damage 20d6} acid damage. She targets a creature within 60 feet that is casting a shadow, which must attempt a {@dc 37} Will save.",
+							"Mariama can't use Rupture Shadow again for {@dice 1d4} rounds.",
+							{
+								"type": "successDegree",
+								"entries": {
+									"Critical Success": [
+										"The target is unaffected and becomes temporarily immune for 1 day."
+									],
+									"Success": [
+										"The target takes half damage. The bursting shadow deals 5 acid {@trait splash} damage to all creatures within 5 feet of the target."
+									],
+									"Failure": [
+										"The target takes full damage, and the bursting shadow deals 10 acid {@trait splash} damage."
+									],
+									"Critical Failure": [
+										"The target takes double damage, the bursting shadow deals 20 acid {@trait splash} damage, and the target also takes {@damage 4d6} {@condition persistent damage||persistent acid damage}."
+									]
+								}
+							}
 						]
 					}
 				]
@@ -5353,7 +5401,8 @@
 				"languages": [
 					"common",
 					"draconic",
-					"elven,"
+					"elven",
+					"terran"
 				]
 			},
 			"skills": {
@@ -5603,22 +5652,11 @@
 				}
 			],
 			"abilities": {
-				"top": [
-					{
-						"name": "Terran"
-					}
-				],
 				"mid": [
 					{
-						"name": "Shadow's Displeasure When",
+						"name": "Shadow's Displeasure",
 						"entries": [
-							"Okoro has fewer than 150"
-						]
-					},
-					{
-						"name": "Hit",
-						"entries": [
-							"Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. He looks pained and {@condition confused}, and he becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, he falls {@condition unconscious}."
+							"When Okoro has fewer than 150 Hit Points, his shadow pulls at his essence to show the Vesicant Egg's displeasure. He looks pained and confused, and he becomes {@condition clumsy||clumsy 1} and {@condition stupefied||stupefied 1} until healed to 150 Hit Points or more. These conditions increase to 2 when below 100 Hit Points. When below 50 Hit Points, he falls {@condition unconscious}."
 						]
 					},
 					{

--- a/data/hazards.json
+++ b/data/hazards.json
@@ -7813,7 +7813,7 @@
 						"unit": "reaction"
 					},
 					"trigger": "The Rumormonger or the Inkmaster enters the room",
-					"effect": [
+					"entries": [
 						"The trap rolls initiative"
 					],
 					"name": "Arm Activation"


### PR DESCRIPTION
Specifically, a lot of instances of malformed ability data where abilities with no entries have been created because it's actually the continuation of a previous ability's text.

Plus a lot of other miscellaneous fixes where the data is obviously malformed - e.g. tags not ended, language or other fields overflowing into an ability field, some fields missing their entry text for other reasons, etc.